### PR TITLE
Add printMetadata flag to the dumpnode action. 

### DIFF
--- a/Source/CNTK/CNTK.cpp
+++ b/Source/CNTK/CNTK.cpp
@@ -98,10 +98,15 @@ void DumpNodeInfo(const ConfigParameters& config)
     wstring defOutFilePath = modelPath + L"." + nodeName + L".txt";
     wstring outputFile = config(L"outputFile", defOutFilePath);
     bool printValues = config(L"printValues", true);
+    bool printMetadata = config(L"printMetadata", true);
+    if (!printValues && !printMetadata)
+    {
+        InvalidArgument("printValues and printMetadata: Since both are set to false, there will be nothing to dump");
+    }
 
     ComputationNetwork net(-1); // always use CPU
     net.Load<ElemType>(modelPath);
-    net.DumpNodeInfoToFile(nodeName, printValues, outputFile, nodeNameRegexStr);
+    net.DumpNodeInfoToFile(nodeName, printValues, printMetadata, outputFile, nodeNameRegexStr);
 }
 
 size_t GetMaxEpochs(const ConfigParameters& configParams)

--- a/Source/CNTK/ModelEditLanguage.cpp
+++ b/Source/CNTK/ModelEditLanguage.cpp
@@ -264,7 +264,7 @@ void MELScript<ElemType>::CallFunction(const std::string& p_name, const ConfigPa
         {
             NetNdl<ElemType>* netNdl = &found->second;
             ProcessNDLScript(netNdl, ndlPassAll, true);
-            found->second.cn->DumpAllNodesToFile(includeData, fileName);
+            found->second.cn->DumpAllNodesToFile(includeData, true, fileName);
         }
     }
     else if (EqualInsensitive(name, "DumpNode"))
@@ -280,7 +280,7 @@ void MELScript<ElemType>::CallFunction(const std::string& p_name, const ConfigPa
         NetNdl<ElemType>* netNdl;
         vector<ComputationNodeBasePtr> nodes = FindSymbols(params[0], netNdl);
         ProcessNDLScript(netNdl, ndlPassAll);
-        netNdl->cn->DumpNodeInfoToFile(nodes, includeData, fileName);
+        netNdl->cn->DumpNodeInfoToFile(nodes, includeData, true, fileName);
     }
     else if (EqualInsensitive(name, "CopyNode", "Copy"))
     {

--- a/Source/CNTK/NDLUtil.h
+++ b/Source/CNTK/NDLUtil.h
@@ -94,7 +94,7 @@ public:
             // if requested then dump the nodes
             // Note: This happens on the invalidated network.
             if (dumpFileName != L"")
-                m_net->DumpAllNodesToFile(false, dumpFileName);
+                m_net->DumpAllNodesToFile(false, true, dumpFileName);
         }
         SynchronousNodeEvaluator<ElemType> ndlEvaluator(m_net);
         NDLNode<ElemType>* lastNode = script->Evaluate(ndlEvaluator, L"", ndlPass, skipThrough);

--- a/Source/ComputationNetworkLib/ComputationNetwork.h
+++ b/Source/ComputationNetworkLib/ComputationNetwork.h
@@ -642,7 +642,7 @@ public:
     // if node name is not found, dump all nodes
     // otherwise dump just that node
     // This function is called from MEL, i.e. must be prepared to operate on an uncompiled network (only m_nameToNodeMap is valid).
-    void DumpNodeInfoToFile(const std::wstring& nodeName, const bool printValues, const std::wstring outputFile, const std::wstring& nodeNameInRegEx = L"")
+    void DumpNodeInfoToFile(const std::wstring& nodeName, const bool printValues, const bool printMetadata, const std::wstring outputFile, const std::wstring& nodeNameInRegEx = L"")
     {
         if (nodeNameInRegEx.empty())
         {
@@ -652,13 +652,13 @@ public:
                              FileOptions::fileOptionsText | FileOptions::fileOptionsWrite);
 
                 const ComputationNodeBasePtr& nodePtr = GetNodeFromName(nodeName);
-                nodePtr->DumpNodeInfo(printValues, fstream);
+                nodePtr->DumpNodeInfo(printValues, printMetadata, fstream);
             }
             else // node name is not found, dump all nodes
             {
                 fprintf(stderr, "Warning: node name %ls does not exist in the network. dumping all nodes.\n",
                         nodeName.c_str());
-                DumpAllNodesToFile(printValues, outputFile);
+                DumpAllNodesToFile(printValues, printMetadata, outputFile);
             }
         }
         else
@@ -680,12 +680,13 @@ public:
                 fprintf(stderr, "\t%ls\n", x.c_str());
             }
             fprintf(stderr, "DumpNodeInfo: dumping node info (%s printing values) to %ls\n", printValues ? "with" : "without", outputFile.c_str());
-            DumpNodeInfoToFile(NodeList, printValues, outputFile);
+            DumpNodeInfoToFile(NodeList, printValues, printMetadata, outputFile);
         }
     }
 
     // dump all nodes in the network to file
     void DumpAllNodesToFile(const bool printValues,
+                            const bool printMetadata,
                             const std::wstring outputFile)
     {
         File fstream(outputFile,
@@ -694,12 +695,13 @@ public:
         for (auto nodeIter = m_nameToNodeMap.begin(); nodeIter != m_nameToNodeMap.end(); nodeIter++)
         {
             ComputationNodeBasePtr nodePtr = nodeIter->second;
-            nodePtr->DumpNodeInfo(printValues, fstream);
+            nodePtr->DumpNodeInfo(printValues, printMetadata, fstream);
         }
     }
 
     void DumpNodeInfoToFile(const vector<ComputationNodeBasePtr>& nodes,
                             const bool printValues,
+                            const bool printMetadata,
                             const std::wstring outputFile)
     {
         File fstream(outputFile,
@@ -708,7 +710,7 @@ public:
         for (auto nodeIter = nodes.begin(); nodeIter != nodes.end(); nodeIter++)
         {
             ComputationNodeBasePtr nodePtr = *nodeIter;
-            nodePtr->DumpNodeInfo(printValues, fstream);
+            nodePtr->DumpNodeInfo(printValues, printMetadata, fstream);
         }
     }
 

--- a/Source/ComputationNetworkLib/ComputationNode.cpp
+++ b/Source/ComputationNetworkLib/ComputationNode.cpp
@@ -234,20 +234,23 @@ TensorShape ComputationNodeBase::GetTensorSliceFor(size_t rank, const FrameRange
 // -----------------------------------------------------------------------
 
 template <class ElemType>
-/*virtual*/ void ComputationNode<ElemType>::DumpNodeInfo(const bool /*printValues*/, File& fstream) const
+/*virtual*/ void ComputationNode<ElemType>::DumpNodeInfo(const bool /*printValues*/, const bool printMetadata, File& fstream) const
 {
-    fstream << L"\n" + NodeName() + L"=" + OperationName();
-
-    if (!IsLeaf())
+    if (printMetadata)
     {
-        fstream << wstring(L"(");
-        for (size_t i = 0; i < GetNumInputs(); i++)
+        fstream << L"\n" + NodeName() + L"=" + OperationName();
+
+        if (!IsLeaf())
         {
-            if (i > 0)
-                fstream << wstring(L",");
-            fstream << (Input(i) ? Input(i)->NodeName() : L"NULL");
+            fstream << wstring(L"(");
+            for (size_t i = 0; i < GetNumInputs(); i++)
+            {
+                if (i > 0)
+                    fstream << wstring(L",");
+                fstream << (Input(i) ? Input(i)->NodeName() : L"NULL");
+            }
+            fstream << wstring(L")");
         }
-        fstream << wstring(L")");
     }
 }
 

--- a/Source/ComputationNetworkLib/ComputationNode.h
+++ b/Source/ComputationNetworkLib/ComputationNode.h
@@ -108,7 +108,7 @@ struct /*interface*/ IComputationNode
     // --- optional overrides for more informative logging
 
     virtual void PrintSelfBeforeValidation() const = 0; // called in validation loop right before Validate()
-    virtual void DumpNodeInfo(const bool /*printValues*/, File& fstream) const = 0;
+    virtual void DumpNodeInfo(const bool /*printValues*/, const bool /*printMetadata*/, File& fstream) const = 0;
 
 protected:
     virtual ~IComputationNode()
@@ -1443,16 +1443,19 @@ public:
     // miscellaneous
     // -----------------------------------------------------------------------
 
-    virtual void DumpNodeInfo(const bool /*printValues*/, File& fstream) const;
+    virtual void DumpNodeInfo(const bool /*printValues*/, const bool /*printMetadata*/, File& fstream) const;
 
 protected:
 
     // print node values
-    void PrintNodeValuesToFile(const bool printValues, File& fstream) const
+    void PrintNodeValuesToFile(const bool printValues, const bool printMetadata, File& fstream) const
     {
         if (printValues)
-        {
-            fstream << wstring(L"\n");
+        { 
+            if (printMetadata)
+            {
+                fstream << wstring(L"\n");
+            }
             const Matrix<ElemType>& m = Value();
             for (size_t i = 0; i < m.GetNumRows(); i++)
             {
@@ -1462,7 +1465,10 @@ protected:
                 }
                 fstream << wstring(L"\n");
             }
-            fstream << wstring(L"####################################################################");
+            if (printMetadata)
+            {
+                fstream << wstring(L"####################################################################");
+            }
         }
     }
 
@@ -1637,7 +1643,7 @@ public:
     // these are meant to be called during computation, so provide dummy implementations
     virtual bool RequiresPreCompute() const override { return false; } // return true if the node's value should be computed before the normal training. e.g., mean and invStd of input features.
     virtual void PrintSelfBeforeValidation() const override { }
-    virtual void DumpNodeInfo(const bool /*printValues*/, File& fstream) const override { }
+    virtual void DumpNodeInfo(const bool /*printValues*/, const bool /*printMetadata*/, File& fstream) const override {}
 
 protected: public:                                     // needed in ComputationNetwork::FindInRecurrentLoops(), which really should be part of SEQTraversalFlowControlNode
     std::vector<ComputationNodeBasePtr> m_nestedNodes; // nodes tucked away in this node, in evaluation order

--- a/Source/ComputationNetworkLib/ConvolutionalNodes.h
+++ b/Source/ComputationNetworkLib/ConvolutionalNodes.h
@@ -268,9 +268,9 @@ public:
         }
     }
 
-    void DumpNodeInfo(const bool printValues, File& fstream) const override
+    void DumpNodeInfo(const bool printValues, const bool printMetadata, File& fstream) const override
     {
-        Base::DumpNodeInfo(printValues, fstream);
+        Base::DumpNodeInfo(printValues, printMetadata, fstream);
 
         auto inDims = ImageDimensions(GetInputSampleLayout(1), m_imageLayoutKind);
         auto outDims = ImageDimensions(m_sampleLayout, m_imageLayoutKind);
@@ -471,21 +471,24 @@ public:
         }
     }
 
-    void DumpNodeInfo(const bool printValues, File& fstream) const override
+    void DumpNodeInfo(const bool printValues, const bool printMetadata, File& fstream) const override
     {
-        Base::DumpNodeInfo(printValues, fstream);
+        Base::DumpNodeInfo(printValues, printMetadata, fstream);
 
-        auto inputSampleLayout = GetInputSampleLayout(0);
+        if (printMetadata)
+        {
+            auto inputSampleLayout = GetInputSampleLayout(0);
 
-        char str[4096];
-        sprintf(str, "Input[Width:%lu, Height:%lu, Channels:%lu]  \n", inputSampleLayout[1], inputSampleLayout[2], inputSampleLayout[0]);
-        fstream << string(str);
-        sprintf(str, "PoolingWindow[Width:%lu, Height:%lu]  SubSampling[Horizontal:%lu, Vertical:%lu]\n", m_windowWidth, m_windowHeight, m_horizontalSubsample, m_verticalSubsample);
-        fstream << string(str);
-        sprintf(str, "Output[Width:%lu, Height:%lu, Channels:%lu]  \n", m_sampleLayout[1], m_sampleLayout[2], m_sampleLayout[0]);
-        fstream << string(str);
-        sprintf(str, "TotalSizePerSample[Input:%lu, Output:%lu]  \n", m_inputSizePerSample, m_outputSizePerSample);
-        fstream << string(str);
+            char str[4096];
+            sprintf(str, "Input[Width:%lu, Height:%lu, Channels:%lu]  \n", inputSampleLayout[1], inputSampleLayout[2], inputSampleLayout[0]);
+            fstream << string(str);
+            sprintf(str, "PoolingWindow[Width:%lu, Height:%lu]  SubSampling[Horizontal:%lu, Vertical:%lu]\n", m_windowWidth, m_windowHeight, m_horizontalSubsample, m_verticalSubsample);
+            fstream << string(str);
+            sprintf(str, "Output[Width:%lu, Height:%lu, Channels:%lu]  \n", m_sampleLayout[1], m_sampleLayout[2], m_sampleLayout[0]);
+            fstream << string(str);
+            sprintf(str, "TotalSizePerSample[Input:%lu, Output:%lu]  \n", m_inputSizePerSample, m_outputSizePerSample);
+            fstream << string(str);
+        }
     }
 
 protected:

--- a/Source/ComputationNetworkLib/InputAndParamNodes.h
+++ b/Source/ComputationNetworkLib/InputAndParamNodes.h
@@ -196,17 +196,20 @@ public:
         m_pMBLayout = nullptr; // this node does not hold mini-batch data
     }
 
-    virtual void DumpNodeInfo(const bool printValues, File& fstream) const override
+    virtual void DumpNodeInfo(const bool printValues, const bool printMetadata, File& fstream) const override
     {
-        Base::DumpNodeInfo(printValues, fstream);
+        if (printMetadata)
+        {
+            Base::DumpNodeInfo(printValues, printMetadata, fstream);
 
-        char str[4096];
-        sprintf(str, "[%lu,%lu]  ", GetAsMatrixNumRows(), GetAsMatrixNumCols());
-        fstream << string(str);
-        sprintf(str, "NeedGradient=%s", m_parameterUpdateRequired ? "true" : "false"); // TODO: update NDL to accept a better matching name as well
-        fstream << string(str);
+            char str[4096];
+            sprintf(str, "[%lu,%lu]  ", GetAsMatrixNumRows(), GetAsMatrixNumCols());
+            fstream << string(str);
+            sprintf(str, "NeedGradient=%s", m_parameterUpdateRequired ? "true" : "false"); // TODO: update NDL to accept a better matching name as well
+            fstream << string(str);
+        }
 
-        PrintNodeValuesToFile(printValues, fstream);
+        PrintNodeValuesToFile(printValues, printMetadata, fstream);
     }
 };
 
@@ -306,10 +309,13 @@ public:
         LogicError("InputValueBase::BackpropTo() should never be called.");
     }
 
-    virtual void DumpNodeInfo(const bool printValues, File& fstream) const override
+    virtual void DumpNodeInfo(const bool printValues, const bool printMetadata, File& fstream) const override
     {
-        Base::DumpNodeInfo(printValues, fstream);
-        fstream << "[" << string(GetSampleLayout()) << "]";
+        Base::DumpNodeInfo(printValues, printMetadata, fstream);
+        if (printMetadata)
+        {
+            fstream << "[" << string(GetSampleLayout()) << "]";
+        }
     }
 
 private:

--- a/Source/ComputationNetworkLib/PreComputeNodes.h
+++ b/Source/ComputationNetworkLib/PreComputeNodes.h
@@ -73,17 +73,20 @@ public:
         // Note: This loses the sample layout, but that is recovered by Validate().
     }
 
-    virtual void DumpNodeInfo(const bool printValues, File& fstream) const override
+    virtual void DumpNodeInfo(const bool printValues, const bool printMetadata, File& fstream) const override
     {
-        Base::DumpNodeInfo(printValues, fstream);
+        Base::DumpNodeInfo(printValues, printMetadata, fstream);
 
-        char str[4096];
-        sprintf(str, "[%s]  ", string(GetSampleLayout()).c_str());
-        fstream << string(str);
-        sprintf(str, "HasComputed=%ls", HasComputed() ? L"true" : L"false");
-        fstream << string(str);
+        if (printMetadata)
+        {
+            char str[4096];
+            sprintf(str, "[%s]  ", string(GetSampleLayout()).c_str());
+            fstream << string(str);
+            sprintf(str, "HasComputed=%ls", HasComputed() ? L"true" : L"false");
+            fstream << string(str);
+        }
 
-        PrintNodeValuesToFile(printValues, fstream);
+        PrintNodeValuesToFile(printValues, printMetadata, fstream);
     }
 
     virtual void /*ComputationNodeBase::*/ Validate(bool isFinalValidationPass) override


### PR DESCRIPTION
This flag lets the dumpnode action to write only values of the node to the file. This is useful for dumping the learnable parameters and subsequent processing, e.g. converting to binary and consuming in the SR engine. The default value is true.

This is example usage

DumpnodeA=[
     action=dumpnode
     modelPath=\\somepath
     nodeName="LSTMoutput1.bits"
     printMetadata=false
     outputFile=D:\output
}