### PR TITLE
Add node 'ClassPrediction(labels,output)'

### DIFF
--- a/Examples/Image/MNIST/Config/01_OneHidden.cntk
+++ b/Examples/Image/MNIST/Config/01_OneHidden.cntk
@@ -92,5 +92,38 @@ test = [
             labelDim = 10
             labelMappingFile = "$DataDir$/labelsmap.txt"
         ]
-    ]    
+    ]
+]
+
+#######################################
+#  OUTPUT PREDICTION CONFIG           #
+#######################################
+
+output_pred = [
+    action = "write"
+    minibatchSize = 16
+
+    NDLNetworkBuilder = [
+        networkDescription = "$ConfigDir$/01_OneHidden.ndl"
+    ]
+    
+    reader = [
+        readerType = "UCIFastReader"
+        file = "$DataDir$/Test-28x28.txt"
+        
+        features = [
+            dim = 784
+            start = 1
+        ]
+        
+        labels = [
+            dim = 1
+            start = 0
+            labelDim = 10
+            labelMappingFile = "$DataDir$/labelsmap.txt"
+        ]
+    ]
+
+    outputPath="$OutputDir$/01_OneHidden"
+    outputNodeNames=(pred)
 ]

--- a/Examples/Image/MNIST/Config/01_OneHidden.ndl
+++ b/Examples/Image/MNIST/Config/01_OneHidden.ndl
@@ -23,6 +23,7 @@ DNN = [
     
     ce = CrossEntropyWithSoftmax(labels, ol)
     err = ErrorPrediction(labels, ol)
+    pred = ClassPrediction(labels, ol)
     
     # Special Nodes
     FeatureNodes = (features)

--- a/Examples/Image/MNIST/Config/02_Convolution.cntk
+++ b/Examples/Image/MNIST/Config/02_Convolution.cntk
@@ -96,3 +96,36 @@ test = [
         ]
     ]
 ]
+
+#######################################
+#  OUTPUT PREDICTION CONFIG           #
+#######################################
+
+output_pred = [
+    action = write
+    minibatchSize = 16
+    
+    NDLNetworkBuilder = [
+        networkDescription = "$ConfigDir$/02_Convolution.ndl"
+    ]
+    
+    reader = [
+        readerType = "UCIFastReader"
+        file = "$DataDir$/Test-28x28.txt"
+        
+        features = [
+            dim = 784
+            start = 1
+        ]
+        
+        labels = [
+            dim = 1
+            start = 0
+            labelDim = 10
+            labelMappingFile = "$DataDir$/labelsmap.txt"
+        ]
+    ]
+
+    outputPath="$OutputDir$/02_Convolution"
+    outputNodeNames=(pred)
+]

--- a/Examples/Image/MNIST/Config/02_Convolution.ndl
+++ b/Examples/Image/MNIST/Config/02_Convolution.ndl
@@ -57,6 +57,7 @@ DNN=[
     
     ce = CrossEntropyWithSoftmax(labels, ol)
     err = ErrorPrediction(labels, ol)
+    pred = ClassPrediction(labels, ol)
 
     # Special Nodes
     FeatureNodes = (features)

--- a/Examples/Image/MNIST/Config/03_ConvBatchNorm.cntk
+++ b/Examples/Image/MNIST/Config/03_ConvBatchNorm.cntk
@@ -91,3 +91,36 @@ test = [
         ]
     ]
 ]
+
+#######################################
+#  OUTPUT PREDICTION CONFIG           #
+#######################################
+
+output_pred = [
+    action = "write"
+    minibatchSize = 16
+    
+    NDLNetworkBuilder = [
+        networkDescription = "$ConfigDir$/03_ConvBatchNorm.ndl"
+    ]
+    
+    reader = [
+        readerType = "UCIFastReader"
+        file = "$DataDir$/Test-28x28.txt"
+        
+        features = [
+            dim = 784
+            start = 1
+        ]
+        
+        labels = [
+            dim = 1
+            start = 0
+            labelDim = 10
+            labelMappingFile = "$DataDir$/labelsmap.txt"
+        ]
+    ]
+
+    outputPath="$OutputDir$/03_ConvBatchNorm"
+    outputNodeNames=(pred)
+]

--- a/Examples/Image/MNIST/Config/03_ConvBatchNorm.ndl
+++ b/Examples/Image/MNIST/Config/03_ConvBatchNorm.ndl
@@ -56,6 +56,7 @@ DNN = [
     
     ce = CrossEntropyWithSoftmax(labels, ol)
     err = ErrorPrediction(labels, ol)
+    pred = ClassPrediction(labels, ol)
     
     # Special Nodes
     FeatureNodes = (features)

--- a/Source/CNTK/NetworkDescriptionLanguage.cpp
+++ b/Source/CNTK/NetworkDescriptionLanguage.cpp
@@ -159,6 +159,7 @@ bool CheckFunction(std::string& p_nodeType, bool* allowUndeterminedVariable)
     else if (EqualInsensitive(nodeType, OperationNameOf(CRFNode), L"CRF")) ret = true;
 #endif
     else if (EqualInsensitive(nodeType, OperationNameOf(ClassBasedCrossEntropyWithSoftmaxNode), L"CBCEWithSM")) ret = true;
+    else if (EqualInsensitive(nodeType, OperationNameOf(ClassPredictionNode))) ret = true;
     else if (EqualInsensitive(nodeType, OperationNameOf(ConvolutionNode), L"Convolve")) ret = true;
     else if (EqualInsensitive(nodeType, OperationNameOf(CosDistanceNode), L"CosDist")) ret = true;
     else if (EqualInsensitive(nodeType, OperationNameOf(CosDistanceWithNegativeSamplesNode), L"CosWithNegSamples")) ret = true;

--- a/Source/ComputationNetworkLib/ComputationNetworkBuilder.cpp
+++ b/Source/ComputationNetworkLib/ComputationNetworkBuilder.cpp
@@ -38,6 +38,7 @@ static shared_ptr<ComputationNode<ElemType>> CreateStandardNode(const std::wstri
     else
 #endif
          if (nodeType == OperationNameOf(ClassBasedCrossEntropyWithSoftmaxNode))return New<ClassBasedCrossEntropyWithSoftmaxNode<ElemType>>(forward<_Types>(_Args)...);
+    else if (nodeType == OperationNameOf(ClassPredictionNode))                  return New<ClassPredictionNode<ElemType>>(forward<_Types>(_Args)...);
     else if (nodeType == OperationNameOf(CosDistanceNode))                      return New<CosDistanceNode<ElemType>>(forward<_Types>(_Args)...);
     else if (nodeType == OperationNameOf(CosDistanceWithNegativeSamplesNode))   return New<CosDistanceWithNegativeSamplesNode<ElemType>>(forward<_Types>(_Args)...);
     else if (nodeType == OperationNameOf(CosineNode))                           return New<CosineNode<ElemType>>(forward<_Types>(_Args)...);
@@ -278,6 +279,12 @@ template <class ElemType>
 shared_ptr<ComputationNode<ElemType>> ComputationNetworkBuilder<ElemType>::ErrorPrediction(const ComputationNodePtr a, const ComputationNodePtr b, const std::wstring nodeName)
 {
     return net.AddNodeToNetAndAttachInputs(New<ErrorPredictionNode<ElemType>>(net.GetDeviceId(), nodeName), a, b);
+}
+
+template <class ElemType>
+shared_ptr<ComputationNode<ElemType>> ComputationNetworkBuilder<ElemType>::ClassPrediction(const ComputationNodePtr label, const ComputationNodePtr prediction, const std::wstring nodeName)
+{
+    return net.AddNodeToNetAndAttachInputs(New<ClassPredictionNode<ElemType>>(net.GetDeviceId(), nodeName), label, prediction);
 }
 
 template <class ElemType>

--- a/Source/ComputationNetworkLib/ComputationNetworkBuilder.h
+++ b/Source/ComputationNetworkLib/ComputationNetworkBuilder.h
@@ -77,6 +77,7 @@ public:
     ComputationNodePtr CRF(const ComputationNodePtr label, const ComputationNodePtr postDepScore, const ComputationNodePtr transition_score, const std::wstring nodeName = L"");
 #endif
     ComputationNodePtr ClassCrossEntropyWithSoftmax(const ComputationNodePtr label, const ComputationNodePtr prediction, const ComputationNodePtr input_weight, const ComputationNodePtr cls_log_post_prob, const std::wstring nodeName = L"");
+    ComputationNodePtr ClassPrediction(const ComputationNodePtr label, const ComputationNodePtr prediction, const std::wstring nodeName = L"");
     ComputationNodePtr Cos(const ComputationNodePtr a, const std::wstring nodeName = L"");
     ComputationNodePtr CosDistance(const ComputationNodePtr a, const ComputationNodePtr b, const std::wstring nodeName = L"");
     ComputationNodePtr CrossEntropy(const ComputationNodePtr label, const ComputationNodePtr prediction, const std::wstring nodeName = L"");

--- a/Source/SGDLib/SimpleOutputWriter.h
+++ b/Source/SGDLib/SimpleOutputWriter.h
@@ -140,12 +140,15 @@ public:
         // allocate memory for forward computation
         m_net->AllocateAllMatrices({}, outputNodes, nullptr);
 
-        // specify feature value nodes
+        // specify feature value and label nodes
         auto& featureNodes = m_net->FeatureNodes();
+        auto& labelNodes = m_net->LabelNodes();
         std::map<std::wstring, Matrix<ElemType>*> inputMatrices;
         // BUGBUG: This loop is inconsistent with the above version of this function in that it does not handle label nodes.
         for (size_t i = 0; i < featureNodes.size(); i++)
             inputMatrices[featureNodes[i]->NodeName()] = &dynamic_pointer_cast<ComputationNode<ElemType>>(featureNodes[i])->Value();
+        for (size_t i = 0; i < labelNodes.size(); i++)
+            inputMatrices[labelNodes[i]->NodeName()] = &dynamic_pointer_cast<ComputationNode<ElemType>>(labelNodes[i])->Value();
 
         // evaluate with minibatches
         dataReader.StartMinibatchLoop(mbSize, 0, numOutputSamples);


### PR DESCRIPTION
Add node 'ClassPrediction(labels,output)' to conveniently output a net's predictions together with the corresponding labels. See MNIST examples for usage.