### PR TITLE
Mac port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ LIBPATH += $(OPENCV_PATH)/lib $(OPENCV_PATH)/release/lib
 
 $(IMAGEREADER): $(IMAGEREADER_OBJ) | $(CNTKMATH_LIB)
 	@echo $(SEPARATOR)
-	$(CXX) $(LDFLAGS) -shared $(patsubst %,-L%, $(LIBDIR) $(LIBPATH)) $(patsubst %,$(RPATH)%, $(ORIGINDIR) $(LIBPATH)) -o $@ $^ -l$(CNTKMATH) -lopencv_core -lopencv_imgproc -lopencv_imgcodecs
+	$(CXX) $(LDFLAGS) -shared $(patsubst %,-L%, $(LIBDIR) $(LIBPATH)) $(patsubst %,$(RPATH)%, $(ORIGINDIR) $(LIBPATH)) -o $@ $^ -l$(CNTKMATH) -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -fopenmp
 endif
 
 ########################################

--- a/Source/ActionsLib/OtherActions.cpp
+++ b/Source/ActionsLib/OtherActions.cpp
@@ -500,11 +500,11 @@ void DoTopologyPlot(const ConfigParameters& config)
     if (!outRending.empty())
     {
         fprintf(stderr, "Executing a third-part tool for rendering dot:\n%S\n", rescmd.c_str());
-#ifdef __unix__
+#ifdef _WIN32
+        _wsystem(rescmd.c_str());
+#else
         const auto rc = system(msra::strfun::utf8(rescmd).c_str());
         rc /*ignoring the result--this gets flagged by gcc if we don't save the return value*/;
-#else
-        _wsystem(rescmd.c_str());
 #endif
         fprintf(stderr, "Done\n");
     }

--- a/Source/CNTK/CNTK.cpp
+++ b/Source/CNTK/CNTK.cpp
@@ -676,7 +676,7 @@ int wmain(int argc, wchar_t* argv[]) // wmain wrapper that reports Win32 excepti
 }
 #endif
 
-#ifdef __UNIX__
+#ifndef _WIN32
 /// UNIX main function converts arguments in UTF-8 encoding and passes to Visual-Studio style wmain() which takes wchar_t strings.
 int main(int argc, char* argv[])
 {

--- a/Source/CNTK/NDLNetworkBuilder.h
+++ b/Source/CNTK/NDLNetworkBuilder.h
@@ -231,6 +231,4 @@ private:
     DEVICEID_TYPE m_deviceId;
 };
 
-template class NDLBuilder<float>;
-template class NDLBuilder<double>;
 } } }

--- a/Source/CNTK/NDLUtil.h
+++ b/Source/CNTK/NDLUtil.h
@@ -171,6 +171,4 @@ public:
     }
 };
 
-template class NDLUtil<float>;
-template class NDLUtil<double>;
 } } }

--- a/Source/CNTK/NetworkDescriptionLanguage.cpp
+++ b/Source/CNTK/NetworkDescriptionLanguage.cpp
@@ -230,6 +230,9 @@ bool CheckFunction(std::string& p_nodeType, bool* allowUndeterminedVariable)
     return ret;
 }
 
+// Explicit instantiation required for template definition in cpp file
+template bool CheckFunction<float>(std::string& p_nodeType, bool* allowUndeterminedVariable);
+
 template <typename ElemType>
 NDLScript<ElemType> NDLScript<ElemType>::s_global("global");
 

--- a/Source/CNTK/NetworkDescriptionLanguage.h
+++ b/Source/CNTK/NetworkDescriptionLanguage.h
@@ -99,8 +99,6 @@ public:
     }
 };
 
-template class NDLNodeEvaluator<float>;
-template class NDLNodeEvaluator<double>;
 
 template <typename ElemType>
 class NetNdl // class to associate a network with an NDLScript

--- a/Source/Common/File.cpp
+++ b/Source/Common/File.cpp
@@ -18,7 +18,7 @@
 #define NOMINMAX
 #include "Windows.h"
 #endif
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
 #endif
 

--- a/Source/Common/Include/Basics.h
+++ b/Source/Common/Include/Basics.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 #include <assert.h>
-#if __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 #include <dlfcn.h> // for Plugin
 #endif
 
@@ -592,7 +592,11 @@ public:
     void* Load(const STRING& plugin, const std::string& proc)
     {
         string soName = msra::strfun::utf8(plugin);
-        soName = soName + ".so";
+#if defined(__APPLE__) && defined(__MACH__)
+        soName += ".dylib";
+#else
+        soName += ".so";
+#endif
         void* handle = dlopen(soName.c_str(), RTLD_LAZY);
         if (handle == NULL)
             RuntimeError("Plugin not found: %s (error: %s)", soName.c_str(), dlerror());

--- a/Source/Common/Include/Config.h
+++ b/Source/Common/Include/Config.h
@@ -222,7 +222,7 @@ public:
         return ival;
     }
 //#if (SIZE_MAX != ULONG_MAX)     // on x64 GCC unsigned long == size_t, i.e. we'd get an ambigous declaration
-#ifdef _MSC_VER // somehow the above check does not work on GCC/Cygwin, causing an ambiguous declaration
+#if defined(_MSC_VER) || (defined(__APPLE__) && defined(__MACH__)) // somehow the above check does not work on GCC/Cygwin, causing an ambiguous declaration
     operator unsigned long() const
     {
         return toulong();

--- a/Source/Common/Include/File.h
+++ b/Source/Common/Include/File.h
@@ -13,7 +13,7 @@
 #define NOMINMAX
 #include "Windows.h"
 #endif
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
 #endif
 #include "fileutil.h" // for f{ge,pu}t{,Text}()

--- a/Source/Common/Include/Platform.h
+++ b/Source/Common/Include/Platform.h
@@ -52,6 +52,9 @@
 #include <stdexcept>
 #include <chrono>
 #include <thread>
+#if defined(__APPLE__) && defined(__MACH__)
+#include <mach/mach_time.h>
+#endif
 // basic type conversion
 typedef int BOOL;
 typedef unsigned char BYTE;
@@ -84,6 +87,13 @@ typedef void *HANDLE;
 //string and io conversion
 #define strtok_s strtok_r
 #define sprintf_s snprintf
+#if defined(__APPLE__) && defined(__MACH__)
+template <size_t n, class ...Args>
+int snprintf(char (&buffer)[n], const char *format, Args... args)
+{
+    return snprintf(buffer, n, format, &args...);
+}
+#endif
 #define sscanf_s sscanf
 #define _strdup strdup
 
@@ -118,10 +128,17 @@ inline int _ftelli64(FILE *file)
 
 inline long GetTickCount(void)
 {
+#if defined(__APPLE__) && defined(__MACH__)
+    static mach_timebase_info_data_t sTimebaseInfo{0, 0};
+    if (sTimebaseInfo.denom == 0 && mach_timebase_info(&sTimebaseInfo) != KERN_SUCCESS)
+        return 0;
+    return mach_absolute_time() * sTimebaseInfo.numer / (sTimebaseInfo.denom * NSEC_PER_MSEC);
+#else
     struct timespec now;
     if (clock_gettime(CLOCK_MONOTONIC, &now))
         return 0;
     return now.tv_sec * 1000 + now.tv_nsec / 1000000;
+#endif
 }
 
 inline errno_t strcpy_s(char *strDest, size_t numElem, const char *strSrc)
@@ -130,6 +147,14 @@ inline errno_t strcpy_s(char *strDest, size_t numElem, const char *strSrc)
     strncpy(strDest, strSrc, numElem);
     return 0;
 }
+
+#if defined(__APPLE__) && defined(__MACH__)
+template <size_t n>
+inline errno_t strcpy_s(char (&dest)[n], const char *src)
+{
+    return strcpy_s(dest, n, src);
+}
+#endif
 
 inline errno_t wcstombs_s(size_t *prt, char *mbStr, size_t sizeInBytes, const wchar_t *wcStr, size_t count)
 {

--- a/Source/Common/Include/fileutil.h
+++ b/Source/Common/Include/fileutil.h
@@ -15,7 +15,7 @@
 #include "Windows.h" // for mmreg.h and FILETIME
 #include <mmreg.h>
 #endif
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 #include <sys/types.h>
 #include <sys/stat.h>
 #endif
@@ -41,7 +41,7 @@
 FILE* fopenOrDie(const std::string& pathname, const char* mode);
 FILE* fopenOrDie(const std::wstring& pathname, const wchar_t* mode);
 
-#ifndef __unix__
+#ifdef _WIN32
 // ----------------------------------------------------------------------------
 // fsetmode(): set mode to binary or text
 // ----------------------------------------------------------------------------

--- a/Source/Common/Include/numahelpers.h
+++ b/Source/Common/Include/numahelpers.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#ifndef __unix__
+#ifdef _WIN32
 #include <Windows.h>
 #include "pplhelpers.h"
 #endif

--- a/Source/Common/Include/pplhelpers.h
+++ b/Source/Common/Include/pplhelpers.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#ifndef __unix__
+#ifdef _WIN32
 #include <ppl.h>
 #endif
 namespace msra { namespace parallel {

--- a/Source/Common/Include/ssefloat4.h
+++ b/Source/Common/Include/ssefloat4.h
@@ -9,8 +9,7 @@
 
 #ifdef _WIN32
 #include <intrin.h> // for intrinsics
-#endif
-#ifdef __unix__
+#else
 #include <x86intrin.h>
 #endif
 

--- a/Source/Common/Include/ssematrix.h
+++ b/Source/Common/Include/ssematrix.h
@@ -14,14 +14,18 @@
 #include "simple_checked_arrays.h" // ... for dotprod(); we can eliminate this I believe
 #include "ssefloat4.h"
 #include <stdexcept>
-#ifndef __unix__
+#ifdef WIN32
 #include <ppl.h>
 #include "pplhelpers.h"
 #include "numahelpers.h"
 #endif
 #include "fileutil.h" // for saving and reading matrices
 #include <limits>     // for NaN
+#if defined(__APPLE__) && defined(__MACH__)
+#include <malloc/malloc.h>
+#else
 #include <malloc.h>
+#endif
 
 #ifdef min
 #undef min // some garbage from some Windows header that conflicts with std::min()
@@ -1360,7 +1364,7 @@ class ssematrix : public ssematrixbase
             _aligned_free(p);
     }
 #endif
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
     template <typename T>
     static T *new_sse(size_t nbytes)
     {

--- a/Source/Common/TimerUtility.cpp
+++ b/Source/Common/TimerUtility.cpp
@@ -5,6 +5,8 @@
 #include "Windows.h"
 static LARGE_INTEGER s_ticksPerSecond;
 static BOOL s_setFreq = QueryPerformanceFrequency(&s_ticksPerSecond);
+#elif defined(__APPLE__) && defined(__MACH__)
+#include <sys/time.h>
 #else
 #include <time.h>
 #endif
@@ -17,6 +19,10 @@ long long Timer::GetStamp()
     LARGE_INTEGER li;
     QueryPerformanceCounter(&li);
     return li.QuadPart;
+#elif defined(__APPLE__) && defined(__MACH__)
+    struct timeval now;
+    gettimeofday(&now, NULL);
+    return now.tv_sec * NANO_PER_SEC + now.tv_usec * MICRO_PER_NANO;
 #else
     timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts); // Works on Linux

--- a/Source/Common/fileutil.cpp
+++ b/Source/Common/fileutil.cpp
@@ -17,7 +17,7 @@
 #define _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES 1
 #include "Basics.h"
 #include "fileutil.h"
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -1999,23 +1999,22 @@ static inline std::wstring mbstowcs(const std::string& p) // input: MBCS
 
 wstring s2ws(const string& str)
 {
-#ifdef __unix__
-    return mbstowcs(str);
-#else
+#ifdef _WIN32
     typedef std::codecvt_utf8<wchar_t> convert_typeX;
     std::wstring_convert<convert_typeX, wchar_t> converterX;
     return converterX.from_bytes(str);
-
+#else
+    return mbstowcs(str);
 #endif
 }
 
 string ws2s(const wstring& wstr)
 {
-#ifdef __unix__
-    return wcstombs(wstr);
-#else
+#ifdef _WIN32
     typedef codecvt_utf8<wchar_t> convert_typeX;
     wstring_convert<convert_typeX, wchar_t> converterX;
     return converterX.to_bytes(wstr);
+#else
+    return wcstombs(wstr);
 #endif
 }

--- a/Source/Common/fileutil.cpp
+++ b/Source/Common/fileutil.cpp
@@ -799,6 +799,10 @@ CHAR* fgetline(FILE* f, CHAR* buf, int size)
     return buf;
 }
 
+// Explicit instantiation required for template definition in cpp file
+template char* fgetline(FILE* f, char* buf, int size);
+template wchar_t* fgetline(FILE* f, wchar_t* buf, int size);
+
 // STL string version
 std::string fgetline(FILE* f)
 {

--- a/Source/ComputationNetworkLib/ComputationNetwork.h
+++ b/Source/ComputationNetworkLib/ComputationNetwork.h
@@ -922,10 +922,6 @@ private:
 };
 typedef ComputationNetwork::ComputationNetworkPtr ComputationNetworkPtr;
 
-// The following emits the class and enables the BaseMatrix<double> to be available (used by EvalDll)
-// The corresponding Matrix<float> is emitted in the SetDeviceId function above.
-template class Matrix<double>;
-
 // TODOs:
 //  - automatic inference of time window w.r.t. delay nodes (and related nodes such as a temporal pooling)
 //  - have overrides of RuntimeError etc. in ComputationNode, which prepend the error string with the node name and operation

--- a/Source/ComputationNetworkLib/ConvolutionalNodes.h
+++ b/Source/ComputationNetworkLib/ConvolutionalNodes.h
@@ -313,8 +313,6 @@ private:
     std::unique_ptr<ConvolutionTensor4D> m_biasT;
 };
 
-template class ConvolutionNode<float>;
-template class ConvolutionNode<double>;
 
 // -----------------------------------------------------------------------
 // PoolingNodeBase (input)
@@ -542,8 +540,6 @@ public:
     }
 };
 
-template class MaxPoolingNode<float>;
-template class MaxPoolingNode<double>;
 
 // -----------------------------------------------------------------------
 // AveragePoolingNode
@@ -581,7 +577,5 @@ public:
     }
 };
 
-template class AveragePoolingNode<float>;
-template class AveragePoolingNode<double>;
 
 } } }

--- a/Source/ComputationNetworkLib/EvaluationNodes.h
+++ b/Source/ComputationNetworkLib/EvaluationNodes.h
@@ -130,8 +130,6 @@ private:
     int m_topK;
 };
 
-template class ErrorPredictionNode<float>;
-template class ErrorPredictionNode<double>;
 
 #ifdef COMING_SOON
 
@@ -332,8 +330,6 @@ public:
     }
 };
 
-template class SequenceDecoderNode<float>;
-template class SequenceDecoderNode<double>;
 
 #endif
 

--- a/Source/ComputationNetworkLib/InputAndParamNodes.h
+++ b/Source/ComputationNetworkLib/InputAndParamNodes.h
@@ -356,8 +356,6 @@ public:
     }
 };
 
-template class InputValue<float>;
-template class InputValue<double>;
 
 // -----------------------------------------------------------------------
 // SparseInputValue (/*no input*/)
@@ -394,8 +392,6 @@ public:
     }
 };
 
-template class SparseInputValue<float>;
-template class SparseInputValue<double>;
 
 // -----------------------------------------------------------------------
 // LookupTableNode (embedding matrix, bag-of-word representation of the inputs)
@@ -571,6 +567,4 @@ public:
     }
 };
 
-template class LookupTableNode<float>;
-template class LookupTableNode<double>;
 } } }

--- a/Source/ComputationNetworkLib/LinearAlgebraNodes.h
+++ b/Source/ComputationNetworkLib/LinearAlgebraNodes.h
@@ -68,8 +68,6 @@ public:
     }
 };
 
-template class PlusNode<float>;
-template class PlusNode<double>;
 
 // -----------------------------------------------------------------------
 // MinusNode (minuend, subtrahend)
@@ -116,8 +114,6 @@ public:
     }
 };
 
-template class MinusNode<float>;
-template class MinusNode<double>;
 
 // -----------------------------------------------------------------------
 // NegateNode (input)
@@ -172,8 +168,6 @@ public:
     }
 };
 
-template class NegateNode<float>;
-template class NegateNode<double>;
 
 // -----------------------------------------------------------------------
 // TimesNodeBase (A, B)
@@ -325,8 +319,6 @@ public:
     }
 };
 
-template class TimesNode<float>;
-template class TimesNode<double>;
 
 // -----------------------------------------------------------------------
 // TransposeTimesNode (A', B)
@@ -351,8 +343,6 @@ public:
     }
 };
 
-template class TransposeTimesNode<float>;
-template class TransposeTimesNode<double>;
 
 // -----------------------------------------------------------------------
 // ElementTimesNode (factor1, factor2)
@@ -407,8 +397,6 @@ public:
     }
 };
 
-template class ElementTimesNode<float>;
-template class ElementTimesNode<double>;
 
 // -----------------------------------------------------------------------
 // DiagTimesNode (vector representing the diagonal of a square matrix, data)
@@ -534,8 +522,6 @@ private:
     shared_ptr<Matrix<ElemType>> m_rightGradient;
 };
 
-template class DiagTimesNode<float>;
-template class DiagTimesNode<double>;
 
 // -----------------------------------------------------------------------
 // SumElementsNode (input)
@@ -592,8 +578,6 @@ public:
     }
 };
 
-template class SumElementsNode<float>;
-template class SumElementsNode<double>;
 
 // -----------------------------------------------------------------------
 // SumColumnElementsNode (input)
@@ -659,8 +643,6 @@ public:
     }
 };
 
-template class SumColumnElementsNode<float>;
-template class SumColumnElementsNode<double>;
 
 #ifdef COMING_SOON  // known bug in backprop; generalize to tensor
 
@@ -749,8 +731,6 @@ public:
     }
 };
 
-template class TransposeNode<float>;
-template class TransposeNode<double>;
 
 #endif
 
@@ -880,8 +860,6 @@ private:
     shared_ptr<Matrix<ElemType>> m_temp;
 };
 
-template class CosDistanceNode<float>;
-template class CosDistanceNode<double>;
 
 // -----------------------------------------------------------------------
 // KhatriRaoProductNode (left, right)
@@ -951,8 +929,6 @@ public:
     }
 };
 
-template class KhatriRaoProductNode<float>;
-template class KhatriRaoProductNode<double>;
 
 // -----------------------------------------------------------------------
 // CosDistanceWithNegativeSamplesNode (left, right, shift, neg)
@@ -1201,6 +1177,4 @@ private:
     shared_ptr<Matrix<ElemType>> m_temp;
 };
 
-template class CosDistanceWithNegativeSamplesNode<float>;
-template class CosDistanceWithNegativeSamplesNode<double>;
 } } }

--- a/Source/ComputationNetworkLib/NonlinearityNodes.h
+++ b/Source/ComputationNetworkLib/NonlinearityNodes.h
@@ -279,8 +279,6 @@ private:
     shared_ptr<Matrix<ElemType>> m_diff;
 };
 
-template class SoftmaxNode<float>;
-template class SoftmaxNode<double>;
 
 // -----------------------------------------------------------------------
 // LogSoftmaxNode (input) -- log of soft-max over input vector(s)
@@ -352,8 +350,6 @@ private:
     shared_ptr<Matrix<ElemType>> m_softmax;
 };
 
-template class LogSoftmaxNode<float>;
-template class LogSoftmaxNode<double>;
 
 // -----------------------------------------------------------------------
 // Hardmax(prediction)
@@ -403,7 +399,5 @@ public:
     }
 };
 
-template class HardmaxNode<float>;
-template class HardmaxNode<double>;
 
 } } }

--- a/Source/ComputationNetworkLib/PreComputeNodes.h
+++ b/Source/ComputationNetworkLib/PreComputeNodes.h
@@ -279,8 +279,6 @@ public:
     }
 };
 
-template class MeanNode<float>;
-template class MeanNode<double>;
 
 // -----------------------------------------------------------------------
 // InvStdDevNode (features)
@@ -408,8 +406,6 @@ private:
     Matrix<ElemType> m_temp;
 };
 
-template class InvStdDevNode<float>;
-template class InvStdDevNode<double>;
 
 // -----------------------------------------------------------------------
 // PerDimMeanVarNormalizationNode (feature, mean, invStdDev)
@@ -512,8 +508,6 @@ public:
     }
 };
 
-template class PerDimMeanVarNormalizationNode<float>;
-template class PerDimMeanVarNormalizationNode<double>;
 
 // -----------------------------------------------------------------------
 // PerDimMeanVarDeNormalizationNode (feature, mean, invStdDev)
@@ -624,7 +618,5 @@ public:
     }
 };
 
-template class PerDimMeanVarDeNormalizationNode<float>;
-template class PerDimMeanVarDeNormalizationNode<double>;
 
 } } }

--- a/Source/ComputationNetworkLib/RecurrentNodes.h
+++ b/Source/ComputationNetworkLib/RecurrentNodes.h
@@ -490,8 +490,6 @@ public:
     }
 };
 
-template class PastValueNode<float>;
-template class PastValueNode<double>;
 
 // -----------------------------------------------------------------------
 // FutureValueNode (input) -- delay node in future direction
@@ -527,8 +525,6 @@ public:
     }
 };
 
-template class FutureValueNode<float>;
-template class FutureValueNode<double>;
 
 #ifdef COMING_SOON
 

--- a/Source/ComputationNetworkLib/ReshapingNodes.h
+++ b/Source/ComputationNetworkLib/ReshapingNodes.h
@@ -181,8 +181,6 @@ private:
     int m_endDimParameter;
 };
 
-template class ReshapeNode<float>;
-template class ReshapeNode<double>;
 
 // -----------------------------------------------------------------------
 // ReconcileMBLayout (dataInput, layoutInput)
@@ -245,8 +243,6 @@ public:
     }
 };
 
-template class ReconcileMBLayoutNode<float>;
-template class ReconcileMBLayoutNode<double>;
 
 // -----------------------------------------------------------------------
 // RowSliceNode (input)
@@ -348,8 +344,6 @@ private:
     size_t m_startIndex, m_sliceHeight;
 };
 
-template class RowSliceNode<float>;
-template class RowSliceNode<double>;
 
 // -----------------------------------------------------------------------
 // RowStackNode (input0, input1, ...)
@@ -479,8 +473,6 @@ private:
     std::vector<size_t> m_firstIndices;  // start row number in the stacked matrix of each input (child) (cumsum of matrix heights); plus one final entry that equals the total dimension
 };
 
-template class RowStackNode<float>;
-template class RowStackNode<double>;
 
 // -----------------------------------------------------------------------
 // RowRepeatNode (input) -- duplicate row(s) of a matrix multiple times
@@ -578,8 +570,6 @@ private:
     size_t m_numRepeat;
 };
 
-template class RowRepeatNode<float>;
-template class RowRepeatNode<double>;
 
 // -----------------------------------------------------------------------
 // DiagonalNode -- extract diagonal elements of a square matrix into a row vector
@@ -648,8 +638,6 @@ public:
     }
 };
 
-template class DiagonalNode<float>;
-template class DiagonalNode<double>;
 
 // -----------------------------------------------------------------------
 // ReinterpretNodeBase (input) -- base class for nodes that reinterpret
@@ -1064,8 +1052,6 @@ private:
     }
 };
 
-template class LegacyReshapeNode<float>;
-template class LegacyReshapeNode<double>;
 
 /*
 

--- a/Source/ComputationNetworkLib/SpecialPurposeNodes.h
+++ b/Source/ComputationNetworkLib/SpecialPurposeNodes.h
@@ -397,8 +397,6 @@ protected:
     shared_ptr<Matrix<ElemType>> m_temp;
 };
 
-template class GMMLogLikelihoodNode<float>;
-template class GMMLogLikelihoodNode<double>;
 
 #endif
 
@@ -643,8 +641,6 @@ protected:
     unsigned long long m_partialtime;
 };
 
-template class SequenceWithSoftmaxNode<float>;
-template class SequenceWithSoftmaxNode<double>;
 
 
 // -----------------------------------------------------------------------
@@ -731,7 +727,5 @@ public:
     }
 };
 
-template class DummyCriterionNode<float>;
-template class DummyCriterionNode<double>;
 
 } } }

--- a/Source/ComputationNetworkLib/TrainingNodes.h
+++ b/Source/ComputationNetworkLib/TrainingNodes.h
@@ -107,8 +107,6 @@ private:
     shared_ptr<Matrix<ElemType>> m_leftMinusRight;
 };
 
-template class SquareErrorNode<float>;
-template class SquareErrorNode<double>;
 
 // -----------------------------------------------------------------------
 // CrossEntropyWithSoftmaxNode (labels, prediction)
@@ -232,8 +230,6 @@ protected:
     shared_ptr<Matrix<ElemType>> m_softmaxOfRight;
 };
 
-template class CrossEntropyWithSoftmaxNode<float>;
-template class CrossEntropyWithSoftmaxNode<double>;
 
 // -----------------------------------------------------------------------
 /// CrossEntropyNode (labels, prediction)
@@ -359,8 +355,6 @@ private:
     shared_ptr<Matrix<ElemType>> m_leftDivRight;
 };
 
-template class CrossEntropyNode<float>;
-template class CrossEntropyNode<double>;
 
 // -----------------------------------------------------------------------
 // MatrixL1RegNode (input)
@@ -452,8 +446,6 @@ private:
     shared_ptr<Matrix<ElemType>> m_gradientOfL1Norm; // temporary
 };
 
-template class MatrixL1RegNode<float>;
-template class MatrixL1RegNode<double>;
 
 // -----------------------------------------------------------------------
 // MatrixL2RegNode (input)
@@ -507,8 +499,6 @@ public:
     }
 };
 
-template class MatrixL2RegNode<float>;
-template class MatrixL2RegNode<double>;
 
 // -----------------------------------------------------------------------
 // NoiseContrastiveEstimationNode (labels, input, inputWeights, biasWeights)
@@ -692,8 +682,6 @@ protected:
 private:
     NCEEvalMode m_evalMode;
 };
-template class NoiseContrastiveEstimationNode<float>;
-template class NoiseContrastiveEstimationNode<double>;
 
 // -----------------------------------------------------------------------
 // ClassBasedCrossEntropyWithSoftmaxNode (labeldata(.,t), inputdata(.,t), embeddingMatrix, clsProbBeforeSoftmaxData(.,t))
@@ -995,8 +983,6 @@ protected:
     size_t m_totalNbrWords;
 };
 
-template class ClassBasedCrossEntropyWithSoftmaxNode<float>;
-template class ClassBasedCrossEntropyWithSoftmaxNode<double>;
 
 #ifdef COMING_SOON
 
@@ -1456,8 +1442,6 @@ private:
     shared_ptr<Matrix<ElemType>> m_temp;
 };
 
-template class LogisticNode<float>;
-template class LogisticNode<double>;
 
 // -----------------------------------------------------------------------
 // DropoutNode (input) -- perform drop-out
@@ -1587,8 +1571,6 @@ private:
     shared_ptr<Matrix<ElemType>> m_maskOfDropout;
 };
 
-template class DropoutNode<float>;
-template class DropoutNode<double>;
 
 // -----------------------------------------------------------------------
 // BatchNormalizationNode (...)  --TODO: document inputs
@@ -1889,7 +1871,5 @@ private:
     std::unique_ptr<ConvolutionTensor4D> m_scaleBiasT;
 };
 
-template class BatchNormalizationNode<float>;
-template class BatchNormalizationNode<double>;
 
 } } }

--- a/Source/Math/cudalatticeops.cu.h
+++ b/Source/Math/cudalatticeops.cu.h
@@ -20,7 +20,7 @@
 #include "Windows.h" // for timer
 #endif
 
-#if __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 #include <sys/time.h>
 #endif
 
@@ -29,7 +29,7 @@ namespace msra { namespace cuda {
 cudaStream_t GetCurrentStream();
 
 // auto_timer timer; run(); double seconds = timer; // now can abandon the object
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 typedef timeval LARGE_INTEGER;
 #endif
 class auto_timer
@@ -45,8 +45,7 @@ public:
         if (!QueryPerformanceFrequency(&freq)) // count ticks per second
             RuntimeError("auto_timer: QueryPerformanceFrequency failure");
         QueryPerformanceCounter(&start);
-#endif
-#ifdef __unix__
+#else
         gettimeofday(&start, NULL);
 #endif
     }
@@ -56,8 +55,7 @@ public:
 #ifdef _WIN32
         QueryPerformanceCounter(&end);
         return (end.QuadPart - start.QuadPart) / (double) freq.QuadPart;
-#endif
-#ifdef __unix__
+#else
         gettimeofday(&end, NULL);
         return (end.tv_sec - start.tv_sec) + (end.tv_usec - start.tv_usec) / (1000 * 1000);
 #endif

--- a/Source/Readers/HTKMLFReader/HTKMLFReader.cpp
+++ b/Source/Readers/HTKMLFReader/HTKMLFReader.cpp
@@ -30,7 +30,7 @@
 #include <vld.h> // for memory leak detection
 #endif
 
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 #include <limits.h>
 typedef unsigned long DWORD;
 typedef unsigned short WORD;
@@ -474,8 +474,7 @@ void HTKMLFReader<ElemType>::PrepareForTrainingOrTesting(const ConfigRecordType&
             DWORD attrib = GetFileAttributes(pageFilePath.c_str());
             if (attrib == INVALID_FILE_ATTRIBUTES || !(attrib & FILE_ATTRIBUTE_DIRECTORY))
                 RuntimeError("pageFilePath does not exist");
-#endif
-#ifdef __unix__
+#else
             struct stat statbuf;
             if (stat(wtocharpath(pageFilePath).c_str(), &statbuf) == -1)
             {
@@ -488,8 +487,7 @@ void HTKMLFReader<ElemType>::PrepareForTrainingOrTesting(const ConfigRecordType&
 #ifdef _WIN32
             pageFilePath.reserve(MAX_PATH);
             GetTempPath(MAX_PATH, &pageFilePath[0]);
-#endif
-#ifdef __unix__
+#else
             pageFilePath = L"/tmp/temp.CNTK.XXXXXX";
 #endif
         }
@@ -507,8 +505,7 @@ void HTKMLFReader<ElemType>::PrepareForTrainingOrTesting(const ConfigRecordType&
             wchar_t tempFile[MAX_PATH];
             GetTempFileName(pageFilePath.c_str(), L"CNTK", 0, tempFile);
             pagePaths.push_back(tempFile);
-#endif
-#ifdef __unix__
+#else
             char tempFile[PATH_MAX];
             strcpy(tempFile, msra::strfun::utf8(pageFilePath).c_str());
             int fid = mkstemp(tempFile);

--- a/Source/Readers/HTKMLFReader/basetypes.h
+++ b/Source/Readers/HTKMLFReader/basetypes.h
@@ -33,8 +33,7 @@
 #ifdef _WIN32
 #define NOMINMAX
 #include "Windows.h" // for CRITICAL_SECTION and Unicode conversion functions   --TODO: is there a portable alternative?
-#endif
-#if __unix__
+#else
 #include <strings.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -65,7 +64,7 @@ static inline wchar_t *GetWC(const char *c)
 
 namespace msra { namespace basetypes {
 
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 typedef timeval LARGE_INTEGER;
 #endif
 class auto_timer
@@ -81,8 +80,7 @@ public:
         if (!QueryPerformanceFrequency(&freq)) // count ticks per second
             RuntimeError("auto_timer: QueryPerformanceFrequency failure");
         QueryPerformanceCounter(&start);
-#endif
-#ifdef __unix__
+#else
         gettimeofday(&start, NULL);
 #endif
     }
@@ -92,8 +90,7 @@ public:
 #ifdef _WIN32
         QueryPerformanceCounter(&end);
         return (end.QuadPart - start.QuadPart) / (double) freq.QuadPart;
-#endif
-#ifdef __unix__
+#else
         gettimeofday(&end, NULL);
         return (end.tv_sec - start.tv_sec) + (end.tv_usec - start.tv_usec) / (1000 * 1000);
 #endif

--- a/Source/Readers/HTKMLFReader/chunkevalsource.h
+++ b/Source/Readers/HTKMLFReader/chunkevalsource.h
@@ -8,7 +8,7 @@
 #include "Basics.h"    // for attempt()
 #include "htkfeatio.h" // for reading HTK features
 #include "minibatchsourcehelpers.h"
-#ifndef __unix__
+#ifdef _WIN32
 #include "ssematrix.h" // TODO: why can it not be removed for Windows as well? At least needs a comment here.
 #endif
 

--- a/Source/Readers/HTKMLFReader/minibatchsourcehelpers.h
+++ b/Source/Readers/HTKMLFReader/minibatchsourcehelpers.h
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <vector>
 #include <algorithm>
-#ifndef __unix__
+#ifdef _WIN32
 #include "ssematrix.h" // for matrix type
 #endif
 

--- a/Source/Readers/HTKMLFReader/rollingwindowsource.h
+++ b/Source/Readers/HTKMLFReader/rollingwindowsource.h
@@ -629,8 +629,7 @@ public:
                     {
 #ifdef _WIN32
                         key = regex_replace((wstring) ppath, wregex(L"\\.[^\\.\\\\/:]*$"), wstring()); // delete extension (or not if none)
-#endif
-#ifdef __unix__
+#else
                         key = removeExtension(basename(ppath));
 #endif
                         if (labels[0].find(key) == labels[0].end())

--- a/Source/Readers/HTKMLFReader/stdafx.h
+++ b/Source/Readers/HTKMLFReader/stdafx.h
@@ -12,7 +12,7 @@
 #include "Platform.h"
 #define _CRT_SECURE_NO_WARNINGS // "secure" CRT not available on all platforms
 
-#ifndef __unix__
+#ifdef _WIN32
 #include "targetver.h"
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 // Windows Header Files:

--- a/Source/Readers/Kaldi2Reader/HTKMLFReader.cpp
+++ b/Source/Readers/Kaldi2Reader/HTKMLFReader.cpp
@@ -26,7 +26,7 @@
 #include <vld.h> // for memory leak detection
 #endif
 
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 #include <limits.h>
 typedef unsigned long DWORD;
 typedef unsigned short WORD;
@@ -500,8 +500,7 @@ void HTKMLFReader<ElemType>::PrepareForTrainingOrTesting(const ConfigRecordType&
             DWORD attrib = GetFileAttributes(pageFilePath.c_str());
             if (attrib == INVALID_FILE_ATTRIBUTES || !(attrib & FILE_ATTRIBUTE_DIRECTORY))
                 throw std::runtime_error("pageFilePath does not exist");
-#endif
-#ifdef __unix__
+#else
             struct stat statbuf;
             if (stat(wtocharpath(pageFilePath).c_str(), &statbuf) == -1)
             {
@@ -515,8 +514,7 @@ void HTKMLFReader<ElemType>::PrepareForTrainingOrTesting(const ConfigRecordType&
 #ifdef _WIN32
             pageFilePath.reserve(MAX_PATH);
             GetTempPath(MAX_PATH, &pageFilePath[0]);
-#endif
-#ifdef __unix__
+#else
             pageFilePath.reserve(PATH_MAX);
             pageFilePath = L"/tmp/temp.CNTK.XXXXXX";
 #endif
@@ -525,8 +523,7 @@ void HTKMLFReader<ElemType>::PrepareForTrainingOrTesting(const ConfigRecordType&
 #ifdef _WIN32
         if (pageFilePath.size() > MAX_PATH - 14) // max length of input to GetTempFileName is PATH_MAX-14
             throw std::runtime_error(msra::strfun::strprintf("pageFilePath must be less than %d characters", MAX_PATH - 14));
-#endif
-#ifdef __unix__
+#else
         if (pageFilePath.size() > PATH_MAX - 14) // max length of input to GetTempFileName is PATH_MAX-14
             throw std::runtime_error(msra::strfun::strprintf("pageFilePath must be less than %d characters", PATH_MAX - 14));
 #endif
@@ -536,8 +533,7 @@ void HTKMLFReader<ElemType>::PrepareForTrainingOrTesting(const ConfigRecordType&
             wchar_t tempFile[MAX_PATH];
             GetTempFileName(pageFilePath.c_str(), L"CNTK", 0, tempFile);
             pagePaths.push_back(tempFile);
-#endif
-#ifdef __unix__
+#else
             char* tempFile;
             // GetTempFileName(pageFilePath.c_str(), L"CNTK", 0, tempFile);
             tempFile = (char*) pageFilePath.c_str();

--- a/Source/Readers/Kaldi2Reader/basetypes.h
+++ b/Source/Readers/Kaldi2Reader/basetypes.h
@@ -33,8 +33,7 @@
 #ifdef _WIN32
 #define NOMINMAX
 #include "Windows.h" // for CRITICAL_SECTION and Unicode conversion functions   --TODO: is there a portable alternative?
-#endif
-#if __unix__
+#else
 #include <strings.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -96,7 +95,7 @@ static inline std::wstring removeExtension(std::wstring const &filename)
 
 namespace msra { namespace basetypes {
 
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 typedef timeval LARGE_INTEGER;
 #endif
 class auto_timer
@@ -112,8 +111,7 @@ public:
         if (!QueryPerformanceFrequency(&freq)) // count ticks per second
             RuntimeError("auto_timer: QueryPerformanceFrequency failure");
         QueryPerformanceCounter(&start);
-#endif
-#ifdef __unix__
+#else
         gettimeofday(&start, NULL);
 #endif
     }
@@ -123,8 +121,7 @@ public:
 #ifdef _WIN32
         QueryPerformanceCounter(&end);
         return (end.QuadPart - start.QuadPart) / (double) freq.QuadPart;
-#endif
-#ifdef __unix__
+#else
         gettimeofday(&end, NULL);
         return (end.tv_sec - start.tv_sec) + (end.tv_usec - start.tv_usec) / (1000 * 1000);
 #endif

--- a/Source/Readers/Kaldi2Reader/chunkevalsource.h
+++ b/Source/Readers/Kaldi2Reader/chunkevalsource.h
@@ -9,7 +9,7 @@
 #include "htkfeatio.h" // for reading HTK features
 #include "minibatchsourcehelpers.h"
 
-#ifndef __unix__
+#ifdef _WIN32
 #include "ssematrix.h"
 #endif
 

--- a/Source/Readers/Kaldi2Reader/minibatchsourcehelpers.h
+++ b/Source/Readers/Kaldi2Reader/minibatchsourcehelpers.h
@@ -12,7 +12,7 @@
 #include <vector>
 #include <algorithm>
 
-#ifndef __unix__
+#ifdef _WIN32
 #include "ssematrix.h" // for matrix type
 #endif
 

--- a/Source/Readers/Kaldi2Reader/numahelpers.h
+++ b/Source/Readers/Kaldi2Reader/numahelpers.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#ifndef __unix__
+#ifdef _WIN32
 #define NOMINMAX
 #include "Windows.h"
 #include "pplhelpers.h"

--- a/Source/Readers/Kaldi2Reader/pplhelpers.h
+++ b/Source/Readers/Kaldi2Reader/pplhelpers.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#ifndef __unix__
+#ifdef _WIN32
 #include <ppl.h>
 #endif
 namespace msra { namespace parallel {

--- a/Source/Readers/Kaldi2Reader/rollingwindowsource.h
+++ b/Source/Readers/Kaldi2Reader/rollingwindowsource.h
@@ -341,8 +341,7 @@ public:
                     {
 #ifdef _WIN32
                         key = regex_replace((wstring) ppath, wregex(L"\\.[^\\.\\\\/:]*$"), wstring()); // delete extension (or not if none)
-#endif
-#ifdef __unix__
+#else
                         key = removeExtension(basename(ppath));
 #endif
                         if (labels[0].find(key) == labels[0].end())

--- a/Source/Readers/Kaldi2Reader/ssefloat4.h
+++ b/Source/Readers/Kaldi2Reader/ssefloat4.h
@@ -9,8 +9,7 @@
 
 #ifdef _WIN32
 #include <intrin.h> // for intrinsics
-#endif
-#ifdef __unix__
+#else
 #include <x86intrin.h>
 #endif
 

--- a/Source/Readers/Kaldi2Reader/ssematrix.h
+++ b/Source/Readers/Kaldi2Reader/ssematrix.h
@@ -12,7 +12,7 @@
 #include "simple_checked_arrays.h" // ... for dotprod(); we can eliminate this I believe
 #include "ssefloat4.h"
 #include <stdexcept>
-#ifndef __unix__
+#ifdef _WIN32
 #include <ppl.h>
 #include "pplhelpers.h"
 #include "numahelpers.h"
@@ -1400,8 +1400,7 @@ class ssematrix : public ssematrixbase
         sprintf_s(buf, "allocation of SSE vector failed (%d bytes)", nbytes);
         throw std::bad_exception(buf);
     }
-#endif
-#ifdef __unix__
+#else
     static void failed(size_t nbytes)
     {
         static /*not thread-safe--for diagnostics only*/ char buf[80] = {0};
@@ -1427,8 +1426,7 @@ class ssematrix : public ssematrixbase
         if (p)
             _aligned_free(p);
     }
-#endif
-#ifdef __unix__
+#else
     template <typename T>
     static T *new_sse(size_t nbytes)
     {

--- a/Source/Readers/Kaldi2Reader/stdafx.h
+++ b/Source/Readers/Kaldi2Reader/stdafx.h
@@ -13,7 +13,7 @@
 #define _CRT_SECURE_NO_WARNINGS // "secure" CRT not available on all platforms  --add this at the top of all CPP files that give "function or variable may be unsafe" warnings
 #endif
 
-#ifndef __unix__
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 // Windows Header Files:
 #define NOMINMAX

--- a/Source/Readers/LMSequenceReader/SequenceParser.cpp
+++ b/Source/Readers/LMSequenceReader/SequenceParser.cpp
@@ -403,7 +403,7 @@ size_t SequenceParser<NumType, LabelType>::UpdateBuffer()
     }
 
     // read the next block
-    size_t bytesToRead = min(m_bufferSize, m_fileSize - m_bufferStart) - saveBytes;
+    size_t bytesToRead = min(m_bufferSize, static_cast<size_t>(m_fileSize) - m_bufferStart) - saveBytes;
     size_t bytesRead = fread(m_fileBuffer + saveBytes, 1, bytesToRead, m_pFile);
     if (bytesRead == 0 && ferror(m_pFile))
         RuntimeError("SequenceParser::UpdateBuffer - error reading file");

--- a/Source/Readers/LUSequenceReader/LUSequenceParser.h
+++ b/Source/Readers/LUSequenceReader/LUSequenceParser.h
@@ -181,10 +181,10 @@ public:
         mUnkStr = unkstr;
 
         mFile.close();
-#ifdef __unix__
-        mFile.open(ws2s(fileName), wifstream::in);
-#else
+#ifdef _WIN32
         mFile.open(fileName, wifstream::in);
+#else
+        mFile.open(ws2s(fileName), wifstream::in);
 #endif
         if (!mFile.good())
             RuntimeError("cannot open file %ls", fileName);
@@ -193,10 +193,10 @@ public:
     void ParseReset()
     {
         mFile.close();
-#ifdef __unix__
-        mFile.open(ws2s(mFileName), wifstream::in);
-#else
+#ifdef _WIN32
         mFile.open(mFileName, wifstream::in);
+#else
+        mFile.open(ws2s(mFileName), wifstream::in);
 #endif
         if (!mFile.good())
             RuntimeError("cannot open file %ls", mFileName.c_str());

--- a/Source/Readers/UCIFastReader/UCIParser.cpp
+++ b/Source/Readers/UCIFastReader/UCIParser.cpp
@@ -445,7 +445,7 @@ size_t UCIParser<NumType, LabelType>::UpdateBuffer()
     }
 
     // read the next block
-    size_t bytesToRead = min(m_bufferSize, m_fileSize - m_bufferStart) - saveBytes;
+    size_t bytesToRead = min(m_bufferSize, static_cast<size_t>(m_fileSize) - m_bufferStart) - saveBytes;
     size_t bytesRead = fread(m_fileBuffer + saveBytes, 1, bytesToRead, m_pFile);
     if (bytesRead == 0 && ferror(m_pFile))
         RuntimeError("UCIParser::UpdateBuffer - error reading file");

--- a/Source/SGDLib/SGD.cpp
+++ b/Source/SGDLib/SGD.cpp
@@ -2655,6 +2655,9 @@ SGDParams::SGDParams(const ConfigRecordType& configSGD, size_t sizeofElemType)
     }
 }
 
+// Explicit instantiation required for template definition in cpp file
+template SGDParams::SGDParams(const ScriptableObjects::IConfigRecord& configSGD, size_t sizeofElemType);
+
 static size_t GetSizeOfPrecision(const ScriptableObjects::IConfigRecordPtr configp)
 {
     wstring precision = configp->Get(L"precision");

--- a/configure
+++ b/configure
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 configure=$0
-build_top=$PWD
+build_top="$PWD"
 
 have_cuda=no
 cuda_path=
@@ -45,14 +45,14 @@ default_use_1bitsgd=no
 enable_1bitsgd=$default_use_1bitsgd
 
 # List from best to worst choice
-default_path_list="/usr /usr/local /opt /opt/local"
+default_path_list="/usr:/usr/local:/opt:/opt/local"
 
 # List from best to worst choice
 default_acmls="acml5.3.1/ifort64_mp"
 default_mkls=""
 
 # NOTE: Will get compilation errors with cuda-6.0
-default_cudas="cuda-7.5 cuda-7.0 cuda-6.5"
+default_cudas="cuda-7.5:cuda-7.0:cuda-6.5"
 default_kaldis="kaldi-trunk"
 default_gdks=". gdk/usr"
 default_cubs="cub-1.4.1"
@@ -61,14 +61,14 @@ default_opencvs="opencv-3.0.0"
 
 function default_paths ()
 {
-    echo $build_top $HOME $default_path_list
+    echo "$build_top:$HOME:$default_path_list"
 }
 
 # $1 is directory
 # $2 is file that must be present
 function check_dir ()
 {
-    if test -e $1/$2
+    if test -e "$1/$2"
     then
         echo yes
     else
@@ -80,17 +80,17 @@ function check_dir ()
 # $2 is some file that must exist in $1
 function find_dir ()
 {
-    for tail in $1
+    (IFS=":"; for tail in "$1"
     do
         for head in $(default_paths)
         do
-            if test x$(check_dir "$head/$tail" $2) = xyes
+            if test x$(check_dir "$head/$tail" "$2") = xyes
             then
                 echo $head/$tail
                 return 0
             fi
         done
-    done
+    done)
 }
 
 function find_acml ()
@@ -135,17 +135,21 @@ function find_opencv ()
 function is_hardlinked ()
 {
     r=no
-    if test -e $1 && test -e $2
+    if test -e "$1" && test -e "$2"
     then
         r=yes
-        [ "`stat -c '%i' $1`" != "`stat -c '%i' $2`" ] && r=no
+        if [ "$(uname -s)" = "Darwin" ]; then
+            [ "$(stat -f '%i' "$1")" != "$(stat -f '%i' "$2")" ] && r=no
+        else
+            [ "$(stat -c '%i' "$1")" != "$(stat -c '%i' "$2")" ] && r=no
+        fi
     fi
     echo $r
 }
 
 function default_use_cuda () 
 {
-    if test x$(find_cuda) = x || test x$(find_gdk) = x
+    if test x"$(find_cuda)" = x || test x"$(find_gdk)" = x
     then
         echo no
     else
@@ -156,7 +160,7 @@ enable_cuda=$(default_use_cuda)
 
 function show_default () 
 {
-    if test x$1 = x
+    if test x"$1" = x
     then
         echo "(no default)"
     else
@@ -169,9 +173,9 @@ function show_help ()
     echo "Usage: configure [options]"
     echo "Options:"
     echo "  -h|--help this help"
-    echo "  --with-build-top=directory build directory $(show_default $build_top)"
+    echo "  --with-build-top=directory build directory $(show_default "$build_top")"
     echo "  --add directory add directory to library search path"
-    echo "  --1bitsgd[=(yes|no)] use 1Bit SGD $(show_default $(default_use_1bitsgd))"
+    echo "  --1bitsgd[=(yes|no)] use 1Bit SGD $(show_default $default_use_1bitsgd)"
     echo "  --cuda[=(yes|no)] use cuda GPU $(show_default $(default_use_cuda))"
     echo "  --with-cuda[=directory] $(show_default $(find_cuda))"
     echo "  --with-cub[=directory] $(show_default $(find_cub))"
@@ -183,10 +187,10 @@ function show_help ()
     echo "  --with-kaldi[=directory] $(show_default $(find_kaldi))"
     echo "  --with-opencv[=directory] $(show_default $(find_opencv))"
     echo "Libraries search path:"
-    for head in $(default_paths)
+    (IFS=":"; for head in $(default_paths)
     do
         echo "    $head"
-    done
+    done)
 }
 
 while [[ $# > 0 ]]
@@ -204,18 +208,18 @@ do
             exit 1
             ;;
         --with-build-top*)
-            if test x$optarg != x
+            if test x"$optarg" != x
             then
-                build_top=$optarg
-                mkdir -p $build_top
+                build_top="$optarg"
+                mkdir -p "$build_top"
             fi
             ;;
         --add*)
-            if test x$optarg = x
+            if test x"$optarg" = x
             then
-                shift ; optarg=$1
+                shift ; optarg="$1"
             fi
-            default_path_list="$optarg $default_path_list"
+            default_path_list="$optarg:$default_path_list"
             ;;
         --1bitsgd*)
             if test x$optarg = xyes || test x$optarg = xno
@@ -242,19 +246,19 @@ do
         --with-cuda*)
             have_cuda=yes
             enable_cuda=yes
-            if test x$optarg = x
+            if test x"$optarg" = x
             then
-                cuda_path=$(find_cuda)
-                if test x$cuda_path = x
+                cuda_path="$(find_cuda)"
+                if test x"$cuda_path" = x
                 then
                     echo "Cannot find cuda directory."
                     echo "Please specify a value for --with-cuda"
                     exit 1
                 fi
             else
-                if test $(check_dir $optarg $cuda_check) = yes
+                if test $(check_dir "$optarg" $cuda_check) = yes
                 then
-                    cuda_path=$optarg
+                    cuda_path="$optarg"
                 else
                     echo "Invalid cuda directory $optarg"
                     exit 1
@@ -263,10 +267,10 @@ do
             ;;
         --with-cub*)
             have_cub=yes
-            if test x$optarg = x
+            if test x"$optarg" = x
             then
-                cub_path=$(find_cub)
-                if test x$cub_path = x
+                cub_path="$(find_cub)"
+                if test x"$cub_path" = x
                 then
                     echo "Cannot find NVIDIA CUB directory."
                     echo "Please specify a value for --with-cub"
@@ -274,9 +278,9 @@ do
                     exit 1
                 fi
             else
-                if test $(check_dir $optarg $cub_check) = yes
+                if test $(check_dir "$optarg" $cub_check) = yes
                 then
-                    cub_path=$optarg
+                    cub_path="$optarg"
                 else
                     echo "Invalid CUB directory $optarg"
                     exit 1
@@ -285,19 +289,19 @@ do
             ;;
         --with-gdk*)
             have_gdk=yes
-            if test x$optarg = x
+            if test x"$optarg" = x
             then
-                gdk_path=$(find_gdk)
-                if test x$gdk_path = x
+                gdk_path="$(find_gdk)"
+                if test x"$gdk_path" = x
                 then
                     echo "Cannot find gdk directory."
                     echo "Please specify a value for --with-gdk"
                     exit 1
                 fi
             else
-                if test $(check_dir $optarg $gdk_check) = yes
+                if test $(check_dir "$optarg" $gdk_check) = yes
                 then
-                    gdk_path=$optarg
+                    gdk_path="$optarg"
                 else
                     echo "Invalid gdk directory $optarg"
                     exit 1
@@ -306,19 +310,19 @@ do
             ;;
         --with-cudnn*)
             have_cudnn=yes
-            if test x$optarg = x
+            if test x"$optarg" = x
             then
-                cudnn_path=$(find_cudnn)
-                if test x$cudnn_path = x
+                cudnn_path="$(find_cudnn)"
+                if test x"$cudnn_path" = x
                 then
                     echo "Cannot find NVIDIA cuDNN directory."
                     echo "Please specify a value for --with-cudnn"
                     exit 1
                 fi
             else
-                if test $(check_dir $optarg $cudnn_check) = yes
+                if test $(check_dir "$optarg" $cudnn_check) = yes
                 then
-                    cudnn_path=$optarg
+                    cudnn_path="$optarg"
                 else
                     echo "Invalid cuDNN directory $optarg"
                     exit 1
@@ -328,19 +332,19 @@ do
         --with-acml*)
             have_acml=yes
             mathlib=acml
-            if test x$optarg = x
+            if test x"$optarg" = x
             then
-                acml_path=$(find_acml)
-                if test x$acml_path = x
+                acml_path="$(find_acml)"
+                if test x"$acml_path" = x
                 then
                     echo "Cannot fine acml directory"
                     echo "Please specify a value for --with-acml"
                     exit 1
                 fi
             else
-                if test $(check_dir $optarg $acml_check) = yes
+                if test $(check_dir "$optarg" $acml_check) = yes
                 then
-                    acml_path=$optarg
+                    acml_path="$optarg"
                 else
                     echo "Invalid acml directory $optarg"
                     exit 1
@@ -350,19 +354,19 @@ do
         --with-mkl*)
             have_mkl=yes
             mathlib=mkl
-            if test x$optarg = x
+            if test x"$optarg" = x
             then
-                mkl_path=$(find_mkl)
-                if test x$mkl_path = x
+                mkl_path="$(find_mkl)"
+                if test x"$mkl_path" = x
                 then
                     echo "Cannot fine mkl directory"
                     echo "Please specify a value for --with-mkl"
                     exit 1
                 fi
             else
-                if test $(check_dir $optarg $mkl_check) = yes
+                if test $(check_dir "$optarg" $mkl_check) = yes
                 then
-                    mkl_path=$optarg
+                    mkl_path="$optarg"
                 else
                     echo "Invalid mkl directory $optarg"
                     exit 1
@@ -383,19 +387,19 @@ do
             ;;
         --with-kaldi*)
             have_kaldi=yes
-            if test x$optarg = x
+            if test x"$optarg" = x
             then
-                kaldi_path=$(find_kaldi)
-                if test x$kaldi_path = x
+                kaldi_path="$(find_kaldi)"
+                if test x"$kaldi_path" = x
                 then
                     echo "Cannot find kaldi directory"
                     echo "Please specify a value for --with-kaldi"
                     exit 1
                 fi
             else
-                if test $(check_dir $optarg $kaldi_check)
+                if test $(check_dir "$optarg" $kaldi_check)
                 then
-                    kaldi_path=$optarg
+                    kaldi_path="$optarg"
                 else
                     echo "Invalid kaldi directory $optarg"
                     exit 1
@@ -404,10 +408,10 @@ do
             ;;
         --with-opencv*)
             have_opencv=yes
-            if test x$optarg = x
+            if test x"$optarg" = x
             then
-                opencv_path=$(find_opencv)
-                if test x$opencv_path = x
+                opencv_path="$(find_opencv)"
+                if test x"$opencv_path" = x
                 then
                     echo "Cannot find OpenCV directory."
                     echo "Please specify a value for --with-opencv"
@@ -415,9 +419,9 @@ do
                     exit 1
                 fi
             else
-                if test $(check_dir $optarg $opencv_check) = yes
+                if test $(check_dir "$optarg" $opencv_check) = yes
                 then
-                    opencv_path=$optarg
+                    opencv_path="$optarg"
                 else
                     echo "Invalid OpenCV directory $optarg"
                     exit 1
@@ -441,11 +445,11 @@ fi
 # If no math library was specified, search for acml and then mkl
 if test x$have_acml = xno && test x$have_mkl = xno
 then
-    acml_path=$(find_acml)
-    if test x$acml_path = x
+    acml_path="$(find_acml)"
+    if test x"$acml_path" = x
     then
-        mkl_path=$(find_mkl)
-        if test x$mkl_path = x
+        mkl_path="$(find_mkl)"
+        if test x"$mkl_path" = x
         then
             echo "Cannot find a CPU math library."
             echo "Please specify --with-acml or --with-mkl with a path."
@@ -461,8 +465,8 @@ fi
 # If no cuda library specified, search for one
 if test x$enable_cuda = xyes && test x$cuda_path = x
 then
-    cuda_path=$(find_cuda)
-    if test x$cuda_path = x ; then
+    cuda_path="$(find_cuda)"
+    if test x"$cuda_path" = x ; then
         echo Cannot locate a cuda directory
         echo GPU will be disabled
         enable_cuda=no
@@ -473,8 +477,8 @@ fi
 
 if test $enable_cuda = yes && test x$gdk_path = x
 then
-    gdk_path=$(find_gdk)
-    if test x$gdk_path = x ; then
+    gdk_path="$(find_gdk)"
+    if test x"$gdk_path" = x ; then
         echo Cannot locate a gdk directory
         echo GPU will be disabled
         enable_cuda=no
@@ -485,8 +489,8 @@ fi
 
 if test $enable_cuda = yes && test x$cub_path = x
 then
-    cub_path=$(find_cub)
-    if test x$cub_path = x ; then
+    cub_path="$(find_cub)"
+    if test x"$cub_path" = x ; then
         echo Cannot locate NVIDIA CUB directory
         echo GPU will be disabled
         echo NVIDIA CUB can be downloaded from https://github.com/NVlabs/cub/archive/1.4.1.zip, extract the archive to /usr/local
@@ -498,8 +502,8 @@ fi
 
 if test $enable_cuda = yes && test x$cudnn_path = x
 then
-    cudnn_path=$(find_cudnn)
-    if test x$cudnn_path = x ; then
+    cudnn_path="$(find_cudnn)"
+    if test x"$cudnn_path" = x ; then
         echo Cannot locate NVIDIA cuDNN directory
         echo CNTK will use default convolution engine.
     else
@@ -507,10 +511,10 @@ then
     fi
 fi
 
-if test x$opencv_path = x
+if test x"$opencv_path" = x
 then
-    opencv_path=$(find_opencv)
-    if test x$opencv_path = x ; then
+    opencv_path="$(find_opencv)"
+    if test x"$opencv_path" = x ; then
         echo Cannot locate OpenCV 3.0.0 directory
         echo ImageReader will NOT be built.
     else
@@ -518,48 +522,47 @@ then
     fi
 fi
 
-config=$build_top/Config.make
+config="$build_top/Config.make"
 echo Generating $config
-echo "#Configuration file for cntk" > $config
-echo BUILDTYPE=$buildtype >> $config
-echo MATHLIB=$mathlib >> $config
+echo "#Configuration file for cntk" > "$config"
+echo BUILDTYPE=$buildtype >> "$config"
+echo MATHLIB=$mathlib >> "$config"
 case $mathlib in
     acml)
-        echo ACML_PATH=$acml_path >> $config
+        echo ACML_PATH=\"$acml_path\" >> "$config"
         ;;
     mkl)
-        echo MKL_PATH=$mkl_path >> $config
+        echo MKL_PATH=\"$mkl_path\" >> "$config"
         ;;
 esac
 if test $enable_cuda = yes ; then
-    echo CUDA_PATH=$cuda_path >> $config
-    echo GDK_PATH=$gdk_path >> $config
-    echo CUB_PATH=$cub_path >> $config
-    echo CUDNN_PATH=$cudnn_path >> $config
+    echo CUDA_PATH=\"$cuda_path\" >> "$config"
+    echo GDK_PATH=\"$gdk_path\" >> "$config"
+    echo CUB_PATH=\"$cub_path\" >> "$config"
+    echo CUDNN_PATH=\"$cudnn_path\" >> "$config"
 fi
 if test x$kaldi_path != x ; then
-    echo KALDI_PATH=$kaldi_path >> $config
+    echo KALDI_PATH=\"$kaldi_path\" >> "$config"
 fi
 if test x$opencv_path != x ; then
-    echo OPENCV_PATH=$opencv_path >> $config
+    echo OPENCV_PATH=\"$opencv_path\" >> "$config"
 fi
 if test $enable_1bitsgd = yes ; then
     echo CNTK_ENABLE_1BitSGD=true >> $config
 fi
 
 # If we are not in the configure directory, generate a trampoline Makefile
-makefile=$build_top/Makefile
+makefile="$build_top/Makefile"
 if test $(is_hardlinked "$configure" "$build_top/configure") = no
 then
     echo Generating $makefile
-    realconf=`readlink -f $configure`
-    dir=`dirname $realconf`
-    echo "#Generate Makefile" > $makefile
-    echo dir=$dir >> $makefile
-    echo BUILD_TOP=$build_top >> $makefile
-    echo >> $makefile
-    echo all clean : >> $makefile
-    printf '\t$(MAKE) -C $(dir) BUILD_TOP=$(BUILD_TOP) $@\n' >> $makefile
+    dir=$(cd "$(dirname "$configure")"; pwd -P)
+    echo "#Generate Makefile" > "$makefile"
+    echo dir=\"$dir\" >> "$makefile"
+    echo BUILD_TOP=\"$build_top\" >> "$makefile"
+    echo >> "$makefile"
+    echo all clean : >> "$makefile"
+    printf '\t$(MAKE) -C $(dir) BUILD_TOP=$(BUILD_TOP) $@\n' >> "$makefile"
 fi
 echo run 
 echo '>make -j all'


### PR DESCRIPTION
These change made it possible for me to build CNTK on OS X 10.11.3. Just a single commit deals with Mac-specific changes, the others correct non-standard linking behaviour that depends on luck and compiler implementation details (I'm surprised CNTK even links on Windows and Linux).

I based this PR on f628e52de2ea1fe91a0a87de107bdcf384679ef0 because the Linux build is currently broken in master. I'll rebase this PR as soon as this is fixed.

I could only test the CPU-only version because I don't have an Nvidia GPU. On the other hand, I set up CI to test the changes with GCC 4.9 and 5.3 both on Linux and Mac, so I'm pretty confident they don't break anything (see [Travis CI](https://travis-ci.org/jpauwels/CNTK/builds/107701923)). Now I'd like someone to verify on a Windows machine.

In order to build on a Mac, you need an `mpic++` that is built with GCC, which doesn't come standard with OS X. If you have homebrew, you can do: `brew install gcc --without-multilib` and then `brew install --cc=gcc openmpi`. You also need Intel MKL, because ACML is not available for Mac, but the former is [freely available](https://software.intel.com/sites/campaigns/nest/) too (since recently).
