### PR TITLE
MaxGpus was hardcoded to 8 GPUs

### DIFF
--- a/Source/Math/GPUMatrix.h
+++ b/Source/Math/GPUMatrix.h
@@ -46,6 +46,10 @@ typedef struct CUstream_st* cudaStream_t;
 #define USE_TIME_BASED_SEED ULONG_MAX
 #endif
 
+#ifndef MAX_GPUS
+#define MAX_GPUS 16
+#endif
+
 // Stream management functions
 void MATH_API SetStream(cudaStream_t stream);
 cudaStream_t MATH_API GetStream();
@@ -101,7 +105,7 @@ class MATH_API GPUMatrix : public BaseMatrix<ElemType>
     friend class GPUMatrix;
 
 public:
-    static const int MaxGpus = 8; // support up to 8 GPUs
+    static const int MaxGpus = MAX_GPUS; // support up to 8 GPUs
     using BaseMatrix<ElemType>::m_computeDevice;
     using BaseMatrix<ElemType>::m_elemSizeAllocated;
     using BaseMatrix<ElemType>::m_matrixName;


### PR DESCRIPTION
Increasing the limit to 16 to support a K80 CS-Storm node; MAX_GPUS can be used to define this value at compile time.