### PR TITLE
Fix issue https://github.com/Microsoft/CNTK/issues/171

### DIFF
--- a/Examples/Image/MNIST/Config/02_Convolution.cntk
+++ b/Examples/Image/MNIST/Config/02_Convolution.cntk
@@ -42,7 +42,7 @@ train = [
     SGD = [
         epochSize = 60000
         minibatchSize = 32
-        learningRatesPerMB = 0.5
+        learningRatesPerMB = 0.05
         momentumPerMB = 0*10:0.7
         maxEpochs = 15
     ]


### PR DESCRIPTION
Fix issue https://github.com/Microsoft/CNTK/issues/171
After change learningRatesPerMD from 0.5 to 0.05, the error rate goes to 1% (Original error rate is about 90%).
