### PR TITLE
When we execute the plot action, It shows "The syntax of the command is incorrect."

### DIFF
--- a/Source/ActionsLib/OtherActions.cpp
+++ b/Source/ActionsLib/OtherActions.cpp
@@ -521,8 +521,8 @@ void DoTopologyPlot(const ConfigParameters& config)
         renderCmd = regex_replace(renderCmd, inputPlaceHolder,  L"$1" + outputDotFile + L"$3");
         renderCmd = regex_replace(renderCmd, outputPlaceHolder, L"$1" + outputFile    + L"$3");
 #endif
-        msra::strfun::ReplaceAll(renderCmd, wstring(L"<IN>"), outputDotFile);
-        msra::strfun::ReplaceAll(renderCmd, wstring(L"<OUT>"), outputFile);
+        renderCmd = msra::strfun::ReplaceAll(renderCmd, wstring(L"<IN>"), outputDotFile);
+        renderCmd = msra::strfun::ReplaceAll(renderCmd, wstring(L"<OUT>"), outputFile);
     }
 
 


### PR DESCRIPTION
When we use the 'plot' action to render model, we will get an issue "The syntax of the command is incorrect." from the 'dot.exe'.
It is caused by the rendering cmd is not correctly,

According to the function DoTopologyPlot in OtherActions.cpp,
we want to use bellow code to replace the renderCmd, it will not replace anything,
    msra::strfun::ReplaceAll(renderCmd, wstring(L"<IN>"), outputDotFile);
    msra::strfun::ReplaceAll(renderCmd, wstring(L"<OUT>"), outputFile);
I fixed it by bellow code,
    renderCmd = msra::strfun::ReplaceAll(renderCmd, wstring(L"<IN>"), outputDotFile);
    renderCmd = msra::strfun::ReplaceAll(renderCmd, wstring(L"<OUT>"), outputFile);

https://github.com/Microsoft/CNTK/issues/257