### PR TITLE
CPU and GPU dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,10 @@ else
 endif
 
 ifeq ("$(MATHLIB)","acml")
-  INCLUDEPATH += $(ACML_PATH)/include
-  LIBPATH += $(ACML_PATH)/lib
+  INCLUDEPATH += $(ACML_PATH)/ifort64/include
+  INCLUDEPATH += $(ACML_PATH)/ifort64_mp/include
+  LIBPATH += $(ACML_PATH)/ifort64/lib
+  LIBPATH += $(ACML_PATH)/ifort64_mp/lib
   LIBS += -lacml_mp -liomp5 -lm -lpthread
   COMMON_FLAGS += -DUSE_ACML
 endif

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ ifdef CUDA_PATH
 # Set up CUDA includes and libraries
   INCLUDEPATH += $(CUDA_PATH)/include
   LIBPATH += $(CUDA_PATH)/lib64
+  LIBPATH += $(CUDA_PATH)/lib64/stubs
   LIBS += -lcublas -lcudart -lcuda -lcurand -lcusparse -lnvidia-ml
 
 # Set up cuDNN if needed

--- a/configure
+++ b/configure
@@ -10,7 +10,7 @@ enable_cuda=
 
 have_acml=no
 acml_path=
-acml_check=include/acml.h
+acml_check=ifort64/include/acml.h
 
 have_mkl=no
 mkl_path=
@@ -486,7 +486,7 @@ do
                     exit 1
                 fi
             else
-                if test $(check_dir $optarg $$libzip_check) = yes
+                if test $(check_dir $optarg $libzip_check) = yes
                 then
                     libzip_path=$optarg
                 else


### PR DESCRIPTION
here is a revision of the CPU dockerfile, now based on ubuntu:14.04.  And a first draft of a GPU dockerfile, based ultimately on ubuntu:14.04.  Both presume that the user has already downloaded the AMD ACML .tgz.   The GPU dockerfile is easiest to use with nvidia-docker, tho it runs with standard docker as well if you set all the device mappings correctly.