### PR TITLE
Makefile and configure changes for docker and for using alternative install paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,10 @@ else
 endif
 
 ifeq ("$(MATHLIB)","acml")
-  INCLUDEPATH += $(ACML_PATH)/include
-  LIBPATH += $(ACML_PATH)/lib
+  INCLUDEPATH += $(ACML_PATH)/ifort64/include
+  INCLUDEPATH += $(ACML_PATH)/ifort64_mp/include
+  LIBPATH += $(ACML_PATH)/ifort64/lib
+  LIBPATH += $(ACML_PATH)/ifort64_mp/lib
   LIBS += -lacml_mp -liomp5 -lm -lpthread
   COMMON_FLAGS += -DUSE_ACML
 endif

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ ifdef CUDA_PATH
 # Set up CUDA includes and libraries
   INCLUDEPATH += $(CUDA_PATH)/include
   LIBPATH += $(CUDA_PATH)/lib64
+  LIBPATH += $(CUDA_PATH)/lib64/stubs
   LIBS += -lcublas -lcudart -lcuda -lcurand -lcusparse -lnvidia-ml
 
 # Set up cuDNN if needed

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ endif
 ifeq ("$(MATHLIB)","openblas")
   INCLUDEPATH += $(OPENBLAS_PATH)/include
   LIBPATH += $(OPENBLAS_PATH)/lib
-  LIBS += -lopenblas -lm -lpthread
+  LIBS += -lopenblas -llapacke -lm -lpthread
   CPPFLAGS += -DUSE_OPENBLAS
 endif
 

--- a/configure
+++ b/configure
@@ -10,7 +10,7 @@ enable_cuda=
 
 have_acml=no
 acml_path=
-acml_check=include/acml.h
+acml_check=ifort64/include/acml.h
 
 have_mkl=no
 mkl_path=
@@ -486,7 +486,7 @@ do
                     exit 1
                 fi
             else
-                if test $(check_dir $optarg $$libzip_check) = yes
+                if test $(check_dir $optarg $libzip_check) = yes
                 then
                     libzip_path=$optarg
                 else


### PR DESCRIPTION
I don't expect you to merge this pull request, just using it to communicate some changes that seem effective to me, for you to consider in your next linux release.  Explanation of each change follows:

Makefile:109 -- this is needed for docker image builds, as the base nvidia docker images put libcuda.so in a slightly different place than expected.

Makefile: 125-129 -- these lines permit install of the ACML package in a different location.  one var, ACML_PATH, can now be set and libs in both ifort64 adn ifort64_mp will be picked up

configure:13 -- companion change needed for the makefile change above

configure:489 -- this is just a bug fix
