### PR TITLE
FIXED: error: expected ')' before 'PRIu64' on Linux CPU-only

### DIFF
--- a/Source/Common/File.cpp
+++ b/Source/Common/File.cpp
@@ -12,7 +12,8 @@
 #define FORMAT_SPECIALIZE // to get the specialized version of the format routines
 #include "File.h"
 #include <string>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <locale>
 #ifdef _WIN32
 #define NOMINMAX

--- a/Source/Common/Include/Config.h
+++ b/Source/Common/Include/Config.h
@@ -7,7 +7,8 @@
 #include <vector>
 #include <map>
 #include <stdexcept>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 using namespace std;
 

--- a/Source/Common/Include/File.h
+++ b/Source/Common/Include/File.h
@@ -8,7 +8,8 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #ifdef _WIN32
 #define NOMINMAX
 #include "Windows.h"

--- a/Source/Common/Include/fileutil.h
+++ b/Source/Common/Include/fileutil.h
@@ -26,7 +26,8 @@
 #include <functional>
 #include <cctype>
 #include <errno.h>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <assert.h>
 #include <string.h>  // for strerror()
 #include <stdexcept> // for exception

--- a/Source/Common/Include/latticearchive.h
+++ b/Source/Common/Include/latticearchive.h
@@ -17,7 +17,6 @@
 #include "latticestorage.h"
 #include "simple_checked_arrays.h"
 #include "fileutil.h"
-#include <stdint.h>
 #include <vector>
 #include <string>
 #include <unordered_map>

--- a/Source/Common/Include/latticestorage.h
+++ b/Source/Common/Include/latticestorage.h
@@ -10,7 +10,8 @@
 #include "Basics.h"
 #include <string> // for the error message in checkoverflow() only
 #include <stdexcept>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <cstdio>
 
 #undef INITIAL_STRANGE // [v-hansu] intialize structs to strange values

--- a/Source/Common/fileutil.cpp
+++ b/Source/Common/fileutil.cpp
@@ -28,7 +28,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <assert.h>
 #ifdef _WIN32
 #define NOMINMAX

--- a/Source/Math/CommonMatrix.h
+++ b/Source/Math/CommonMatrix.h
@@ -15,7 +15,8 @@
 
 #include "Basics.h"
 #include <string>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <memory>
 
 #pragma warning( disable: 4251 )

--- a/Source/Readers/BinaryReader/BinaryFile.cpp
+++ b/Source/Readers/BinaryReader/BinaryFile.cpp
@@ -9,7 +9,8 @@
 #include "DataReader.h"
 #include "BinaryReader.h"
 #include <limits.h>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 namespace Microsoft { namespace MSR { namespace CNTK {
 

--- a/Source/Readers/CNTKTextFormatReader/Descriptors.h
+++ b/Source/Readers/CNTKTextFormatReader/Descriptors.h
@@ -5,7 +5,8 @@
 
 #pragma once
 
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <vector>
 #include "DataDeserializer.h"
 

--- a/Source/Readers/CNTKTextFormatReader/Indexer.cpp
+++ b/Source/Readers/CNTKTextFormatReader/Indexer.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "stdafx.h"
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include "Indexer.h"
 #include "TextReaderConstants.h"

--- a/Source/Readers/CNTKTextFormatReader/Indexer.h
+++ b/Source/Readers/CNTKTextFormatReader/Indexer.h
@@ -5,7 +5,8 @@
 
 #pragma once
 
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <vector>
 #include "Descriptors.h"
 

--- a/Source/Readers/CNTKTextFormatReader/TextParser.cpp
+++ b/Source/Readers/CNTKTextFormatReader/TextParser.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "stdafx.h"
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <cfloat>
 #include <limits>

--- a/Source/Readers/ExperimentalHTKMLFReader/MLFDataDeserializer.cpp
+++ b/Source/Readers/ExperimentalHTKMLFReader/MLFDataDeserializer.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "stdafx.h"
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <limits>
 #include "MLFDataDeserializer.h"

--- a/Source/Readers/HTKMLFReader/htkfeatio.h
+++ b/Source/Readers/HTKMLFReader/htkfeatio.h
@@ -16,7 +16,8 @@
 #include <regex>
 #include <set>
 #include <unordered_map>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <limits.h>
 #include <wchar.h>
 #include "simplesenonehmm.h"

--- a/Source/Readers/HTKMLFReader/latticearchive.cpp
+++ b/Source/Readers/HTKMLFReader/latticearchive.cpp
@@ -12,7 +12,8 @@
 #include "latticearchive.h"
 #include "msra_mgram.h" // for MLF reading for numer lattices
 #include <stdio.h>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <vector>
 #include <string>
 #include <set>

--- a/Source/Readers/ImageReader/ImageDataDeserializer.cpp
+++ b/Source/Readers/ImageReader/ImageDataDeserializer.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "stdafx.h"
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <opencv2/opencv.hpp>
 #include <numeric>

--- a/Source/Readers/Kaldi2Reader/htkfeatio.h
+++ b/Source/Readers/Kaldi2Reader/htkfeatio.h
@@ -16,7 +16,8 @@
 #include <regex>
 #include <set>
 #include <unordered_map>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <limits.h>
 #include <wchar.h>
 //#include <iostream>

--- a/Source/Readers/Kaldi2Reader/latticearchive.cpp
+++ b/Source/Readers/Kaldi2Reader/latticearchive.cpp
@@ -12,7 +12,8 @@
 #include "latticearchive.h"
 #include "msra_mgram.h" // for MLF reading for numer lattices
 #include <stdio.h>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <vector>
 #include <string>
 #include <set>

--- a/Source/Readers/LMSequenceReader/SequenceParser.cpp
+++ b/Source/Readers/LMSequenceReader/SequenceParser.cpp
@@ -7,7 +7,8 @@
 
 #include "stdafx.h"
 #include <stdexcept>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include "Basics.h"
 #include "SequenceParser.h"
 #include "fileutil.h"

--- a/Source/Readers/LMSequenceReader/SequenceParser.h
+++ b/Source/Readers/LMSequenceReader/SequenceParser.h
@@ -12,7 +12,8 @@
 #include <assert.h>
 #include <fstream>
 #include <map>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include "Basics.h"
 #include "fileutil.h"
 

--- a/Source/Readers/LUSequenceReader/LUSequenceParser.h
+++ b/Source/Readers/LUSequenceReader/LUSequenceParser.h
@@ -13,7 +13,8 @@
 #include <fstream>
 #include <iostream>
 #include <map>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include "Platform.h"
 #include "DataReader.h"
 

--- a/Source/Readers/ReaderLib/SequencePacker.cpp
+++ b/Source/Readers/ReaderLib/SequencePacker.cpp
@@ -7,6 +7,7 @@
 #define _SCL_SECURE_NO_WARNINGS
 
 #include <numeric>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include "SequencePacker.h"
 #include "ElementTypeUtils.h"

--- a/Source/Readers/UCIFastReader/UCIParser.cpp
+++ b/Source/Readers/UCIFastReader/UCIParser.cpp
@@ -9,7 +9,8 @@
 #include "Basics.h"
 #include "UCIParser.h"
 #include <stdexcept>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 #if WIN32
 #define ftell64 _ftelli64

--- a/Source/Readers/UCIFastReader/UCIParser.h
+++ b/Source/Readers/UCIFastReader/UCIParser.h
@@ -9,7 +9,8 @@
 #include <string>
 #include <vector>
 #include <assert.h>
-#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <algorithm>
 
 #ifdef min


### PR DESCRIPTION
When compiling CPU-only flavor of CNTK on Linux it fails to build because of
```
error: expected ')' before 'PRIu64'
```
Solution, replaced all:
```
#include <stdint.h>
```
with:
```
#define __STDC_FORMAT_MACROS
#include <inttypes.h>
```

which include the #include <stdint.h> and also define PRIu64.