### PR TITLE
bugfix: grayscale image now assumed by default if number of channels …

### DIFF
--- a/Source/Readers/ImageReader/ImageConfigHelper.cpp
+++ b/Source/Readers/ImageReader/ImageConfigHelper.cpp
@@ -77,7 +77,7 @@ ImageConfigHelper::ImageConfigHelper(const ConfigParameters& config)
 
     m_mapPath = config(L"file");
 
-    m_grayscale = config(L"grayscale", false);
+    m_grayscale = config(L"grayscale", c == 1);
     std::string rand = config(L"randomize", "auto");
 
     if (AreEqualIgnoreCase(rand, "auto"))


### PR DESCRIPTION
Using ImageReader with grayscale images crashes CNTK unless the reader parameter "grayscale=true" is set in the cntk config. However, CNTK should be smart enough to (by default) read grayscale images if the number of channels in the feature section of the reader is one anyway (channels=1).