### PR TITLE
bugfix: multiview in ImageReader now disabled by default (as intended)

### DIFF
--- a/Source/Readers/ImageReader/ImageConfigHelper.cpp
+++ b/Source/Readers/ImageReader/ImageConfigHelper.cpp
@@ -112,7 +112,7 @@ ImageConfigHelper::ImageConfigHelper(const ConfigParameters& config)
 
     m_cpuThreadCount = config(L"numCPUThreads", 0);
 
-    m_multiViewCrop = AreEqualIgnoreCase((string)featureSection(L"cropType", ""), "multiview10");
+    m_multiViewCrop = AreEqualIgnoreCase((string)featureSection(L"cropType", "center"), "multiview10");
 }
 
 std::vector<StreamDescriptionPtr> ImageConfigHelper::GetStreams() const


### PR DESCRIPTION
An empty string will (curiously) be mapped to CropType::Multiview10 instead of CropType::Center. This is #1 unintuitive and #2, for regression tasks, this is never desirable since it would result in wrongly labeled images.