### PR TITLE
Make exceptions serializable

### DIFF
--- a/Source/Extensibility/EvalWrapper/EvalWrapper.cpp
+++ b/Source/Extensibility/EvalWrapper/EvalWrapper.cpp
@@ -23,6 +23,7 @@ using namespace std;
 using namespace System;
 using namespace System::Collections::Generic;
 using namespace System::Collections;
+using namespace System::Runtime::Serialization;
 using namespace Microsoft::MSR::CNTK;
 
 namespace Microsoft { namespace MSR { namespace CNTK { namespace Extensibility { namespace Managed {
@@ -524,7 +525,8 @@ public:
     }
 };
 
-public ref class CNTKException : Exception
+[Serializable]
+public ref class CNTKException : Exception, ISerializable
 {
 public:
     CNTKException() : Exception()
@@ -537,8 +539,23 @@ public:
     {}
 
     const String^ NativeCallStack;
+
+
+    [System::Security::Permissions::SecurityPermissionAttribute
+        (System::Security::Permissions::SecurityAction::LinkDemand,
+        Flags = System::Security::Permissions::SecurityPermissionFlag::SerializationFormatter)]
+    virtual void GetObjectData(SerializationInfo^ info, StreamingContext context) override
+    {
+        Exception::GetObjectData(info, context);
+    }
+
+protected:
+
+    CNTKException(SerializationInfo^ info, StreamingContext context) : Exception(info, context)
+    {}
 };
 
+[Serializable]
 public ref class CNTKRuntimeException : CNTKException
 {
 public:
@@ -547,8 +564,14 @@ public:
 
     CNTKRuntimeException(String^ message, String^ callstack) : CNTKException(message, callstack)
     {}
+
+protected:
+
+    CNTKRuntimeException(SerializationInfo^ info, StreamingContext context) : CNTKException(info, context)
+    {}
 };
 
+[Serializable]
 public ref class CNTKLogicErrorException : CNTKException
 {
 public:
@@ -557,8 +580,14 @@ public:
 
     CNTKLogicErrorException(String^ message, String^ callstack) : CNTKException(message, callstack)
     {}
+
+protected:
+
+    CNTKLogicErrorException(SerializationInfo^ info, StreamingContext context) : CNTKException(info, context)
+    {}
 };
 
+[Serializable]
 public ref class CNTKInvalidArgumentException : CNTKException
 {
 public:
@@ -567,8 +596,14 @@ public:
 
     CNTKInvalidArgumentException(String^ message, String^ callstack) : CNTKException(message, callstack)
     {}
+
+protected:
+
+    CNTKInvalidArgumentException(SerializationInfo^ info, StreamingContext context) : CNTKException(info, context)
+    {}
 };
 
+[Serializable]
 public ref class CNTKBadAllocException : CNTKException
 {
 public:
@@ -576,6 +611,11 @@ public:
     {}
 
     CNTKBadAllocException(String^ message) : CNTKException(message)
+    {}
+
+protected:
+
+    CNTKBadAllocException(SerializationInfo^ info, StreamingContext context) : CNTKException(info, context)
     {}
 };
 


### PR DESCRIPTION
Makes managed exceptions in EvalWrapper.cpp serializable so they can be passed across app domains.