### PR TITLE
Remove huge matrix dump

### DIFF
--- a/Source/ComputationNetworkLib/TrainingNodes.h
+++ b/Source/ComputationNetworkLib/TrainingNodes.h
@@ -1923,7 +1923,6 @@ public:
                 runInvStdDev.AssignElementPowerOf(runInvStdDev, 2);
                 runInvStdDev.ElementInverse();
                 runInvStdDev += (float) m_epsilon;
-                runInvStdDev.Print();
                 m_convertRunningVariancePending = false;
             }
 


### PR DESCRIPTION
Loading a model trained with an version before 1.7 like ResNet need to compute variance from invStdDev to match CuDNN v5.

The current commit remove the print of the invStdDev matrix to the console (which is really huge).