### PR TITLE
Removing #define for min() function

### DIFF
--- a/Source/Math/Matrix.cpp
+++ b/Source/Math/Matrix.cpp
@@ -24,10 +24,6 @@
 #pragma warning(disable : 4239) // nonstandard extension; triggered by this pattern: "auto& second = transposeB ? b.m_GPUMatrix->Transpose() : *b.m_GPUMatrix;"
 #pragma warning(disable : 4702) // unreachable code; triggered for unknown reasons
 
-#ifndef min
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-#endif
-
 // Helper to dispath matrix calls to the 4 underlying matrix libraries (CPU,GPU) x (DENSE,SPARSE)
 // 'MatrixPointerToCheck' determines where the operation takes place.
 // 'MatrixPointerToSetFlag' is the output. If not null and its location is BOTH, we collapse it to one.


### PR DESCRIPTION
This appears to be no longer needed as it just hides the corresponding
stl functionality..