### PR TITLE
NCCL support in SimpleDistGradAggregator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,14 @@ ifdef CUDA_PATH
     LIBS_LIST += cudnn
     COMMON_FLAGS +=-DUSE_CUDNN
   endif
+
+# Set up NCCL if needed
+  ifdef NCCL_PATH
+    INCLUDEPATH += $(NCCL_PATH)/include
+    LIBPATH += $(NCCL_PATH)/lib
+    LIBS_LIST += nccl
+    COMMON_FLAGS += -DUSE_NCCL
+  endif
 else
   DEVICE = cpu
 
@@ -313,6 +321,7 @@ MATH_SRC =\
 	$(SOURCEDIR)/Math/DataTransferer.cpp \
 	$(SOURCEDIR)/Math/RNGHandle.cpp \
 	$(SOURCEDIR)/Math/TensorView.cpp \
+	$(SOURCEDIR)/Math/NcclComm.cpp \
 
 ifdef SUPPORT_AVX2
 MATH_SRC +=\

--- a/Source/Common/Common.vcxproj
+++ b/Source/Common/Common.vcxproj
@@ -62,6 +62,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\Math\NcclComm.cpp" />
     <ClCompile Include="Config.cpp" />
     <ClCompile Include="DataReader.cpp" />
     <ClCompile Include="DataWriter.cpp" />

--- a/Source/Math/NcclComm.cpp
+++ b/Source/Math/NcclComm.cpp
@@ -1,0 +1,117 @@
+//
+// Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+//
+
+#include "NcclComm.h"
+
+#ifdef USE_NCCL
+#include "GPUMatrix.h"
+#include <nccl.h>
+#include <cuda_runtime.h>
+
+namespace Microsoft { namespace MSR { namespace CNTK {
+
+// allows to write cudaFunction() || "error"   (CUDA runtime)
+static void operator||(cudaError_t rc, const char *msg)
+{
+    if (rc != cudaSuccess)
+        RuntimeError("%s: %s (cuda error %d)", msg, cudaGetErrorString(rc), (int) rc);
+}
+
+NcclComm::NcclComm(int deviceId, const MPIWrapperPtr& mpi)
+    : m_ncclComm(nullptr), m_stream(nullptr)
+{
+    if (mpi->IsMultiHost())
+        return;
+
+    size_t numRanks = mpi->NumNodesInUse();
+    MPI_Comm mpiComm = mpi->Communicator();
+    std::vector<int> allDevs(numRanks);
+    MPI_Allgather(&deviceId, 1, MPI_INT, allDevs.data(), 1, MPI_INT, mpiComm)
+        || MpiFail("NcclComm: MPI_Allgather");
+
+    for (size_t r = 0; r<numRanks; r++)
+    {
+        if (allDevs[r] == CPUDEVICE)
+            return;
+        for (size_t s = 0; s<r; s++)
+            if (allDevs[r] == allDevs[s]) // same device used by more than one rank
+                return;
+    }
+
+    ncclUniqueId ncclId;
+    ncclResult_t res;
+
+    res = ncclGetUniqueId(&ncclId);
+    if (res != ncclSuccess)
+        RuntimeError("NcclComm failed to obtain ncclUniqueId: %s", ncclGetErrorString(res));
+
+    MPI_Bcast(&ncclId, NCCL_UNIQUE_ID_BYTES, MPI_CHAR, 0, mpiComm)
+        || MpiFail("NcclComm: MPI_Bcase");
+
+    PrepareDevice(deviceId);
+    res = ncclCommInitRank(&m_ncclComm, numRanks, ncclId, mpi->CurrentNodeRank());
+    if (res != ncclSuccess)
+      RuntimeError("NcclComm failed to initialize ncclComm_t: %s", ncclGetErrorString(res));
+
+    cudaStreamCreateWithFlags(&m_stream, cudaStreamNonBlocking)
+        || "cudaStreamCreateWithFlags failed";
+}
+
+NcclComm::~NcclComm()
+{
+    if (m_stream != nullptr)
+        cudaStreamDestroy(m_stream);
+    if (m_ncclComm != nullptr)
+        ncclCommDestroy(m_ncclComm);
+}
+
+bool NcclComm::IsSupported()
+{
+    return m_ncclComm != nullptr;
+}
+
+void NcclComm::AllReduceImpl(void* buffer, size_t count, DataType dtype)
+{
+    ncclResult_t res;
+    if (dtype == DataType::FLOAT)
+    {
+        res = ncclAllReduce(buffer, buffer, count, ncclFloat, ncclSum, m_ncclComm, m_stream);
+    }
+    else
+    {
+        assert(dtype == DataType::DOUBLE);
+        res = ncclAllReduce(buffer, buffer, count, ncclDouble, ncclSum, m_ncclComm, m_stream);
+    }
+
+    if (res != ncclSuccess)
+        RuntimeError("NcclComm ncclAllReduce failed: %s", ncclGetErrorString(res));
+}
+
+void NcclComm::Sync()
+{
+    cudaStreamSynchronize(m_stream) || "NcclComm: cudaStreamSynchronize failed";
+}
+
+}}} // end namespaces
+
+#else // !USE_NCCL
+namespace Microsoft { namespace MSR { namespace CNTK {
+
+NcclComm::NcclComm(int /*deviceId*/, const MPIWrapperPtr& /*mpi*/) { }
+
+NcclComm::~NcclComm() { }
+
+bool NcclComm::IsSupported()
+{
+    return false;
+}
+
+void NcclComm::Sync()
+{
+    return;
+}
+
+}}} // end namespaces
+#endif

--- a/Source/Math/NcclComm.h
+++ b/Source/Math/NcclComm.h
@@ -1,0 +1,56 @@
+//
+// Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
+// Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
+//
+// Encapsulates NCCLs dependencies
+#pragma once
+
+#include "Matrix.h"
+#include "MPIWrapper.h"
+
+#include <vector>
+#include <type_traits>
+
+// Forward declare CUDA stuff
+typedef struct CUstream_st* cudaStream_t;
+typedef struct ncclComm* ncclComm_t;
+
+namespace Microsoft { namespace MSR { namespace CNTK {
+
+class NcclComm
+{
+#ifdef USE_NCCL
+private:
+    enum class DataType : int {FLOAT, DOUBLE};
+    void AllReduceImpl(void* buffer, size_t count, DataType dtype);
+    cudaStream_t m_stream;
+    ncclComm_t m_ncclComm;
+#endif
+
+public:
+    NcclComm(int deviceId, const MPIWrapperPtr& mpiComm);
+    ~NcclComm();
+    bool IsSupported();
+    void Sync(); // waits for outstanding reductions to complete
+
+    template <typename ElemType>
+    void AllReduce(const std::vector<Matrix<ElemType>*>& grads)
+    {
+#ifdef USE_NCCL
+        DataType dtype = DataType::FLOAT;
+        if (std::is_same<ElemType, double>::value)
+            dtype = DataType::DOUBLE;
+        else if (!std::is_same<ElemType, float>::value)
+            RuntimeError("NcclComm Unsupported reduction type");
+
+        for (size_t i=0; i<grads.size(); ++i)
+        {
+            AllReduceImpl(grads[i]->Data(), grads[i]->GetNumElements(), dtype);
+        }
+#else
+        RuntimeError("NcclComm: CNTK was built without NCCL support.");
+#endif
+    }
+};
+
+}}}

--- a/Source/SGDLib/PostComputingActions.cpp
+++ b/Source/SGDLib/PostComputingActions.cpp
@@ -116,7 +116,7 @@ void PostComputingActions<ElemType>::BatchNormalizationStatistics(IDataReader * 
             // push the statistics results of mean and variance of bn nodes into mpi updating vector
             std::vector<Matrix<ElemType>*> learnParamsValues(2, nullptr);
 
-            SimpleDistGradAggregator<ElemType> distGradAgg(m_mpi, false /*useAsyncAggregation*/, 0 /*syncStatsTrace*/);
+            SimpleDistGradAggregator<ElemType> distGradAgg(m_mpi, false /*useAsyncAggregation*/, m_net->GetDeviceId(), 0 /*syncStatsTrace*/);
 
             auto runMeanParameterPtr = node->Input(3);
             auto runStdParameterPtr  = node->Input(4);

--- a/Source/SGDLib/SGD.cpp
+++ b/Source/SGDLib/SGD.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
 // Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
 //
 // SGD.cpp -- implements SGD with all bells and whistles, parallelization, randomization, etc.
@@ -330,7 +331,7 @@ void SGD<ElemType>::TrainOrAdaptModel(int startEpoch, ComputationNetworkPtr net,
     if (GetParallelizationMethod() == ParallelizationMethod::dataParallelSGD)
     {
         currentNumGradientBits = m_numGradientBits[startEpoch]; // remember so that we can detect a change
-        InitDistGradAgg(evaluationNodes.size(), currentNumGradientBits, m_traceLevel);
+        InitDistGradAgg(evaluationNodes.size(), currentNumGradientBits, net->GetDeviceId(), m_traceLevel);
     }
     else if (GetParallelizationMethod() == ParallelizationMethod::modelAveragingSGD || 
              GetParallelizationMethod() == ParallelizationMethod::blockMomentumSGD)
@@ -417,7 +418,7 @@ void SGD<ElemType>::TrainOrAdaptModel(int startEpoch, ComputationNetworkPtr net,
             currentNumGradientBits != m_numGradientBits[i])
         {
             currentNumGradientBits = m_numGradientBits[i];
-            InitDistGradAgg(evaluationNodes.size(), currentNumGradientBits, m_traceLevel);
+            InitDistGradAgg(evaluationNodes.size(), currentNumGradientBits, net->GetDeviceId(), m_traceLevel);
         }
 
         Timer timer;
@@ -2011,31 +2012,35 @@ void SGD<ElemType>::AttemptUtteranceDerivativeFeatures(ComputationNetworkPtr net
 }
 
 template <class ElemType>
-void SGD<ElemType>::InitDistGradAgg(int numEvalNodes, int numGradientBits, int traceLevel)
+void SGD<ElemType>::InitDistGradAgg(int numEvalNodes, int numGradientBits, int deviceId, int traceLevel)
 {
     assert(GetParallelizationMethod() == ParallelizationMethod::dataParallelSGD);
-    if (traceLevel > 0)
-        fprintf(stderr, "Initializing dataParallelSGD for %d-bit quantization.\n", numGradientBits);
 
-#ifdef CNTK_PARALLEL_TRAINING_SUPPORT
-    if (Globals::UseV2Aggregator())
-    {
-        auto communicator = ::CNTK::QuantizedMPICommunicator(m_zeroThresholdFor1Bit, true, numGradientBits);
-        m_distGradAgg = std::make_shared<V2AllReduceDistGradAggregator<ElemType>>(communicator, m_bufferedAsyncGradientAggregation, traceLevel, m_syncStatsTrace);
-    }
-    else
-        m_distGradAgg = std::make_shared<AllReduceDistGradAggregator<ElemType>>(m_mpi, numGradientBits, m_zeroThresholdFor1Bit, true /*useQuantizationForSelfStripe*/, m_bufferedAsyncGradientAggregation, traceLevel, m_syncStatsTrace);
-#else
     if (numGradientBits != (8 * sizeof(ElemType)))
     {
+        if (traceLevel > 0)
+            fprintf(stderr, "Initializing dataParallelSGD for %d-bit quantization.\n", numGradientBits);
+#ifdef CNTK_PARALLEL_TRAINING_SUPPORT
+        if (Globals::UseV2Aggregator())
+        {
+            auto communicator = ::CNTK::QuantizedMPICommunicator(m_zeroThresholdFor1Bit, true, numGradientBits);
+            m_distGradAgg = std::make_shared<V2AllReduceDistGradAggregator<ElemType>>(communicator, m_bufferedAsyncGradientAggregation, traceLevel, m_syncStatsTrace);
+        }
+        else
+            m_distGradAgg = std::make_shared<AllReduceDistGradAggregator<ElemType>>(m_mpi, numGradientBits, m_zeroThresholdFor1Bit, true /*useQuantizationForSelfStripe*/, m_bufferedAsyncGradientAggregation, traceLevel, m_syncStatsTrace);
+#else
         RuntimeError("Gradient quantization is unsupported in CNTK binaries built without quantized gradient aggregation support!");
-    }
-
-    if (Globals::UseV2Aggregator()) // Currently used to check V2 against baselines.
-        m_distGradAgg = std::make_shared<V2SimpleDistGradAggregator<ElemType>>(m_mpi, m_bufferedAsyncGradientAggregation, m_syncStatsTrace, ::CNTK::MPICommunicator());
-    else
-        m_distGradAgg = std::make_shared<SimpleDistGradAggregator<ElemType>>(m_mpi, m_bufferedAsyncGradientAggregation, m_syncStatsTrace);
 #endif // !CNTK_PARALLEL_TRAINING_SUPPORT
+    }
+    else
+    {
+        if (traceLevel > 0)
+            fprintf(stderr, "Initializing dataParallelSGD with FP%d aggregation.\n", numGradientBits);
+        if (Globals::UseV2Aggregator()) // Currently used to check V2 against baselines.
+            m_distGradAgg = std::make_shared<V2SimpleDistGradAggregator<ElemType>>(m_mpi, m_bufferedAsyncGradientAggregation, m_syncStatsTrace, ::CNTK::MPICommunicator());
+        else
+            m_distGradAgg = std::make_shared<SimpleDistGradAggregator<ElemType>>(m_mpi, m_bufferedAsyncGradientAggregation, deviceId, m_syncStatsTrace);
+    }
 
     m_gradHeader.reset(DistGradHeader::Create(numEvalNodes), [](DistGradHeader* ptr) { DistGradHeader::Destroy(ptr); });
 }

--- a/Source/SGDLib/SGD.h
+++ b/Source/SGDLib/SGD.h
@@ -482,7 +482,7 @@ protected:
                          const std::string& prefixMsg = "",
                          const size_t maxNumberOfSamples = SIZE_MAX);
 
-    void InitDistGradAgg(int numEvalNodes, int numGradientBits, int traceLevel);
+    void InitDistGradAgg(int numEvalNodes, int numGradientBits, int deviceId, int traceLevel);
     void InitModelAggregationHandler(int traceLevel, DEVICEID_TYPE devID);
 public:
     // UpdateWeights() - actual weight update, implementing various update rules

--- a/Source/SGDLib/SimpleDistGradAggregator.h
+++ b/Source/SGDLib/SimpleDistGradAggregator.h
@@ -1,5 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
 // Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
 //
 
@@ -7,6 +8,7 @@
 
 #include "IDistGradAggregator.h"
 #include "CUDAPageLockedMemAllocator.h"
+#include "NcclComm.h"
 #include <future>
 #include "GPUDataTransferer.h"
 #include "TimerUtility.h"
@@ -20,8 +22,8 @@ class SimpleDistGradAggregator : public IDistGradAggregator<ElemType>
     UsingIDistGradAggregatorMembers;
 
 public:
-    SimpleDistGradAggregator(const MPIWrapperPtr& mpi, bool useAsyncAggregation, int syncStatsTrace)
-        : IDistGradAggregator<ElemType>(mpi), m_useAsyncAggregation(useAsyncAggregation), m_initialized(false), m_bufferedGradHeader(nullptr), m_syncStatsTrace(syncStatsTrace), m_iterationCount(0)
+    SimpleDistGradAggregator(const MPIWrapperPtr& mpi, bool useAsyncAggregation, int deviceId, int syncStatsTrace)
+        : IDistGradAggregator<ElemType>(mpi), m_useAsyncAggregation(useAsyncAggregation), m_initialized(false), m_bufferedGradHeader(nullptr), m_syncStatsTrace(syncStatsTrace), m_iterationCount(0), m_nccl(deviceId, mpi)
     {}
 
     ~SimpleDistGradAggregator()
@@ -141,7 +143,8 @@ private:
         {
             m_initialized = true;
             int deviceId = gradients[0]->GetDeviceId();
-            if (deviceId != CPUDEVICE)
+
+            if (!m_nccl.IsSupported() && deviceId != CPUDEVICE)
                 m_allocator.reset(new CUDAPageLockedMemAllocator(deviceId));
 
             for (size_t i = 0; i < gradients.size(); i++)
@@ -150,7 +153,7 @@ private:
                 if (gradients[i]->GetMatrixType() != DENSE)
                     RuntimeError("Gradient aggregation for sparse gradient matrices is currently unsupported!");
 
-                if (deviceId != CPUDEVICE)
+                if (!m_nccl.IsSupported() && deviceId != CPUDEVICE)
                 {
                     m_gpuDataTransferers.push_back(std::make_unique<GPUDataTransferer>(deviceId, m_useAsyncAggregation));
                     m_intermediateCPUBuffers.push_back(AllocateIntermediateBuffer(deviceId, gradients[i]->GetNumElements()));
@@ -221,7 +224,7 @@ private:
         }
 
         // Initiate transfer of the gradient matrices to the CPU if needed
-        if (deviceId >= 0)
+        if (!m_nccl.IsSupported() && deviceId >= 0)
         {
             for (size_t i = 0; i < numGradMatrices; ++i)
                 m_gpuDataTransferers[i]->CopyGPUToCPUAsync(gradients[i]->Data(), gradients[i]->GetNumElements(), m_intermediateCPUBuffers[i].get());
@@ -244,20 +247,27 @@ private:
         if (!m_mpi->IsMainNode())
             MPI_Isend(headerCPU, headerCPU->Size(), MPI_CHAR, m_mpi->MainNodeRank(), numGradMatrices, m_mpi->Communicator(), &sendHeaderRequest) || MpiFail("MPI_Isend");
 
-        // Perform MPI async allreduce on the gradient data
+        // Perform async allreduce on the gradient data
         std::vector<MPI_Request> allReduceRequests(numGradMatrices);
-        for (size_t i = 0; i < numGradMatrices; ++i)
+        if (!m_nccl.IsSupported())
         {
-            ElemType* reductionBuffer = gradients[i]->Data();
-            if (deviceId >= 0)
+            for (size_t i = 0; i < numGradMatrices; ++i)
             {
-                m_gpuDataTransferers[i]->WaitForCopyGPUToCPUAsync();
-                reductionBuffer = m_intermediateCPUBuffers[i].get();
-            }
+                ElemType* reductionBuffer = gradients[i]->Data();
+                if (deviceId >= 0)
+                {
+                    m_gpuDataTransferers[i]->WaitForCopyGPUToCPUAsync();
+                    reductionBuffer = m_intermediateCPUBuffers[i].get();
+                }
 
-            // On Windows this async MPI_Iallreduce call requires MS MPI v7 or higher to be installed
-            MPI_Iallreduce(MPI_IN_PLACE, reductionBuffer, gradients[i]->GetNumElements(), MPIWrapper::GetDataType(reductionBuffer), MPI_SUM, m_mpi->Communicator(), &allReduceRequests[i]) || MpiFail("MPI_Iallreduce");
+                // On Windows this async MPI_Iallreduce call requires MS MPI v7 or higher to be installed
+                MPI_Iallreduce(MPI_IN_PLACE, reductionBuffer, gradients[i]->GetNumElements(),
+                               MPIWrapper::GetDataType(reductionBuffer), MPI_SUM,
+                               m_mpi->Communicator(), &allReduceRequests[i]) || MpiFail("MPI_Iallreduce");
+            }
         }
+        else
+            m_nccl.AllReduce(gradients);
 
         // On the main node wait for the headers to arrive and aggregate
         if (m_mpi->IsMainNode())
@@ -298,11 +308,14 @@ private:
         }
 
         // Wait for the allreduce operations to finish and initiate transfer back to the GPU if needed
-        for (size_t i = 0; i < numGradMatrices; ++i)
+        if (!m_nccl.IsSupported())
         {
-            MPI_Wait(&allReduceRequests[i], MPI_STATUSES_IGNORE) || MpiFail("MPI_Wait");
-            if (deviceId >= 0)
-                m_gpuDataTransferers[i]->CopyCPUToGPUAsync(m_intermediateCPUBuffers[i].get(), gradients[i]->GetNumElements(), gradients[i]->Data());
+            for (size_t i = 0; i < numGradMatrices; ++i)
+            {
+                MPI_Wait(&allReduceRequests[i], MPI_STATUSES_IGNORE) || MpiFail("MPI_Wait");
+                if (deviceId >= 0)
+                    m_gpuDataTransferers[i]->CopyCPUToGPUAsync(m_intermediateCPUBuffers[i].get(), gradients[i]->GetNumElements(), gradients[i]->Data());
+            }
         }
 
         // Wait to receive aggregate header
@@ -310,7 +323,9 @@ private:
             MPI_Wait(&recvAggHeaderRequest, MPI_STATUSES_IGNORE) || MpiFail("MPI_Wait");
 
         // Wait for all the transfers to finish
-        if (deviceId >= 0)
+        if (m_nccl.IsSupported())
+            m_nccl.Sync();
+        else if (deviceId >= 0)
         {
             for (size_t i = 0; i < numGradMatrices; ++i)
                 m_gpuDataTransferers[i]->WaitForCopyCPUToGPUAsync();
@@ -354,5 +369,7 @@ private:
     size_t m_iterationCount;
 
     bool m_initialized;
+
+    NcclComm m_nccl;
 };
 } } }

--- a/Source/SGDLib/SimpleEvaluator.h
+++ b/Source/SGDLib/SimpleEvaluator.h
@@ -168,7 +168,7 @@ public:
                     if (Globals::UseV2Aggregator())
                         m_distGradAgg = make_shared<V2SimpleDistGradAggregator<ElemType>>(m_mpi, false /*useAsyncAggregation*/, 0 /*syncStatsTrace*/, ::CNTK::MPICommunicator());
                     else 
-                        m_distGradAgg = make_shared<SimpleDistGradAggregator<ElemType>>(m_mpi, false /*useAsyncAggregation*/, 0 /*syncStatsTrace*/);
+                        m_distGradAgg = make_shared<SimpleDistGradAggregator<ElemType>>(m_mpi, false /*useAsyncAggregation*/, m_net->GetDeviceId(), 0 /*syncStatsTrace*/);
                 }
 
                 m_gradHeader->numEvalNode = evalNodes.size();

--- a/configure
+++ b/configure
@@ -16,6 +16,11 @@ enable_cuda=
 
 enable_python=
 
+# NCCL communication library
+have_nccl=no
+nccl_path=
+nccl_check=include/nccl.h
+
 # CNTK Custom MKL Version
 cntk_custom_mkl_version=2
 
@@ -96,6 +101,7 @@ default_boost="boost-1.60.0"
 
 # NOTE: Will get compilation errors with cuda-6.0
 default_cudas="cuda-7.5 cuda-7.0 cuda-6.5"
+default_nccls="nccl"
 default_kaldis="kaldi-trunk kaldi-c024e8aa"
 default_gdk_includes="include/nvidia/gdk"
 default_gdk_nvml_libs="src/gdk/nvml/lib"
@@ -160,6 +166,11 @@ function find_boost ()
 function find_protobuf ()
 {
     find_dir "$default_protobuf" "$protobuf_check"
+}
+
+function find_nccl ()
+{
+    find_dir "$default_nccls" "$nccl_check"
 }
 
 function find_cuda ()
@@ -318,6 +329,7 @@ function show_help ()
     echo "  --with-gdk-include[=directory] $(show_default $(find_gdk_include))"
     echo "  --with-gdk-nvml-lib[=directory] $(show_default $(find_gdk_nvml_lib))"
     echo "  --with-cudnn[=directory] $(show_default $(find_cudnn))"
+    echo "  --with-nccl[=directory] $(show_default $(find_nccl))"
     echo "  --with-mkl[=directory] $(show_default $(find_mkl))"
     echo "  --with-mkl-sequential[=directory] $(show_default $(find_mkl))"
     echo "  --with-openblas[=directory] (experimental) $(show_default $(find_openblas))"
@@ -584,6 +596,28 @@ do
                     cudnn_path=$optarg
                 else
                     echo "Invalid cuDNN directory $optarg"
+                    exit 1
+                fi
+            fi
+            ;;
+        --with-nccl*)
+            have_nccl=yes
+            if test x$optarg = x
+            then
+                nccl_path=$(find_nccl)
+                if test x$nccl_path = x
+                then
+                    echo "Cannot find NCCL directory."
+                    echo "Please specify a value for --with-nccl"
+                    echo "NCCL can be downloaded from https://github.com/NVIDIA/nccl"
+                    exit 1
+                fi
+            else
+                if test $(check_dir $optarg $nccl_check) = yes
+                then
+                    nccl_path=$optarg
+                else
+                    echo "Invalid NCCL directory $optarg"
                     exit 1
                 fi
             fi
@@ -883,6 +917,14 @@ then
     done
 fi
 
+if test $enable_cuda = yes && test x$nccl_path = x
+then
+    nccl_path=$(find_nccl)
+    if test x$nccl_path != x; then
+        echo Found NCCL at $nccl_path
+    fi
+fi
+
 if test x$opencv_path = x
 then
     opencv_path=$(find_opencv)
@@ -963,6 +1005,7 @@ if test $enable_cuda = yes ; then
     echo GDK_NVML_LIB_PATH=$gdk_nvml_lib_path >> $config
     echo CUB_PATH=$cub_path >> $config
     echo CUDNN_PATH=$cudnn_path >> $config
+    [-z "$nccl_path"] || echo NCCL_PATH=$nccl_path >> $config
 fi
 if test $enable_python = yes ; then
     echo PYTHON_SUPPORT=true >> $config


### PR DESCRIPTION
Use NCCL collectives library (http://github.com/NVIDIA/nccl) to perform all reduce of 32- and 64-bit gradients when all MPI ranks 1) use GPUs and 2) reside on a common host.

Also use SimpleDistGradAggregator for 32- and 64-bit reductions even if CNTK was built with 1-bit SGD support.
