### PR TITLE
Removed "using namespace std" from basetypes.h

### DIFF
--- a/Source/Common/Include/basetypes.h
+++ b/Source/Common/Include/basetypes.h
@@ -43,8 +43,6 @@
 typedef unsigned char byte;
 #endif
 
-using namespace std; // Ugh!
-
 static inline wchar_t *GetWC(const char *c)
 {
     const size_t cSize = strlen(c) + 1;
@@ -394,7 +392,7 @@ static inline void bytereverse(T &v) throw()
     char *p = (char *) &v;
     const size_t elemsize = sizeof(v);
     for (int k = 0; k < elemsize / 2; k++) // swap individual bytes
-        swap(p[k], p[elemsize - 1 - k]);
+        std::swap(p[k], p[elemsize - 1 - k]);
 }
 
 // byte-swap an entire array

--- a/Source/Readers/HTKMLFReader/chunkevalsource.h
+++ b/Source/Readers/HTKMLFReader/chunkevalsource.h
@@ -53,7 +53,7 @@ private:
         size_t firstframe = 0;
         foreach_index (k, numframes)
         {
-            const wstring &outfile = outpaths[k];
+            const std::wstring &outfile = outpaths[k];
             unsigned int sampperiod = sampperiods[k];
             size_t n = numframes[k];
             msra::files::make_intermediate_dirs(outfile);
@@ -87,7 +87,7 @@ public:
 
     // append data to chunk
     template <class MATRIX>
-    void addfile(const MATRIX &feat, const string &featkind, unsigned int sampperiod, const std::wstring &outpath)
+    void addfile(const MATRIX &feat, const std::string &featkind, unsigned int sampperiod, const std::wstring &outpath)
     {
         // append to frames; also expand neighbor frames
         if (feat.cols() < 2)
@@ -182,7 +182,7 @@ private:
         size_t firstframe = 0;
         foreach_index (k, numframes)
         {
-            const wstring &outfile = outpaths[index][k];
+            const std::wstring &outfile = outpaths[index][k];
             unsigned int sampperiod = sampperiods[index][k];
             size_t n = numframes[k];
             msra::files::make_intermediate_dirs(outfile);
@@ -230,7 +230,7 @@ public:
 
     // append data to chunk
     template <class MATRIX>
-    void addfile(const MATRIX &feat, const string &featkind, unsigned int sampperiod, const std::wstring &outpath, size_t index)
+    void addfile(const MATRIX &feat, const std::string &featkind, unsigned int sampperiod, const std::wstring &outpath, size_t index)
     {
         // append to frames; also expand neighbor frames
         if (feat.cols() < 2)
@@ -348,7 +348,7 @@ public:
 
     // append data to chunk
     template <class MATRIX>
-    void AddFile(const MATRIX &feat, const string & /*featkind*/, unsigned int sampPeriod, size_t index)
+    void AddFile(const MATRIX &feat, const std::string & /*featkind*/, unsigned int sampPeriod, size_t index)
     {
         // append to frames; also expand neighbor frames
         if (feat.cols() < 2)

--- a/Source/Readers/HTKMLFReader/minibatchiterator.h
+++ b/Source/Readers/HTKMLFReader/minibatchiterator.h
@@ -37,12 +37,12 @@ public:
     virtual bool getbatch(const size_t globalts,
                           const size_t framesrequested, msra::dbn::matrix &feat, std::vector<size_t> &uids,
                           std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> &transcripts,
-                          std::vector<shared_ptr<const latticesource::latticepair>> &lattices) = 0;
+                          std::vector<std::shared_ptr<const latticesource::latticepair>> &lattices) = 0;
     // alternate (updated) definition for multiple inputs/outputs - read as a vector of feature matrixes or a vector of label strings
     virtual bool getbatch(const size_t globalts,
                           const size_t framesrequested, std::vector<msra::dbn::matrix> &feat, std::vector<std::vector<size_t>> &uids,
                           std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> &transcripts,
-                          std::vector<shared_ptr<const latticesource::latticepair>> &lattices, std::vector<std::vector<size_t>> &sentendmark,
+                          std::vector<std::shared_ptr<const latticesource::latticepair>> &lattices, std::vector<std::vector<size_t>> &sentendmark,
                           std::vector<std::vector<size_t>> &phoneboundaries) = 0;
     // getbatch() overload to support subsetting of mini-batches for parallel training
     // Default implementation does not support subsetting and throws an exception on
@@ -51,7 +51,7 @@ public:
                           const size_t framesrequested, const size_t subsetnum, const size_t numsubsets, size_t &framesadvanced,
                           std::vector<msra::dbn::matrix> &feat, std::vector<std::vector<size_t>> &uids,
                           std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> &transcripts,
-                          std::vector<shared_ptr<const latticesource::latticepair>> &lattices, std::vector<std::vector<size_t>> &sentendmark,
+                          std::vector<std::shared_ptr<const latticesource::latticepair>> &lattices, std::vector<std::vector<size_t>> &sentendmark,
                           std::vector<std::vector<size_t>> &phoneboundaries)
     {
         assert((subsetnum == 0) && (numsubsets == 1) && !supportsbatchsubsetting());
@@ -103,7 +103,7 @@ class minibatchiterator
     std::vector<msra::dbn::matrix> featbuf;                                                      // buffer for holding curernt minibatch's frames
     std::vector<std::vector<size_t>> uids;                                                       // buffer for storing current minibatch's frame-level label sequence
     std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> transcripts; // buffer for storing current minibatch's word-level label sequences (if available and used; empty otherwise)
-    std::vector<shared_ptr<const latticesource::latticepair>> lattices;                          // lattices of the utterances in current minibatch (empty in frame mode)
+    std::vector<std::shared_ptr<const latticesource::latticepair>> lattices;                          // lattices of the utterances in current minibatch (empty in frame mode)
 
     std::vector<std::vector<size_t>> sentendmark;     // buffer for storing current minibatch's utterance end
     std::vector<std::vector<size_t>> phoneboundaries; // buffer for storing phone boundaries
@@ -133,7 +133,7 @@ private:
         }
         // process one mini-batch (accumulation and update)
         assert(requestedmbframes > 0);
-        const size_t requestedframes = min(requestedmbframes, epochendframe - mbstartframe); // (< mbsize at end)
+        const size_t requestedframes = std::min(requestedmbframes, epochendframe - mbstartframe); // (< mbsize at end)
         assert(requestedframes > 0);
         source.getbatch(mbstartframe, requestedframes, subsetnum, numsubsets, mbframesadvanced, featbuf, uids, transcripts, lattices, sentendmark, phoneboundaries);
         timegetbatch = source.gettimegetbatch();
@@ -278,7 +278,7 @@ public:
     }
     std::pair<size_t, size_t> range() const
     {
-        return make_pair(epochstartframe, epochendframe);
+        return std::make_pair(epochstartframe, epochendframe);
     }
 
     // return the current minibatch frames as a matrix ref into the feature buffer
@@ -335,7 +335,7 @@ public:
     }
 
     // return a lattice for an utterance (caller should first get total through currentmblattices())
-    shared_ptr<const msra::dbn::latticepair> lattice(size_t uttindex) const
+    std::shared_ptr<const msra::dbn::latticepair> lattice(size_t uttindex) const
     {
         return lattices[uttindex];
     } // lattices making up the current

--- a/Source/Readers/HTKMLFReader/msra_mgram.h
+++ b/Source/Readers/HTKMLFReader/msra_mgram.h
@@ -92,7 +92,7 @@ static inline double invertlogprob(double logP)
 // compare function to allow char* as keys (without, unordered_map will correctly
 // compute a hash key from the actual strings, but then compare the pointers
 // -- duh!)
-struct less_strcmp : public binary_function<const char *, const char *, bool>
+struct less_strcmp : public std::binary_function<const char *, const char *, bool>
 { // this implements operator<
     bool operator()(const char *const &_Left, const char *const &_Right) const
     {
@@ -102,7 +102,7 @@ struct less_strcmp : public binary_function<const char *, const char *, bool>
 
 class CSymbolSet : public std::unordered_map<const char *, int, std::hash<const char *>, less_strcmp>
 {
-    vector<const char *> symbols; // the symbols
+    std::vector<const char *> symbols; // the symbols
 
     CSymbolSet(const CSymbolSet &);
     CSymbolSet &operator=(const CSymbolSet &);
@@ -149,7 +149,7 @@ public:
         {
             int id = (int) symbols.size();
             symbols.push_back(p); // we own the memory--remember to free it
-            insert(make_pair(p, id));
+            insert(std::make_pair(p, id));
             return id;
         }
         catch (...)
@@ -167,11 +167,11 @@ public:
     }
 
     // overloads to be compatible with C++ strings and CSymMap
-    int sym2existingId(const string &key) const
+    int sym2existingId(const std::string &key) const
     {
         return (*this)[key.c_str()];
     }
-    int sym2id(const string &key)
+    int sym2id(const std::string &key)
     {
         return (*this)[key.c_str()];
     }
@@ -475,14 +475,14 @@ public:
     // swap --used e.g. in merging
     void swap(mgram_map &other)
     {
-        ::swap(M, other.M);
+        std::swap(M, other.M);
         firsts.swap(other.firsts);
         ids.swap(other.ids);
-        ::swap(level1nonsparse, other.level1nonsparse);
+        std::swap(level1nonsparse, other.level1nonsparse);
         level1lookup.swap(other.level1lookup);
         w2id.swap(other.w2id);
         id2w.swap(other.id2w);
-        ::swap(idmax, other.idmax);
+        std::swap(idmax, other.idmax);
     }
 
     // --- id mapping
@@ -1022,7 +1022,7 @@ public:
         }
         // id mapping
         // user-provided w->id map
-        ::swap(w2id, userToLMSymMap);
+        std::swap(w2id, userToLMSymMap);
         // reverse map
         id2w.assign(maxid() + 1, nindex);
         foreach_index (w, w2id)
@@ -1268,7 +1268,7 @@ private:
     std::wstring filename; // input filename
     struct SYMBOL
     {
-        string symbol; // token
+        std::string symbol; // token
         int id;        // numeric id in LM space (index of word read)
         bool operator<(const SYMBOL &other) const
         {
@@ -1318,7 +1318,7 @@ private:
     {
         return p;
     }
-    static const char *const_char_ptr(const string &s)
+    static const char *const_char_ptr(const std::string &s)
     {
         return s.c_str();
     }
@@ -1599,7 +1599,7 @@ public:
 
             skipMGram:
                 // remember current mgram for next iteration
-                ::swap(mgram, prevmgram);
+                std::swap(mgram, prevmgram);
             }
 
             // fix the symbol set -- now we can binary-search in them with symbolToId()
@@ -1710,7 +1710,7 @@ public:
     {
         // deterine sort order
         // Note: This code copies all strings twice.
-        std::vector<pair<std::string, int>> sortTemp(userSymMap.size()); // (string, w)
+        std::vector<std::pair<std::string, int>> sortTemp(userSymMap.size()); // (string, w)
         foreach_index (w, sortTemp)
             sortTemp[w] = make_pair(userSymMap[w], w);
         std::sort(sortTemp.begin(), sortTemp.end());

--- a/Source/Readers/HTKMLFReader/rollingwindowsource.h
+++ b/Source/Readers/HTKMLFReader/rollingwindowsource.h
@@ -31,7 +31,7 @@ class biggrowablevectorarray : public growablevectorbase<msra::dbn::matrix>
     size_t inmembegin; // range we have in memory, rounded to enclosing blocks (not rounded at end)
     size_t inmemend;
 
-    wstring pagepath; // path for paging, empty if no paging
+    std::wstring pagepath; // path for paging, empty if no paging
     auto_file_ptr f;  // file handle for paging
     bool reading;     // have we begun reading?
 
@@ -63,7 +63,7 @@ class biggrowablevectorarray : public growablevectorbase<msra::dbn::matrix>
         if (!wantread)
         {
             FILE *ftry = NULL;
-            wstring pathname(pagepath);
+            std::wstring pathname(pagepath);
             ftry = _wfopen(pathname.c_str(), L"wbS");
             if (ftry)
                 fclose(ftry);
@@ -81,7 +81,7 @@ class biggrowablevectorarray : public growablevectorbase<msra::dbn::matrix>
                 char trynum = 'a';
                 while (!ftry && trynum <= 'z')
                 {
-                    wstring pathname (pagepath);
+                    std::wstring pathname (pagepath);
                     pathname += trynum++;
                     ftry = _wfopen (pathname.c_str(), L"wbS");
                 }
@@ -130,7 +130,7 @@ class biggrowablevectorarray : public growablevectorbase<msra::dbn::matrix>
     }
 
 public:
-    biggrowablevectorarray(const wstring &pagepath)
+    biggrowablevectorarray(const std::wstring &pagepath)
         : growablevectorbase(65536), m(0), inmembegin(0), inmemend(0), pagepath(pagepath), reading(false)
     {
         openpagefile(false);
@@ -192,13 +192,13 @@ public:
 
     // access phase
     // Returns 'true' if data was actually read from disk.
-    bool require(pair<size_t, size_t> bounds) // we require this range of frames
+    bool require(std::pair<size_t, size_t> bounds) // we require this range of frames
     {
         bool readfromdisk = false;
 
         // get bounds rounded to block boundaries
         const size_t ts = bounds.first / elementsperblock * elementsperblock;
-        const size_t te = min(n, (bounds.second + elementsperblock - 1) / elementsperblock * elementsperblock);
+        const size_t te = std::min(n, (bounds.second + elementsperblock - 1) / elementsperblock * elementsperblock);
         assert(paging());
         // free all the memmory
         for (size_t t = inmembegin; t < inmemend; t += elementsperblock)
@@ -232,7 +232,7 @@ public:
         /*const*/ msra::dbn::matrix &block = getblock(t);
         return msra::dbn::matrixstripe(block, blockt, 1);
     }
-    wstring pagepathname()
+    std::wstring pagepathname()
     {
         return pagepath;
     }
@@ -263,7 +263,7 @@ class minibatchframesource : public minibatchsource
 {
     size_t vdim;             // feature dimension after augmenting neighhors (0: don't read features)
     unsigned int sampperiod; // (for reference and to check against model)
-    string featkind;
+    std::string featkind;
     size_t featdim;
     // cache
     biggrowablevectorarray frames;                         // [t][i] all features concatenated
@@ -277,8 +277,8 @@ class minibatchframesource : public minibatchsource
 public:
     // constructor
     // Pass empty labels to denote unsupervised training (so getbatch() will not return uids).
-    minibatchframesource(const std::vector<wstring> &infiles, const map<wstring, std::vector<msra::asr::htkmlfentry>> &labels,
-                         size_t vdim, size_t udim, size_t randomizationrange, const wstring &pagepath, const bool mayhavenoframe = false, int addEnergy = 0)
+    minibatchframesource(const std::vector<std::wstring> &infiles, const std::map<std::wstring, std::vector<msra::asr::htkmlfentry>> &labels,
+                         size_t vdim, size_t udim, size_t randomizationrange, const std::wstring &pagepath, const bool mayhavenoframe = false, int addEnergy = 0)
         : vdim(vdim), sampperiod(0), featdim(0), numframes(0), frames(pagepath), timegetbatch(0), verbosity(2)
     {
         if (vdim == 0 && labels.empty())
@@ -308,11 +308,11 @@ public:
             msra::asr::htkfeatreader::parsedpath ppath(infiles[i]);
 
             // skip files for which labels don't exist (assuming bad alignment)
-            wstring key;
+            std::wstring key;
             if (!labels.empty()) // empty means unsupervised mode (don't load any)
             {
 #ifdef _WIN32
-                key = regex_replace((wstring) ppath, wregex(L"\\.[^\\.\\\\/:]*$"), wstring()); // delete extension (or not if none)
+                key = regex_replace((std::wstring) ppath, wregex(L"\\.[^\\.\\\\/:]*$"), std::wstring()); // delete extension (or not if none)
 #else
                 key = removeExtension(ppath);
 #endif
@@ -380,7 +380,7 @@ public:
                         if (e.classid != (CLASSIDTYPE) e.classid)
                             RuntimeError("CLASSIDTYPE has too few bits");
                         classids.push_back((CLASSIDTYPE) e.classid);
-                        numclasses = max(numclasses, (size_t)(1u + e.classid));
+                        numclasses = std::max(numclasses, (size_t)(1u + e.classid));
                     }
                 }
                 if (vdim == 0)
@@ -455,7 +455,7 @@ public:
     // This function is NOT thread-safe (due to caching of random sequence).
     bool getbatch(const size_t globalts, const size_t framesrequested, msra::dbn::matrix &feat, std::vector<size_t> &uids,
                   std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> &transcripts,
-                  std::vector<shared_ptr<const latticesource::latticepair>> &latticepairs)
+                  std::vector<std::shared_ptr<const latticesource::latticepair>> &latticepairs)
     {
         auto_timer timergetbatch;
 
@@ -465,7 +465,7 @@ public:
         assert(totalframes() > 0);
         const size_t sweep = globalts / totalframes();              // which sweep (this determines randomization)
         const size_t ts = globalts % totalframes();                 // start frame within the sweep
-        const size_t te = min(ts + framesrequested, totalframes()); // do not go beyond sweep boundary
+        const size_t te = std::min(ts + framesrequested, totalframes()); // do not go beyond sweep boundary
         assert(te > ts);
         if (verbosity >= 2)
             fprintf(stderr, "getbatch: frames [%d..%d] in sweep %d\n", (int) ts, (int) (te - 1), (int) sweep);
@@ -476,7 +476,7 @@ public:
 
         // page in the needed range of frames
         const size_t extent = augmentationextent(frames.dim(), vdim);
-        bool readfromdisk = frames.require(m_randomOrdering.Bounds(max(ts, extent) - extent, te + 1 + extent));
+        bool readfromdisk = frames.require(m_randomOrdering.Bounds(std::max(ts, extent) - extent, te + 1 + extent));
 
         // generate features and uids
         feat.resize(vdim, te - ts); // note: special mode vdim == 0 means no features to be loaded
@@ -501,7 +501,7 @@ public:
 
     bool getbatch(const size_t globalts, const size_t framesrequested, std::vector<msra::dbn::matrix> &feat, std::vector<std::vector<size_t>> &uids,
                   std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> &transcripts,
-                  std::vector<shared_ptr<const latticesource::latticepair>> &latticepairs, std::vector<std::vector<size_t>> &sentendmark,
+                  std::vector<std::shared_ptr<const latticesource::latticepair>> &latticepairs, std::vector<std::vector<size_t>> &sentendmark,
                   std::vector<std::vector<size_t>> &phoneboundaries)
     {
         // for single input/output set size to be 1 and run old getbatch
@@ -545,12 +545,12 @@ class minibatchframesourcemulti : public minibatchsource
     std::vector<size_t> leftcontext;  // number of frames to the left of the target frame in the context window
     std::vector<size_t> rightcontext; // number of frames to the right of the target frame in the context window
     unsigned int sampperiod;          // (for reference and to check against model)
-    string featkind;
+    std::string featkind;
     size_t featdim;
     size_t maxvdim;
     // cache
     // std::vector<biggrowablevectorarray> frames;
-    std::vector<unique_ptr<biggrowablevectorarray>> pframes; // [t][i] all features concatenated
+    std::vector<std::unique_ptr<biggrowablevectorarray>> pframes; // [t][i] all features concatenated
     std::vector<char> boundaryflags;                         // [t] -1 for first and +1 for last frame, 0 else (for augmentneighbors())
     std::vector<std::vector<CLASSIDTYPE>> classids;          // [t] the state that the frame belongs to
     size_t numframes;                                        // total frames (==frames.size()==boundaryflags.size()==classids.size()) unless special modes vdim == 0 and/or no labels
@@ -561,8 +561,8 @@ class minibatchframesourcemulti : public minibatchsource
 public:
     // constructor
     // Pass empty labels to denote unsupervised training (so getbatch() will not return uids).
-    minibatchframesourcemulti(const std::vector<std::vector<wstring>> &infiles, const std::vector<map<std::wstring, std::vector<msra::asr::htkmlfentry>>> &labels,
-                              std::vector<size_t> vdim, std::vector<size_t> udim, std::vector<size_t> leftcontext, std::vector<size_t> rightcontext, size_t randomizationrange, const std::vector<wstring> &pagepath, const bool mayhavenoframe = false, int addEnergy = 0)
+    minibatchframesourcemulti(const std::vector<std::vector<std::wstring>> &infiles, const std::vector<std::map<std::wstring, std::vector<msra::asr::htkmlfentry>>> &labels,
+                              std::vector<size_t> vdim, std::vector<size_t> udim, std::vector<size_t> leftcontext, std::vector<size_t> rightcontext, size_t randomizationrange, const std::vector<std::wstring> &pagepath, const bool mayhavenoframe = false, int addEnergy = 0)
         : vdim(vdim), leftcontext(leftcontext), rightcontext(rightcontext), sampperiod(0), featdim(0), numframes(0), timegetbatch(0), verbosity(2), maxvdim(0)
     {
 
@@ -589,7 +589,7 @@ public:
 
         foreach_index (i, infiles)
         {
-            pframes.push_back(unique_ptr<biggrowablevectorarray>(new biggrowablevectorarray(pagepath[i])));
+            pframes.push_back(std::unique_ptr<biggrowablevectorarray>(new biggrowablevectorarray(pagepath[i])));
 
             if (vdim[i] > maxvdim)
                 maxvdim = vdim[i];
@@ -623,13 +623,13 @@ public:
                 msra::asr::htkfeatreader::parsedpath ppath(infiles[m][i]);
 
                 // skip files for which labels don't exist (assuming bad alignment)
-                wstring key;
+                std::wstring key;
                 if (!labels.empty())
                 {
                     if (!labels[0].empty()) // empty means unsupervised mode (don't load any)
                     {
 #ifdef _WIN32
-                        key = regex_replace((wstring) ppath, wregex(L"\\.[^\\.\\\\/:]*$"), wstring()); // delete extension (or not if none)
+                        key = regex_replace((std::wstring) ppath, wregex(L"\\.[^\\.\\\\/:]*$"), std::wstring()); // delete extension (or not if none)
 #else
                         key = removeExtension(ppath);
 #endif
@@ -708,7 +708,7 @@ public:
                                     if (e.classid != (CLASSIDTYPE) e.classid)
                                         RuntimeError("CLASSIDTYPE has too few bits");
                                     classids[j].push_back((CLASSIDTYPE) e.classid);
-                                    numclasses[j] = max(numclasses[j], (size_t)(1u + e.classid));
+                                    numclasses[j] = std::max(numclasses[j], (size_t)(1u + e.classid));
                                 }
                             }
                             if (vdim[m] == 0)
@@ -794,7 +794,7 @@ public:
     // This function is NOT thread-safe (due to caching of random sequence).
     bool getbatch(const size_t globalts, const size_t framesrequested, std::vector<msra::dbn::matrix> &feat, std::vector<std::vector<size_t>> &uids,
                   std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> &transcripts,
-                  std::vector<shared_ptr<const latticesource::latticepair>> &latticepairs, std::vector<std::vector<size_t>> &sentendmark,
+                  std::vector<std::shared_ptr<const latticesource::latticepair>> &latticepairs, std::vector<std::vector<size_t>> &sentendmark,
                   std::vector<std::vector<size_t>> &phoneboundaries)
     {
 
@@ -807,7 +807,7 @@ public:
         assert(totalframes() > 0);
         const size_t sweep = globalts / totalframes();              // which sweep (this determines randomization)
         const size_t ts = globalts % totalframes();                 // start frame within the sweep
-        const size_t te = min(ts + framesrequested, totalframes()); // do not go beyond sweep boundary
+        const size_t te = std::min(ts + framesrequested, totalframes()); // do not go beyond sweep boundary
         assert(te > ts);
         if (verbosity >= 2)
             fprintf(stderr, "getbatch: frames [%d..%d] in sweep %d\n", (int) ts, (int) (te - 1), (int) sweep);
@@ -833,7 +833,7 @@ public:
                 leftextent = leftcontext[i];
                 rightextent = rightcontext[i];
             }
-            readfromdisk = pframes[i]->require(m_randomOrdering.Bounds(max(ts, leftextent) - leftextent, te + 1 + rightextent));
+            readfromdisk = pframes[i]->require(m_randomOrdering.Bounds(std::max(ts, leftextent) - leftextent, te + 1 + rightextent));
             // generate features and uids
             feat[i].resize(vdim[i], te - ts); // note: special mode vdim == 0 means no features to be loaded
             if (issupervised())               // empty means unsupervised training -> return empty uids
@@ -869,7 +869,7 @@ public:
 
     bool getbatch(const size_t /*globalts*/, const size_t /*framesrequested*/, msra::dbn::matrix & /*feat*/, std::vector<size_t> & /*uids*/,
                   std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> & /*transcripts*/,
-                  std::vector<shared_ptr<const latticesource::latticepair>> & /*latticepairs*/)
+                  std::vector<std::shared_ptr<const latticesource::latticepair>> & /*latticepairs*/)
     {
         // should never get here
         RuntimeError("minibatchframesourcemulti: getbatch() being called for single input feature and single output feature, should use minibatchframesource instead\n");

--- a/Source/Readers/HTKMLFReader/utterancesourcemulti.h
+++ b/Source/Readers/HTKMLFReader/utterancesourcemulti.h
@@ -29,14 +29,14 @@ class minibatchutterancesourcemulti : public minibatchsource
     std::vector<size_t> leftcontext;                            // number of frames to the left of the target frame in the context window
     std::vector<size_t> rightcontext;                           // number of frames to the right of the target frame in the context window
     std::vector<unsigned int> sampperiod;                       // (for reference and to check against model)
-    std::vector<string> featkind;
+    std::vector<std::string> featkind;
     std::vector<size_t> featdim;
     std::vector<bool> expandToUtt;           // indicator of whether features should be applied to entire utterance, e.g. ivectors
     const bool framemode;                    // true -> actually return frame-level randomized frames (not possible in lattice mode)
     std::vector<std::vector<size_t>> counts; // [s] occurence count for all states (used for priors)
     int verbosity;
     // lattice reader
-    // const std::vector<unique_ptr<latticesource>> &lattices;
+    // const std::vector<std::unique_ptr<latticesource>> &lattices;
     const latticesource &lattices;
 
     // Flag indicating whether to use Mersenne Twister random generator.
@@ -45,8 +45,8 @@ class minibatchutterancesourcemulti : public minibatchsource
 
     // std::vector<latticesource> lattices;
     // word-level transcripts (for MMI mode when adding best path to lattices)
-    const map<wstring, msra::lattices::lattice::htkmlfwordsequence> &allwordtranscripts; // (used for getting word-level transcripts)
-                                                                                         // std::vector<map<wstring,msra::lattices::lattice::htkmlfwordsequence>> allwordtranscripts;
+    const std::map<std::wstring, msra::lattices::lattice::htkmlfwordsequence> &allwordtranscripts; // (used for getting word-level transcripts)
+                                                                                         // std::vector<std::map<std::wstring,msra::lattices::lattice::htkmlfwordsequence>> allwordtranscripts;
     // data store (incl. paging in/out of features and lattices)
     struct utterancedesc // data descriptor for one utterance
     {
@@ -59,7 +59,7 @@ class minibatchutterancesourcemulti : public minibatchsource
         }
         bool needsExpansion; // ivector type of feature
         size_t framesToExpand; // expected number of frames (to expand ivectors) 
-        wstring logicalpath() const
+        std::wstring logicalpath() const
         {
             return parsedpath; /*type cast will return logical path*/
         }
@@ -70,10 +70,10 @@ class minibatchutterancesourcemulti : public minibatchsource
             else
                 return parsedpath.numframes();
         }
-        wstring key() const // key used for looking up lattice (not stored to save space)
+        std::wstring key() const // key used for looking up lattice (not stored to save space)
         {
 #ifdef _MSC_VER
-            static const wstring emptywstring;
+            static const std::wstring emptywstring;
             static const wregex deleteextensionre(L"\\.[^\\.\\\\/:]*$");
             return regex_replace(logicalpath(), deleteextensionre, emptywstring); // delete extension (or not if none)
 #else
@@ -101,7 +101,7 @@ class minibatchutterancesourcemulti : public minibatchsource
         std::vector<size_t> firstframes;                                            // [utteranceindex] first frame for given utterance
         mutable msra::dbn::matrix frames;                                           // stores all frames consecutively (mutable since this is a cache)
         size_t totalframes;                                                         // total #frames for all utterances in this chunk
-        mutable std::vector<shared_ptr<const latticesource::latticepair>> lattices; // (may be empty if none)
+        mutable std::vector<std::shared_ptr<const latticesource::latticepair>> lattices; // (may be empty if none)
 
         // construction
         utterancechunkdata()
@@ -134,7 +134,7 @@ class minibatchutterancesourcemulti : public minibatchsource
             const size_t n = numframes(i);
             return msra::dbn::matrixstripe(frames, ts, n);
         }
-        shared_ptr<const latticesource::latticepair> getutterancelattice(size_t i) const // return the frame set for a given utterance
+        std::shared_ptr<const latticesource::latticepair> getutterancelattice(size_t i) const // return the frame set for a given utterance
         {
             if (!isinram())
                 LogicError("getutteranceframes: called when data have not been paged in");
@@ -149,7 +149,7 @@ class minibatchutterancesourcemulti : public minibatchsource
         }
         // page in data for this chunk
         // We pass in the feature info variables by ref which will be filled lazily upon first read
-        void requiredata(string &featkind, size_t &featdim, unsigned int &sampperiod, const latticesource &latticesource, int verbosity = 0) const
+        void requiredata(std::string &featkind, size_t &featdim, unsigned int &sampperiod, const latticesource &latticesource, int verbosity = 0) const
         {
             if (numutterances() == 0)
                 LogicError("requiredata: cannot page in virgin block");
@@ -176,7 +176,7 @@ class minibatchutterancesourcemulti : public minibatchsource
                     // fprintf (stderr, ".");
                     // read features for this file
                     auto uttframes = getutteranceframes(i);                                                    // matrix stripe for this utterance (currently unfilled)
-                    reader.read(utteranceset[i].parsedpath, (const string &)featkind, sampperiod, uttframes, utteranceset[i].needsExpansion);  // note: file info here used for checkuing only
+                    reader.read(utteranceset[i].parsedpath, (const std::string &)featkind, sampperiod, uttframes, utteranceset[i].needsExpansion);  // note: file info here used for checkuing only
                     // page in lattice data
                     if (!latticesource.empty())
                         latticesource.getlattices(utteranceset[i].key(), lattices[i], uttframes.cols());
@@ -229,10 +229,10 @@ class minibatchutterancesourcemulti : public minibatchsource
         }
     };
     std::vector<std::vector<utterancechunkdata>> allchunks;           // set of utterances organized in chunks, referred to by an iterator (not an index)
-    std::vector<unique_ptr<biggrowablevector<CLASSIDTYPE>>> classids; // [classidsbegin+t] concatenation of all state sequences
+    std::vector<std::unique_ptr<biggrowablevector<CLASSIDTYPE>>> classids; // [classidsbegin+t] concatenation of all state sequences
 
     bool m_generatePhoneBoundaries;
-    std::vector<unique_ptr<biggrowablevector<HMMIDTYPE>>> phoneboundaries;
+    std::vector<std::unique_ptr<biggrowablevector<HMMIDTYPE>>> phoneboundaries;
     bool issupervised() const
     {
         return !classids.empty();
@@ -307,8 +307,8 @@ class minibatchutterancesourcemulti : public minibatchsource
         }
         void swap(utteranceref &other) // used in randomization
         {
-            ::swap(chunkindex, other.chunkindex);
-            ::swap(m_utteranceindex, other.m_utteranceindex);
+            std::swap(chunkindex, other.chunkindex);
+            std::swap(m_utteranceindex, other.m_utteranceindex);
             assert(globalts == SIZE_MAX && other.globalts == SIZE_MAX && numframes == 0 && other.numframes == 0); // can only swap before assigning these
         }
     };
@@ -525,13 +525,13 @@ class minibatchutterancesourcemulti : public minibatchsource
                     if (sourcechunkindex < targetwindowbegin || sourcechunkindex >= targetwindowend)
                         continue;
                     // admissible--swap the two
-                    ::swap(randomizedframeref(t), randomizedframeref(tswap));
+                    std::swap(randomizedframeref(t), randomizedframeref(tswap));
 
                     // do a post-check if we got it right  --we seem not to
                     if (isframepositionvalid(t) && isframepositionvalid(tswap))
                         break;
                     // not valid: swap them back and try again  --we actually discovered a bug in the code above
-                    ::swap(randomizedframeref(t), randomizedframeref(tswap));
+                    std::swap(randomizedframeref(t), randomizedframeref(tswap));
                     fprintf(stderr, "randomizeFrameRange: BUGBUG --invalid swapping condition detected\n");
                 }
             }
@@ -634,12 +634,12 @@ class minibatchutterancesourcemulti : public minibatchsource
                         if (sourcechunkindex < targetwindowbegin || sourcechunkindex >= targetwindowend)
                             continue;
                         // admissible--swap the two
-                        ::swap(m_randomizedframerefs[t], m_randomizedframerefs[tswap]);
+                        std::swap(m_randomizedframerefs[t], m_randomizedframerefs[tswap]);
                         // do a post-check if we got it right  --we seem not to
                         if (isframepositionvalid(t, ttochunk) && isframepositionvalid(tswap, ttochunk))
                             break;
                         // not valid: swap them back and try again  --we actually discovered a bug in the code above
-                        ::swap(m_randomizedframerefs[t], m_randomizedframerefs[tswap]);
+                        std::swap(m_randomizedframerefs[t], m_randomizedframerefs[tswap]);
                         fprintf(stderr, "lazyrandomization: BUGBUG --invalid swapping condition detected\n");
                     }
                 }
@@ -879,9 +879,9 @@ public:
     // constructor
     // Pass empty labels to denote unsupervised training (so getbatch() will not return uids).
     // This mode requires utterances with time stamps.
-    minibatchutterancesourcemulti(bool useMersenneTwister, const std::vector<std::vector<wstring>> &infiles, const std::vector<map<wstring, std::vector<msra::asr::htkmlfentry>>> &labels,
+    minibatchutterancesourcemulti(bool useMersenneTwister, const std::vector<std::vector<std::wstring>> &infiles, const std::vector<std::map<std::wstring, std::vector<msra::asr::htkmlfentry>>> &labels,
                                   std::vector<size_t> vdim, std::vector<size_t> udim, std::vector<size_t> leftcontext, std::vector<size_t> rightcontext, size_t randomizationrange,
-                                  const latticesource &lattices, const map<wstring, msra::lattices::lattice::htkmlfwordsequence> &allwordtranscripts, const bool framemode, std::vector<bool> expandToUtt)
+                                  const latticesource &lattices, const std::map<std::wstring, msra::lattices::lattice::htkmlfwordsequence> &allwordtranscripts, const bool framemode, std::vector<bool> expandToUtt)
                                   : vdim(vdim), leftcontext(leftcontext), rightcontext(rightcontext), sampperiod(0), featdim(0), randomizationrange(randomizationrange), currentsweep(SIZE_MAX), lattices(lattices), allwordtranscripts(allwordtranscripts), framemode(framemode), chunksinram(0), timegetbatch(0), verbosity(2), m_generatePhoneBoundaries(!lattices.empty()), m_frameRandomizer(randomizedchunks, useMersenneTwister), expandToUtt(expandToUtt),
                                     m_useMersenneTwister(useMersenneTwister)
     // [v-hansu] change framemode (lattices.empty()) into framemode (false) to run utterance mode without lattice
@@ -892,7 +892,7 @@ public:
         size_t nolat = 0;               // number of entries missing in lattice archive (diagnostics)
         std::vector<size_t> numclasses; // number of output classes as found in the label file (diagnostics)
         _totalframes = 0;
-        wstring key;
+        std::wstring key;
         size_t numutts = 0;
 
         std::vector<bool> uttisvalid;    // boolean flag to check that utterance is valid. valid means number of
@@ -904,20 +904,20 @@ public:
         allchunks = std::vector<std::vector<utterancechunkdata>>(infiles.size(), std::vector<utterancechunkdata>());
         featdim = std::vector<size_t>(infiles.size(), 0);
         sampperiod = std::vector<unsigned int>(infiles.size(), 0);
-        featkind = std::vector<string>(infiles.size(), "");
+        featkind = std::vector<std::string>(infiles.size(), "");
 
         numclasses = std::vector<size_t>(labels.size(), 0);
         counts = std::vector<std::vector<size_t>>(labels.size(), std::vector<size_t>());
 
         foreach_index (i, labels)
         {
-            classids.push_back(unique_ptr<biggrowablevector<CLASSIDTYPE>>(new biggrowablevector<CLASSIDTYPE>()));
+            classids.push_back(std::unique_ptr<biggrowablevector<CLASSIDTYPE>>(new biggrowablevector<CLASSIDTYPE>()));
             if (m_generatePhoneBoundaries)
-                phoneboundaries.push_back(unique_ptr<biggrowablevector<HMMIDTYPE>>(new biggrowablevector<HMMIDTYPE>()));
+                phoneboundaries.push_back(std::unique_ptr<biggrowablevector<HMMIDTYPE>>(new biggrowablevector<HMMIDTYPE>()));
 
-            // std::pair<std::vector<wstring>,std::vector<wstring>> latticetocs;
+            // std::pair<std::vector<std::wstring>,std::vector<std::wstring>> latticetocs;
             // std::unordered_map<std::string,size_t> modelsymmap;
-            // lattices.push_back(shared_ptr<latticesource>(new latticesource(latticetocs, modelsymmap)));
+            // lattices.push_back(std::shared_ptr<latticesource>(new latticesource(latticetocs, modelsymmap)));
         }
 
         // first check consistency across feature streams
@@ -1112,7 +1112,7 @@ public:
                                                     phoneboundaries[j]->push_back((HMMIDTYPE)0);
                                             }
                                         }
-                                        numclasses[j] = max(numclasses[j], (size_t)(1u + e.classid));
+                                        numclasses[j] = std::max(numclasses[j], (size_t)(1u + e.classid));
                                         counts[j].resize(numclasses[j], 0);
                                         counts[j][e.classid] += e.numframes;
                                     }
@@ -1223,7 +1223,7 @@ private:
             // swap element i with it
             if (irand == (size_t) i)
                 continue;
-            ::swap(v[i], v[irand]);
+            std::swap(v[i], v[irand]);
         }
     }
     static void checkoverflow(size_t fieldval, size_t targetval, const char *fieldname)
@@ -1568,7 +1568,7 @@ public:
                   const size_t subsetnum, const size_t numsubsets, size_t &framesadvanced,
                   std::vector<msra::dbn::matrix> &feat, std::vector<std::vector<size_t>> &uids,
                   std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> &transcripts,
-                  std::vector<shared_ptr<const latticesource::latticepair>> &latticepairs, std::vector<std::vector<size_t>> &sentendmark,
+                  std::vector<std::shared_ptr<const latticesource::latticepair>> &latticepairs, std::vector<std::vector<size_t>> &sentendmark,
                   std::vector<std::vector<size_t>> &phoneboundaries) override
     {
         bool readfromdisk = false; // return value: shall be 'true' if we paged in anything
@@ -1748,7 +1748,7 @@ public:
         {
             const size_t sweepts = sweep * _totalframes;                      // first global frame index for this sweep
             const size_t sweepte = sweepts + _totalframes;                    // and its end
-            const size_t globalte = min(globalts + framesrequested, sweepte); // we return as much as requested, but not exceeding sweep end
+            const size_t globalte = std::min(globalts + framesrequested, sweepte); // we return as much as requested, but not exceeding sweep end
             mbframes = globalte - globalts;                                   // that's our mb size
 
             // Perform randomization of the desired frame range
@@ -1782,7 +1782,7 @@ public:
                 subsetsizes[frameref.chunkindex % numsubsets]++;
             }
             size_t j = subsetsizes[subsetnum];                                           // return what we have  --TODO: we can remove the above full computation again now
-            const size_t allocframes = max(j, (mbframes + numsubsets - 1) / numsubsets); // we leave space for the desired #frames, assuming caller will try to pad them later
+            const size_t allocframes = std::max(j, (mbframes + numsubsets - 1) / numsubsets); // we leave space for the desired #frames, assuming caller will try to pad them later
 
             // resize feat and uids
             feat.resize(vdim.size());
@@ -1878,7 +1878,7 @@ public:
     bool getbatch(const size_t globalts,
                   const size_t framesrequested, std::vector<msra::dbn::matrix> &feat, std::vector<std::vector<size_t>> &uids,
                   std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> &transcripts,
-                  std::vector<shared_ptr<const latticesource::latticepair>> &lattices, std::vector<std::vector<size_t>> &sentendmark,
+                  std::vector<std::shared_ptr<const latticesource::latticepair>> &lattices, std::vector<std::vector<size_t>> &sentendmark,
                   std::vector<std::vector<size_t>> &phoneboundaries)
     {
         size_t dummy;
@@ -1894,7 +1894,7 @@ public:
     bool getbatch(const size_t /*globalts*/,
                   const size_t /*framesrequested*/, msra::dbn::matrix & /*feat*/, std::vector<size_t> & /*uids*/,
                   std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> & /*transcripts*/,
-                  std::vector<shared_ptr<const latticesource::latticepair>> & /*latticepairs*/)
+                  std::vector<std::shared_ptr<const latticesource::latticepair>> & /*latticepairs*/)
     {
         // should never get here
         RuntimeError("minibatchframesourcemulti: getbatch() being called for single input feature and single output feature, should use minibatchutterancesource instead\n");

--- a/Source/Readers/Kaldi2Reader/chunkevalsource.h
+++ b/Source/Readers/Kaldi2Reader/chunkevalsource.h
@@ -54,7 +54,7 @@ private:
         size_t firstframe = 0;
         foreach_index (k, numframes)
         {
-            const wstring &outfile = outpaths[k];
+            const std::wstring &outfile = outpaths[k];
             unsigned int sampperiod = sampperiods[k];
             size_t n = numframes[k];
             msra::files::make_intermediate_dirs(outfile);
@@ -183,7 +183,7 @@ private:
         size_t firstframe = 0;
         foreach_index (k, numframes)
         {
-            const wstring &outfile = outpaths[index][k];
+            const std::wstring &outfile = outpaths[index][k];
             unsigned int sampperiod = sampperiods[index][k];
             size_t n = numframes[k];
             msra::files::make_intermediate_dirs(outfile);

--- a/Source/Readers/Kaldi2Reader/htkfeatio.h
+++ b/Source/Readers/Kaldi2Reader/htkfeatio.h
@@ -29,9 +29,9 @@ namespace msra { namespace asr {
 class FeatureSection
 {
 public:
-    wstring scpFile;
-    string rx;
-    string feature_transform;
+    std::wstring scpFile;
+    std::string rx;
+    std::string feature_transform;
 
 private:
     kaldi::RandomAccessBaseFloatMatrixReader *feature_reader;
@@ -40,7 +40,7 @@ private:
     kaldi::Matrix<kaldi::BaseFloat> buf;
 
 public:
-    FeatureSection(wstring scpFile, wstring rx_file, wstring feature_transform)
+    FeatureSection(std::wstring scpFile, std::wstring rx_file, std::wstring feature_transform)
     {
         this->scpFile = scpFile;
         this->rx = trimmed(fileToStr(toStr(rx_file)));
@@ -61,9 +61,9 @@ public:
         }
     }
 
-    kaldi::Matrix<kaldi::BaseFloat> &read(wstring wkey)
+    kaldi::Matrix<kaldi::BaseFloat> &read(std::wstring wkey)
     {
-        string key = toStr(wkey);
+        std::string key = toStr(wkey);
 
         if (!feature_reader->HasKey(key))
         {
@@ -151,7 +151,7 @@ class htkfeatwriter : protected htkfeatio
 {
 public:
     // open the file for writing
-    htkfeatwriter(wstring path, string kind, size_t dim, unsigned int period)
+    htkfeatwriter(std::wstring path, std::string kind, size_t dim, unsigned int period)
     {
     }
 
@@ -159,7 +159,7 @@ public:
     // Matrix type needs to have operator(i,j) and resize(n,m).
     // We write to a tmp file first to ensure we don't leave broken files that would confuse make mode.
     template <class MATRIX>
-    static void write(const wstring &path, const string &kindstr, unsigned int period, const MATRIX &feat)
+    static void write(const std::wstring &path, const std::string &kindstr, unsigned int period, const MATRIX &feat)
     {
         // std::wcout << __FILE__ << ":" << __FUNCTION__ << " not implemented" << std::endl;
         exit(1);
@@ -186,14 +186,14 @@ public:
         }
     }
     template <class MATRIX>
-    static void writeKaldi(const wstring &path, const string &kindstr, unsigned int period, const MATRIX &feat, const int precision)
+    static void writeKaldi(const std::wstring &path, const std::string &kindstr, unsigned int period, const MATRIX &feat, const int precision)
     {
         std::string path_utf8 = msra::strfun::utf8(path);
         std::ofstream os(path_utf8.c_str());
 
         if (!os.good())
         {
-            throw runtime_error("parsedpath: this mode requires an input script with start and end frames given");
+            throw std::runtime_error("parsedpath: this mode requires an input script with start and end frames given");
         }
         size_t featdim = feat.rows();
         size_t numframes = feat.cols();
@@ -210,7 +210,7 @@ public:
             WriteBasicType(os, binary, rows);
             WriteBasicType(os, binary, cols);
         }
-        vector<float> v(featdim);
+        std::vector<float> v(featdim);
         for (size_t i = 0; i < numframes; i++)
         {
             foreach_index (k, v)
@@ -228,10 +228,10 @@ public:
         {
         }
 
-        /* wstring tmppath = path + L"$$"; // tmp path for make-mode compliant
+        /* std::wstring tmppath = path + L"$$"; // tmp path for make-mode compliant
         unlinkOrDie (path);             // delete if old file is already there
         // write it out
-        vector<float> v (featdim);
+        std::vector<float> v (featdim);
         htkfeatwriter W (tmppath, kindstr, feat.rows(), period);
         for (size_t i = 0; i < numframes; i++)
         {
@@ -271,8 +271,8 @@ public:
         FeatureSection *featuresection;
 
     private:
-        wstring xpath;       // original full path specification as passed to constructor (for error messages)
-        wstring logicalpath; // sequence ID
+        std::wstring xpath;       // original full path specification as passed to constructor (for error messages)
+        std::wstring logicalpath; // sequence ID
         size_t num_frames;
 
         void malformed() const
@@ -281,9 +281,9 @@ public:
         }
 
         // consume and return up to 'delim'; remove from 'input' (we try to avoid C++0x here for VS 2008 compat)
-        wstring consume(wstring &input, const wchar_t *delim)
+        std::wstring consume(std::wstring &input, const wchar_t *delim)
         {
-            vector<wstring> parts = msra::strfun::split(input, delim); // (not very efficient, but does not matter here)
+            std::vector<std::wstring> parts = msra::strfun::split(input, delim); // (not very efficient, but does not matter here)
             if (parts.size() == 1)
                 input.clear(); // not found: consume to end
             else
@@ -294,7 +294,7 @@ public:
     public:
         // constructor parses a=b[s,e] syntax and fills in the file
         // Can be used implicitly e.g. by passing a string to open().
-        parsedpath(wstring xpath, FeatureSection *featuresection)
+        parsedpath(std::wstring xpath, FeatureSection *featuresection)
             : xpath(xpath), featuresection(featuresection)
         {
             logicalpath = consume(xpath, L" ");
@@ -305,7 +305,7 @@ public:
         }
 
         // casting to wstring yields the logical path
-        operator const wstring &() const
+        operator const std::wstring &() const
         {
             return logicalpath;
         }
@@ -324,7 +324,7 @@ public:
 
     // helper to create a parsed-path object
     // const auto path = parse (xpath)
-    parsedpath parse(const wstring &xpath, FeatureSection *featuresection)
+    parsedpath parse(const std::wstring &xpath, FeatureSection *featuresection)
     {
         return parsedpath(xpath, featuresection);
     }
@@ -338,7 +338,7 @@ public:
     // read an entire utterance into an already allocated matrix
     // Matrix type needs to have operator(i,j)
     template <class MATRIX>
-    void readNoAlloc(const parsedpath &ppath, const string &kindstr, const unsigned int period, MATRIX &feat)
+    void readNoAlloc(const parsedpath &ppath, const std::string &kindstr, const unsigned int period, MATRIX &feat)
     {
         // open the file and check dimensions
         size_t numframes = ppath.numframes();
@@ -356,7 +356,7 @@ public:
             copyKaldiToCntk(kaldifeat, feat);
 
 #if 0
-            std::wcout << (wstring)ppath << std::endl;
+            std::wcout << (std::wstring)ppath << std::endl;
             for (int c=0; c<10; c++) {
                 for (int r=0; r<10; r++) {
                     std::wcout << feat(r, c) << " ";
@@ -375,7 +375,7 @@ public:
     // read an entire utterance into a virgen, allocatable matrix
     // Matrix type needs to have operator(i,j) and resize(n,m)
     template <class MATRIX>
-    void readAlloc(const parsedpath &ppath, string &kindstr, unsigned int &period, MATRIX &feat)
+    void readAlloc(const parsedpath &ppath, std::string &kindstr, unsigned int &period, MATRIX &feat)
     {
         // get the file
         size_t numframes = ppath.numframes();
@@ -420,24 +420,24 @@ public:
 };
 
 template <class ENTRY, class WORDSEQUENCE>
-class htkmlfreader : public map<wstring, vector<ENTRY>> // [key][i] the data
+class htkmlfreader : public std::map<std::wstring, std::vector<ENTRY>> // [key][i] the data
 {
-    wstring curpath;                                      // for error messages
+    std::wstring curpath;                                      // for error messages
     std::unordered_map<std::string, size_t> statelistmap; // for state <=> index
 
-    void strtok(char *s, const char *delim, vector<char *> &toks)
+    void strtok(char *s, const char *delim, std::vector<char *> &toks)
     {
         toks.resize(0);
         char *context = nullptr;
         for (char *p = strtok_s(s, delim, &context); p; p = strtok_s(NULL, delim, &context))
             toks.push_back(p);
     }
-    void malformed(string what)
+    void malformed(std::string what)
     {
         throw std::runtime_error(msra::strfun::strprintf("htkmlfreader: %s in '%S'", what.c_str(), curpath.c_str()));
     }
 
-    vector<char *> readlines(const wstring &path, vector<char> &buffer)
+    std::vector<char *> readlines(const std::wstring &path, std::vector<char> &buffer)
     {
         // load it into RAM in one huge chunk
         auto_file_ptr f(fopenOrDie(path, L"rb"));
@@ -447,7 +447,7 @@ class htkmlfreader : public map<wstring, vector<ENTRY>> // [key][i] the data
         buffer.push_back(0); // this makes it a proper C string
 
         // parse into lines
-        vector<char *> lines;
+        std::vector<char *> lines;
         lines.reserve(len / 20);
         strtok(&buffer[0], "\r\n", lines);
         return lines;
@@ -455,12 +455,12 @@ class htkmlfreader : public map<wstring, vector<ENTRY>> // [key][i] the data
 
 public:
     // return if input statename is sil state (hard code to compared first 3 chars with "sil")
-    bool issilstate(const string &statename) const // (later use some configuration table)
+    bool issilstate(const std::string &statename) const // (later use some configuration table)
     {
         return (statename.size() > 3 && statename.at(0) == 's' && statename.at(1) == 'i' && statename.at(2) == 'l');
     }
 
-    vector<bool> issilstatetable; // [state index] => true if is sil state (cached)
+    std::vector<bool> issilstatetable; // [state index] => true if is sil state (cached)
 
     // return if input stateid represent sil state (by table lookup)
     bool issilstate(const size_t id) const
@@ -470,7 +470,7 @@ public:
     }
 
     // constructor reads multiple MLF files
-    htkmlfreader(const vector<wstring> &paths, const set<wstring> &restricttokeys, const wstring &stateListPath = L"", const double htkTimeToFrame = 100000.0, int targets_delay = 0)
+    htkmlfreader(const std::vector<std::wstring> &paths, const std::set<std::wstring> &restricttokeys, const std::wstring &stateListPath = L"", const double htkTimeToFrame = 100000.0, int targets_delay = 0)
     {
         // read state list
         if (stateListPath != L"")
@@ -482,7 +482,7 @@ public:
     }
 
     // note: this function is not designed to be pretty but to be fast
-    void read(const wstring &path, const set<wstring> &restricttokeys, const double htkTimeToFrame, int targets_delay)
+    void read(const std::wstring &path, const std::set<std::wstring> &restricttokeys, const double htkTimeToFrame, int targets_delay)
     {
         fprintf(stderr, "htkmlfreader: reading MLF file %S ...", path.c_str());
         curpath = path; // for error messages only
@@ -497,7 +497,7 @@ public:
             std::wstring key = toWStr(targets_reader.Key());
             const kaldi::Posterior p = targets_reader.Value();
 
-            vector<ENTRY> &entries = (*this)[key];
+            std::vector<ENTRY> &entries = (*this)[key];
             if (!entries.empty())
                 malformed(msra::strfun::strprintf("duplicate entry '%S'", key.c_str()));
 
@@ -551,12 +551,12 @@ public:
     }
 
     // read state list, index is from 0
-    void readstatelist(const wstring &stateListPath = L"")
+    void readstatelist(const std::wstring &stateListPath = L"")
     {
         if (stateListPath != L"")
         {
-            vector<char> buffer; // buffer owns the characters--don't release until done
-            vector<char *> lines = readlines(stateListPath, buffer);
+            std::vector<char> buffer; // buffer owns the characters--don't release until done
+            std::vector<char *> lines = readlines(stateListPath, buffer);
             size_t index;
             issilstatetable.reserve(lines.size());
             for (index = 0; index < lines.size(); index++)
@@ -578,7 +578,7 @@ public:
         return statelistmap.size();
     }
 
-    size_t getstateid(string statename) // added by Hang Su adaptation
+    size_t getstateid(std::string statename) // added by Hang Su adaptation
     {
         return statelistmap[statename];
     }

--- a/Source/Readers/Kaldi2Reader/htkfeatio_utils.h
+++ b/Source/Readers/Kaldi2Reader/htkfeatio_utils.h
@@ -26,14 +26,14 @@ inline std::string fileToStr(std::string fname)
 inline std::string trimmed(std::string str)
 {
     auto found = str.find_first_not_of(" \t\n");
-    if (found == string::npos)
+    if (found == std::string::npos)
     {
         str.erase(0);
         return str;
     }
     str.erase(0, found);
     found = str.find_last_not_of(" \t\n");
-    if (found != string::npos)
+    if (found != std::string::npos)
         str.erase(found + 1);
 
     return str;

--- a/Source/Readers/Kaldi2Reader/minibatchiterator.h
+++ b/Source/Readers/Kaldi2Reader/minibatchiterator.h
@@ -50,14 +50,14 @@ public:
     //               going to use those HTK format lattices.
     virtual bool getbatch(const size_t globalts,
                           const size_t framesrequested, msra::dbn::matrix &feat, std::vector<size_t> &uids,
-                          std::vector<std::pair<wstring, size_t>> &utteranceinfo,
+                          std::vector<std::pair<std::wstring, size_t>> &utteranceinfo,
                           std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> &transcripts,
-                          std::vector<shared_ptr<const latticesource::latticepair>> &lattices) = 0;
+                          std::vector<std::shared_ptr<const latticesource::latticepair>> &lattices) = 0;
     virtual bool getbatch(const size_t globalts,
                           const size_t framesrequested, std::vector<msra::dbn::matrix> &feat, std::vector<std::vector<size_t>> &uids,
-                          std::vector<std::pair<wstring, size_t>> &utteranceinfo,
+                          std::vector<std::pair<std::wstring, size_t>> &utteranceinfo,
                           std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> &transcripts,
-                          std::vector<shared_ptr<const latticesource::latticepair>> &lattices) = 0;
+                          std::vector<std::shared_ptr<const latticesource::latticepair>> &lattices) = 0;
     virtual size_t totalframes() const = 0;
 
     virtual double gettimegetbatch() = 0;                         // used to report runtime
@@ -88,9 +88,9 @@ class minibatchiterator
 
     std::vector<msra::dbn::matrix> featbuf;                                                      // buffer for holding curernt minibatch's frames
     std::vector<std::vector<size_t>> uids;                                                       // buffer for storing current minibatch's frame-level label sequence
-    std::vector<std::pair<wstring, size_t>> utteranceinfo;                                       // buffer for current minibatch's utterance ID information.
+    std::vector<std::pair<std::wstring, size_t>> utteranceinfo;                                       // buffer for current minibatch's utterance ID information.
     std::vector<const_array_ref<msra::lattices::lattice::htkmlfwordsequence::word>> transcripts; // buffer for storing current minibatch's word-level label sequences (if available and used; empty otherwise)
-    std::vector<shared_ptr<const latticesource::latticepair>> lattices;                          // lattices of the utterances in current minibatch (empty in frame mode)
+    std::vector<std::shared_ptr<const latticesource::latticepair>> lattices;                          // lattices of the utterances in current minibatch (empty in frame mode)
 
     size_t mbstartframe;   // current start frame into generalized time line (used for frame-wise mode and for diagnostic messages)
     size_t actualmbframes; // actual number of frames in current minibatch
@@ -117,7 +117,7 @@ private:
         }
         // process one mini-batch (accumulation and update)
         assert(requestedmbframes > 0);
-        const size_t requestedframes = min(requestedmbframes, epochendframe - mbstartframe); // (< mbsize at end)
+        const size_t requestedframes = std::min(requestedmbframes, epochendframe - mbstartframe); // (< mbsize at end)
         assert(requestedframes > 0);
         source.getbatch(mbstartframe, requestedframes, featbuf, uids, utteranceinfo, transcripts, lattices);
         timegetbatch = source.gettimegetbatch();
@@ -294,14 +294,14 @@ public:
         return uids[i];
     }
 
-    std::vector<std::pair<wstring, size_t>> getutteranceinfo()
+    std::vector<std::pair<std::wstring, size_t>> getutteranceinfo()
     {
         checkhasdata();
         return utteranceinfo;
     }
 
     // return a lattice for an utterance (caller should first get total through currentmblattices())
-    shared_ptr<const msra::dbn::latticepair> lattice(size_t uttindex) const
+    std::shared_ptr<const msra::dbn::latticepair> lattice(size_t uttindex) const
     {
         return lattices[uttindex];
     } // lattices making up the current

--- a/Source/Readers/Kaldi2Reader/minibatchsourcehelpers.h
+++ b/Source/Readers/Kaldi2Reader/minibatchsourcehelpers.h
@@ -40,9 +40,9 @@ static size_t augmentationextent(size_t featdim /*augment from*/, size_t modeldi
     const size_t extent = windowframes / 2;         // extend each side by this
 
     if (modeldim % featdim != 0)
-        throw runtime_error("augmentationextent: model vector size not multiple of input features");
+        throw std::runtime_error("augmentationextent: model vector size not multiple of input features");
     if (windowframes % 2 == 0)
-        throw runtime_error(msra::strfun::strprintf("augmentationextent: neighbor expansion of input features to %d not symmetrical", windowframes));
+        throw std::runtime_error(msra::strfun::strprintf("augmentationextent: neighbor expansion of input features to %d not symmetrical", windowframes));
 
     return extent;
 }

--- a/Source/Readers/Kaldi2Reader/ssematrix.h
+++ b/Source/Readers/Kaldi2Reader/ssematrix.h
@@ -77,10 +77,10 @@ protected:
     }
     void swap(ssematrixbase &other)
     {
-        ::swap(p, other.p);
-        ::swap(numrows, other.numrows);
-        ::swap(numcols, other.numcols);
-        ::swap(colstride, other.colstride);
+        std::swap(p, other.p);
+        std::swap(numrows, other.numrows);
+        std::swap(numcols, other.numcols);
+        std::swap(colstride, other.colstride);
     }
     void move(ssematrixbase &other)
     {
@@ -506,7 +506,7 @@ public:
         assert(i < rows() && j < cols());
         for (size_t n = 0; n < rows(); n++)
         {
-            ::swap(p[locate(n, i)], p[locate(n, j)]);
+            std::swap(p[locate(n, i)], p[locate(n, j)]);
         }
     }
 
@@ -601,13 +601,13 @@ public:
         // loop over col stripes of V
         for (size_t j0 = 0; j0 < V.cols(); j0 += colstripewV)
         {
-            const size_t j1 = min(j0 + colstripewV, V.cols());
+            const size_t j1 = std::min(j0 + colstripewV, V.cols());
             // stripe of V is columns [j0,j1)
 
             // loop over row stripes of M
             for (size_t i0 = beginrow; i0 < endrow; i0 += rowstripehM)
             {
-                const size_t i1 = min(i0 + rowstripehM, endrow);
+                const size_t i1 = std::min(i0 + rowstripehM, endrow);
 
                 // loop over sub-ranges of the dot product (full dot product will exceed the L1 cache)
                 float patchbuffer[rowstripehM * colstripewV + 3]; // note: don't forget column rounding
@@ -616,7 +616,7 @@ public:
 
                 for (size_t k0 = 0; k0 < V.rows(); k0 += dotprodstep)
                 {
-                    const size_t k1 = min(k0 + dotprodstep, V.rows());
+                    const size_t k1 = std::min(k0 + dotprodstep, V.rows());
                     const bool first = k0 == 0;
                     // const bool last = k0 + dotprodstep >= V.rows();
 
@@ -934,7 +934,7 @@ public:
         // loop over stripes of V
         for (size_t j0 = 0; j0 < V.cols(); j0 += cacheablecolsV)
         {
-            const size_t j1 = min(j0 + cacheablecolsV, V.cols());
+            const size_t j1 = std::min(j0 + cacheablecolsV, V.cols());
             // loop over rows of result = rows of M = cols of Mt
             for (size_t i = i0; i < i1; i++)
             {
@@ -1367,11 +1367,11 @@ public:
     // only assignment is by rvalue reference
     ssematrixstriperef &operator=(ssematrixstriperef &&other)
     {
-        move(other);
+        this->move(other);
     }
     ssematrixstriperef(ssematrixstriperef &&other)
     {
-        move(other);
+        this->move(other);
     }
 
     // getting a one-column sub-view on this
@@ -1540,7 +1540,7 @@ public:
         const size_t totalelem = newcolstride * m;
         // fprintf (stderr, "resize (%d, %d) allocating %d elements\n", n, m, totalelem);
         float *pnew = totalelem > 0 ? new_sse<float>(totalelem) : NULL;
-        ::swap(this->p, pnew);
+        std::swap(this->p, pnew);
         delete_sse(pnew); // pnew is now the old p
         this->numrows = n;
         this->numcols = m;
@@ -1775,7 +1775,7 @@ pair<unsigned int, unsigned int> printmatvaluedistributionf(const char *name, co
     const size_t numparts = 100;
     for (size_t i = 1; i <= numparts; i++)
     {
-        fprintf(stderr, "%.5f%% absolute values are under %.10f\n", i * 100.0 / numparts, vals[min((size_t)(num - 1), i * num / numparts)]);
+        fprintf(stderr, "%.5f%% absolute values are under %.10f\n", i * 100.0 / numparts, vals[std::min((size_t)(num - 1), i * num / numparts)]);
     }
     fprintf(stderr, "\n%.5f%% values are zero\n\n", 100.0 * numzeros / num);
 #endif


### PR DESCRIPTION
Fixes compilation errors in cuda_fp16.h when building with CUDA 8.0.