### PR TITLE
Fixed broken link in the tutorial docs

### DIFF
--- a/bindings/python/doc/tutorials.rst
+++ b/bindings/python/doc/tutorials.rst
@@ -24,5 +24,5 @@ Tutorials
 .. _`CIFAR-10 Data preparation`: https://github.com/Microsoft/CNTK/tree/v2.0.beta3.0/bindings/python/tutorials/CNTK_201A_CIFAR-10_DataLoader.ipynb
 .. _`VGG and ResNet classifiers`: https://github.com/Microsoft/CNTK/tree/v2.0.beta3.0/bindings/python/tutorials/CNTK_201B_CIFAR-10_ImageHandsOn.ipynb
 .. _`Language understanding`: https://github.com/Microsoft/CNTK/blob/v2.0.beta3.0/bindings/python/tutorials/CNTK_202_Language_Understanding.ipynb
-.. _`Reinforcement learning basics`: https://github.com/Microsoft/CNTK/blob/master/bindings/python/tutorials/CNTK_203_Reinforcement_Learning_Basics.ipynb
+.. _`Reinforcement learning basics`: https://github.com/Microsoft/CNTK/blob/v2.0.beta3.0/bindings/python/tutorials/CNTK_203_Reinforcement_Learning_Basics.ipynb
   


### PR DESCRIPTION
Link to the reinforcement learning tutorial was broken. Linking it to the v2.0.beta3.0 version like the others as well.