### PR TITLE
Bugfix for python graph.output_function_graph for rnn's

### DIFF
--- a/bindings/python/cntk/layers.py
+++ b/bindings/python/cntk/layers.py
@@ -254,7 +254,7 @@ def Delay(T=1, initial_state=None):
     if T > 0:
         apply_x = past_value  (x, time_step=T, initial_state=initial_state)
     elif T < 0:
-        apply_x = future_value(x, time_step=T, initial_state=initial_state)
+        apply_x = future_value(x, time_step=-T, initial_state=initial_state)
     else:
         apply_x = x
     return Block(apply_x, 'Delay')

--- a/bindings/python/doc/layerref.rst
+++ b/bindings/python/doc/layerref.rst
@@ -847,7 +847,7 @@ vector:
 
     x  = ...                   # input value, e.g. a N-dimensional one-hot vector
     xp = Delay()(x)            # previous value
-    xn = Delay(T-1)(x)         # next value (negative delay)
+    xn = Delay(T=-1)(x)         # next value (negative delay)
     tg = splice ([xp, x, xn])  # concatenate all into a 3N-dimensional three-hot vector
 
 BatchNormalization(), LayerNormalization(), Stabilizer()


### PR DESCRIPTION
The python function cntk.graph.output_function_graph defines the set visited, but does not use it.
Therefore for rnn's the execution time is very high.