### PR TITLE
Fixing Docker CPU image to working with Speech example

### DIFF
--- a/Tools/docker/CNTK-CPUOnly-Image/Dockerfile
+++ b/Tools/docker/CNTK-CPUOnly-Image/Dockerfile
@@ -148,9 +148,10 @@ WORKDIR /cntk
 # Build CNTK
 RUN git clone --depth=1 -b master https://github.com/Microsoft/CNTK.git . && \
     CONFIGURE_OPTS="\
+      --1bitsgd=yes \
       --with-kaldi=${KALDI_PATH} \
       --with-py34-path=/root/anaconda3/envs/cntk-py34" && \
-    git submodule update --init Source/Multiverso && \
+    git submodule update --init --recursive && \
     mkdir -p build/cpu/release && \
     cd build/cpu/release && \
     ../../../configure $CONFIGURE_OPTS --with-openblas=/usr/local/openblas && \


### PR DESCRIPTION
It is not possible to run example Speech/AN4/Config/FeedForward.cntk because of error `Gradient quantization is unsupported in CNTK binaries build without quantized gradient aggregation support`

Enabling 1bit-SGD https://github.com/Microsoft/CNTK/wiki/Enabling-1bit-SGD