### PR TITLE
reserve CNTK_MODEL_VERSION_18 for dilated convolution

### DIFF
--- a/Source/ComputationNetworkLib/ComputationNode.h
+++ b/Source/ComputationNetworkLib/ComputationNode.h
@@ -47,7 +47,9 @@
 #define CNTK_MODEL_VERSION_15 15 // add new nodes: LambdaRankNode and NDCG1Eval
 #define CNTK_MODEL_VERSION_16 16 // save/load rng state for Dropout and RandomSample nodes.
 #define CNTK_MODEL_VERSION_17 17 // use 8 bytes for rng seeds on both platforms
-#define CURRENT_CNTK_MODEL_VERSION CNTK_MODEL_VERSION_17
+#define CNTK_MODEL_VERSION_18 18 // reserving 18 for dilated convolution, write out one more TensorShape 
+#define CURRENT_CNTK_MODEL_VERSION CNTK_MODEL_VERSION_18
+
 
 // helper mode for debugging
 // If TRACK_GAP_NANS is defined then initialize layout gaps to NaN and do NaN checks. Also do detailed logging of node computations.

--- a/Source/ComputationNetworkLib/ConvolutionalNodes.h
+++ b/Source/ComputationNetworkLib/ConvolutionalNodes.h
@@ -290,6 +290,7 @@ public:
     {
         Base::Save(fstream);
         fstream << m_convolution2D;
+        TensorShape(1).Save(fstream); // Write out a dummy tensor, so that model created can be used later after implementing reading this tensor in this model version
     }
 
     void Load(File& fstream, size_t modelVersion) override
@@ -325,6 +326,12 @@ public:
         else
         {
             fstream >> m_convolution2D;
+            if (modelVersion >= CNTK_MODEL_VERSION_18)
+            {
+                TensorShape dummyTensorHolder;
+                dummyTensorHolder.Load(fstream);
+                if(dummyTensorHolder!=TensorShape(1)) LogicError("Loading tensor that is currently not supported.");
+            }
         }
     }
 


### PR DESCRIPTION
Planning new feature. Reserve a version number and adding in a default value of new variable needed.