### PR TITLE
Fix an example

### DIFF
--- a/Examples/Image/GettingStarted/06_OneConvRegrMultiNode.cntk
+++ b/Examples/Image/GettingStarted/06_OneConvRegrMultiNode.cntk
@@ -73,6 +73,7 @@ trainNetwork = {
                 syncPeriod = 64
                 usePipeline = false
             ]
+        ]
     }
 
     reader = {


### PR DESCRIPTION
Fix an unmatched bracket in an example.
(Examples/Image/GettingStarted/06_OneConvRegrMultiNode.cntk)