### PR TITLE
Fixed bug in ConvNet_MNIST.py

### DIFF
--- a/Examples/Image/Classification/ConvNet/Python/ConvNet_MNIST.py
+++ b/Examples/Image/Classification/ConvNet/Python/ConvNet_MNIST.py
@@ -118,7 +118,7 @@ def convnet_mnist(debug_output=False):
         metric_denom += current_minibatch
 
         # Keep track of the number of samples processed so far.
-        sample_count += trainer.previous_minibatch_sample_count
+        sample_count += data[label_var].num_samples
         minibatch_index += 1
 
     print("")


### PR DESCRIPTION
When running `ConvNet_MNIST.py` I get the following error:

```bash
Traceback (most recent call last):
  File "ConvNet_MNIST.py", line 131, in <module>
    convnet_mnist()
  File "ConvNet_MNIST.py", line 117, in convnet_mnist
    metric_numer += trainer.test_minibatch(data) * current_minibatch
  File "/home/hoaphumanoid/anaconda3/envs/cntk-py34/lib/python3.4/site-packages/cntk/trainer.py", line 125, in test_minibatch
    arguments = sanitize_var_map(self.model.arguments, arguments)
  File "/home/hoaphumanoid/anaconda3/envs/cntk-py34/lib/python3.4/site-packages/cntk/utils/__init__.py", line 373, in sanitize_var_map
    len(op_arguments))
ValueError: function expects 1 arguments
```