### PR TITLE
Fast-RCNN Example: Added use of path.join to better accomodate windows scenarios

### DIFF
--- a/Examples/Image/Detection/FastRCNN/A1_GenerateInputROIs.py
+++ b/Examples/Image/Detection/FastRCNN/A1_GenerateInputROIs.py
@@ -32,7 +32,7 @@ if not datasetName.startswith("pascalVoc"):
 
     for subdir in subDirs:
         makeDirectory(roiDir + subdir)
-        imgFilenames = getFilesInDirectory(imgDir + subdir, ".jpg")
+        imgFilenames = getFilesInDirectory(os.path.join(imgDir, subdir), ".jpg")
 
         # loop over all images
         for imgIndex,imgFilename in enumerate(imgFilenames):
@@ -41,7 +41,7 @@ if not datasetName.startswith("pascalVoc"):
             # load image
             print (imgIndex, len(imgFilenames), subdir, imgFilename)
             tstart = datetime.datetime.now()
-            imgPath = imgDir + subdir + "/" + imgFilename
+            imgPath = os.path.join(imgDir, subdir, imgFilename)
             imgOrig = imread(imgPath)
             if imWidth(imgPath) > imHeight(imgPath):
                 print (imWidth(imgPath) , imHeight(imgPath))

--- a/Examples/Image/Detection/FastRCNN/B2_EvaluateInputROIs.py
+++ b/Examples/Image/Detection/FastRCNN/B2_EvaluateInputROIs.py
@@ -16,14 +16,14 @@ subdirs = ['positive', 'testImages']
 overlaps = []
 roiCounts = []
 for subdir in subdirs:
-    imgFilenames = getFilesInDirectory(imgDir + subdir, ".jpg")
+    imgFilenames = getFilesInDirectory(os.path.join(imgDir, subdir), ".jpg")
 
     # loop over all iamges
     for imgIndex,imgFilename in enumerate(imgFilenames):
         if imgIndex % 20 == 0:
             print ("Processing subdir '{}', image {} of {}".format(subdir, imgIndex, len(imgFilenames)))
         # load ground truth
-        imgPath = imgDir + subdir + "/" + imgFilename
+        imgPath = os.path.join(imgDir, subdir, imgFilename)
         imgWidth, imgHeight = imWidthHeight(imgPath)
         gtBoxes, gtLabels = readGtAnnotation(imgPath)
         gtBoxes = [Bbox(*rect) for rect in gtBoxes]

--- a/Examples/Image/Detection/FastRCNN/PARAMETERS.py
+++ b/Examples/Image/Detection/FastRCNN/PARAMETERS.py
@@ -21,14 +21,14 @@ cntk_padHeight = 1000
 
 # directories
 rootDir = os.path.dirname(os.path.realpath(sys.argv[0])) + "/"
-imgDir = rootDir + "../../DataSets/" + datasetName+ "/"
-pascalDataDir = rootDir + "../../DataSets/Pascal/"
+imgDir = os.path.join(rootDir, "../../DataSets/" + datasetName+ "/")
+pascalDataDir = os.path.join(rootDir, "../../DataSets/Pascal/")
 
 # derived directories
-procDir = rootDir + "proc/" + datasetName + "_{}/".format(cntk_nrRois)
-resultsDir = rootDir + "results/" + datasetName + "_{}/".format(cntk_nrRois)
-roiDir = procDir + "rois/"
-cntkFilesDir = procDir + "cntkFiles/"
+procDir = os.path.join(rootDir, "proc/" + datasetName + "_{}/".format(cntk_nrRois))
+resultsDir = os.path.join(rootDir, "results/" + datasetName + "_{}/".format(cntk_nrRois))
+roiDir = os.path.join(procDir, "rois/")
+cntkFilesDir = os.path.join(procDir, "cntkFiles/")
 cntkTemplateDir = rootDir
 
 # ROI generation

--- a/Examples/Image/Detection/FastRCNN/cntk_helpers.py
+++ b/Examples/Image/Detection/FastRCNN/cntk_helpers.py
@@ -103,7 +103,7 @@ def filterRois(rects, maxWidth, maxHeight, roi_minNrPixels, roi_maxNrPixels,
 
 
 def readRois(roiDir, subdir, imgFilename):
-    roiPath = roiDir + subdir + "/" + imgFilename[:-4] + ".roi.txt"
+    roiPath = os.path.join(roiDir, subdir, imgFilename[:-4] + ".roi.txt")
     rois = np.loadtxt(roiPath, np.int)
     if len(rois) == 4 and type(rois[0]) == np.int32:  # if only a single ROI in an image
         rois = [rois]
@@ -122,10 +122,10 @@ def readGtAnnotation(imgPath):
     return bboxes, labels
 
 def getCntkInputPaths(cntkFilesDir, image_set):
-    cntkImgsListPath = cntkFilesDir + image_set + '.txt'
-    cntkRoiCoordsPath = cntkFilesDir + image_set + '.rois.txt'
-    cntkRoiLabelsPath = cntkFilesDir + image_set + '.roilabels.txt'
-    cntkNrRoisPath = cntkFilesDir + image_set + '.nrRois.txt'
+    cntkImgsListPath = os.path.join(cntkFilesDir, image_set + '.txt')
+    cntkRoiCoordsPath = os.path.join(cntkFilesDir, image_set + '.rois.txt')
+    cntkRoiLabelsPath = os.path.join(cntkFilesDir, image_set + '.roilabels.txt')
+    cntkNrRoisPath = os.path.join(cntkFilesDir, image_set + '.nrRois.txt')
     return cntkImgsListPath, cntkRoiCoordsPath, cntkRoiLabelsPath, cntkNrRoisPath
 
 def roiTransformPadScaleParams(imgWidth, imgHeight, padWidth, padHeight, boResizeImg = True):
@@ -559,7 +559,7 @@ def makeDirectory(directory):
         os.makedirs(directory)
 
 def getFilesInDirectory(directory, postfix = ""):
-    fileNames = [s for s in os.listdir(directory) if not os.path.isdir(directory+"/"+s)]
+    fileNames = [s for s in os.listdir(directory) if not os.path.isdir(os.path.join(directory, s))]
     if not postfix or postfix == "":
         return fileNames
     else:
@@ -646,7 +646,7 @@ def sortDictionary(dictionary, sortIndex=0, reverseSort=False):
 
 def imread(imgPath, boThrowErrorIfExifRotationTagSet = True):
     if not os.path.exists(imgPath):
-        "ERROR: image path does not exist."
+        print("ERROR: image path does not exist.")
         error
 
     rotation = rotationFromExifTag(imgPath)

--- a/Examples/Image/Detection/FastRCNN/imdb_data.py
+++ b/Examples/Image/Detection/FastRCNN/imdb_data.py
@@ -60,7 +60,7 @@ class imdb_data(fastRCNN.imdb):
         image_index = []
         image_subdirs = []
         for subdir in self._imgSubdirs[self._image_set]:
-            imgFilenames = getFilesInDirectory(self._imgDir + subdir, self._image_ext)
+            imgFilenames = getFilesInDirectory(os.path.join(self._imgDir,subdir), self._image_ext)
             image_index += imgFilenames
             image_subdirs += [subdir] * len(imgFilenames)
         return image_index, image_subdirs


### PR DESCRIPTION
The example scripts for Fast-RCNN assume that the input paths ends with a "/". This breaks the script when the given input dir path does not end  "/".
I've changed the path concatenation calls to use the built in os.path.join method in order to prevent such issues. Please let me know if any additional change is required. 