### PR TITLE
Add deviceId=localRank mode, enabling process select GPU by its local rank

### DIFF
--- a/Source/CNTK/CNTK.cpp
+++ b/Source/CNTK/CNTK.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
 // Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
 //
 // CNTK.cpp : Defines the entry point for the console application.
@@ -773,7 +774,17 @@ int wmainOldCNTKConfig(int argc, wchar_t* argv[])
 
     // full config info
     PrintBuiltInfo();
-    PrintGpuInfo();
+    if(EqualCI(val, "localRank")) {
+      auto data = GetGpuData(paralleltrain ? mpi->CurrentLocalNodeRank() : 0);
+
+      LOGPRINTF(stderr, "-------------------------------------------------------------------\n");
+      LOGPRINTF(stderr, "GPU info(only print info of gpu being used in localRank mode):\n\n");
+      LOGPRINTF(stderr, "\t\tDevice[%d]: cores = %d; computeCapability = %d.%d; type = \"%s\"; memory = %lu MB\n",
+		data.deviceId, data.cudaCores, data.versionMajor, data.versionMinor, data.name.c_str(), (unsigned long)data.totalMemory);
+      LOGPRINTF(stderr, "-------------------------------------------------------------------\n");
+      LOGPRINTF(stderr, "\n");
+    }
+    else PrintGpuInfo();
 
 #ifdef _DEBUG
     if (traceLevel > 0)

--- a/Source/CNTK/CNTK.cpp
+++ b/Source/CNTK/CNTK.cpp
@@ -690,7 +690,7 @@ int wmainOldCNTKConfig(int argc, wchar_t* argv[])
 
 #ifndef CPUONLY
     ConfigValue val = config("deviceId", "auto");
-    if (!EqualCI(val, "cpu") && !EqualCI(val, "auto"))
+    if (!EqualCI(val, "cpu") && !EqualCI(val, "auto") && !EqualCI(val, "localRank"))
     {
         if (static_cast<int>(val) >= 0) // gpu (id >= 0)
         {
@@ -725,11 +725,19 @@ int wmainOldCNTKConfig(int argc, wchar_t* argv[])
     if (paralleltrain)
     {
        mpi = MPIWrapper::GetInstance(true /*create*/);
+
+       // check support for gpu in case using localRank mode
+       if(EqualCI(val, "localRank")) CheckSupportForGpu(mpi->CurrentLocalNodeRank());
     } 
+    // check gpu 0 in case using localRank mode in single process
+    else if(EqualCI(val, "localRank"))
+        CheckSupportForGpu(0);
 
     Globals::SetShareNodeValueMatrices(config(L"shareNodeValueMatrices", true));
     Globals::SetGradientAccumulationOptimization(config(L"optimizeGradientAccumulation", true));
     Globals::SetHyperCompressMemory(config(L"hyperCompressMemory", false));
+
+
 
     TracingGPUMemoryAllocator::SetTraceLevel(config(L"traceGPUMemoryAllocations", 0));
 

--- a/Source/Common/Include/MPIWrapper.h
+++ b/Source/Common/Include/MPIWrapper.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2016-2017, NVIDIA CORPORATION. All rights reserved.
 // Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
 //
 
@@ -376,6 +376,20 @@ public:
     {
         return m_myRank;
     }
+
+    size_t CurrentLocalNodeRank()
+    {
+        const char* p = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+        if (!p)
+        {
+            RuntimeError("Cannot get local rank, try other mode.\nPossible cause: localRank mode is currently not supported in windows.\n");
+        }
+        else
+        {
+            return std::stoi(string(p));
+        }
+    }
+
     std::wstring CurrentNodeName() const
     {
         return m_myName;


### PR DESCRIPTION
This commit add localRank option. Using this, mpi processes can select GPU base on their local rank.

To use:
`cntk configFile=... deviceId=localRank`

For example, if we launch 3 processed on 2 nodes
Process 0 on node 0 with local rank 0 will will try to pick GPU 0 on node 0
Process 1 and 2 with local rank 0 and 1 will try to pick GPU 0 and 1 on node 1

User can also manually select GPU in this mode by tweak GPU order on each node with environment variable in advance. Normally this is not needed, since faster and closer GPUs may have smaller and closer numbers.

This commit should cover most of use cases when user know the topology. If other cases needed, we are willing to work on those later. 

Note that due to MPI implementation, windows version is not covered in this commit.
