### PR TITLE
FastRCNN - Bad bonding box read when there is only one ground truth annotation

### DIFF
--- a/Examples/Image/Detection/FastRCNN/imdb_data.py
+++ b/Examples/Image/Detection/FastRCNN/imdb_data.py
@@ -152,10 +152,17 @@ class imdb_data(fastRCNN.imdb):
         if not os.path.exists(bboxesPaths) or not os.path.exists(labelsPaths):
             return None
         bboxes = np.loadtxt(bboxesPaths, np.float32)
+
+        # in case there's only one annotation and numpy read the array as single array,
+        # we need to make sure the input is treated as a multi dimensional array instead of a list/ 1D array
+        if len(bboxes.shape) == 1:
+            bboxes = np.array([bboxes])
+
         labels = readFile(labelsPaths)
 
         #remove boxes marked as 'undecided' or 'exclude'
         indicesToKeep = find(labels, lambda x: x!='EXCLUDE' and x!='UNDECIDED')
+
         bboxes = [bboxes[i] for i in indicesToKeep]
         labels = [labels[i] for i in indicesToKeep]
 

--- a/Examples/Image/Detection/FastRCNN/imdb_data.py
+++ b/Examples/Image/Detection/FastRCNN/imdb_data.py
@@ -162,7 +162,6 @@ class imdb_data(fastRCNN.imdb):
 
         #remove boxes marked as 'undecided' or 'exclude'
         indicesToKeep = find(labels, lambda x: x!='EXCLUDE' and x!='UNDECIDED')
-
         bboxes = [bboxes[i] for i in indicesToKeep]
         labels = [labels[i] for i in indicesToKeep]
 


### PR DESCRIPTION
This pull request contains a fix to the following issue:
When an image has only one ground truth annotation, the ground truth bounding box is wrongly read due to the fact that numpy loads the *.bboxes.tsv file as a 1D array (instead of a 2D). This leads to the bounding box of the GT region to be treated as [x1 x1 x1 x1], which leads to all of the ROIs being marked as background (since there are no overlaps with the ground truth).

@pkranen  - Can you please have a look? Let me know if any change to the code is required.