### PR TITLE
Flushing stderr on no cmd args given

### DIFF
--- a/Source/CNTK/CNTK.cpp
+++ b/Source/CNTK/CNTK.cpp
@@ -860,6 +860,7 @@ int wmain1(int argc, wchar_t* argv[]) // called from wmain which is a wrapper th
             PrintBuiltInfo(); // print build info directly in case that user provides zero argument (convenient for checking build type)
             LOGPRINTF(stderr, "No command-line argument given.\n");
             PrintUsageInfo();
+            fflush(stderr);
             return EXIT_FAILURE;
         }
 


### PR DESCRIPTION
Addresses issue described in https://github.com/Microsoft/CNTK/issues/1268
Stderr not properly flushed when no cmd args given (affects just GPU skus)