### PR TITLE
A couple of bugs fixed in CNTK_203_Reinforcement_Learning_Basics tutorial

### DIFF
--- a/Tutorials/CNTK_203_Reinforcement_Learning_Basics.ipynb
+++ b/Tutorials/CNTK_203_Reinforcement_Learning_Basics.ipynb
@@ -298,7 +298,7 @@
     "\n",
     "    def train(self, x, y, epoch=1, verbose=0):\n",
     "        #self.model.fit(x, y, batch_size=64, nb_epoch=epoch, verbose=verbose)\n",
-    "        arguments = dict(zip(self.loss.arguments, [x,y]))\n",
+    "        arguments = dict(zip(self.loss.arguments, [y,x])) # y-q_target, x-observation\n",
     "        updated, results =self.trainer.train_minibatch(arguments, outputs=[self.loss.output])\n",
     "\n",
     "    def predict(self, s):\n",
@@ -584,16 +584,14 @@
     "\n",
     "modelPath = 'dqn.mod'\n",
     "root = C.load_model(modelPath)\n",
-    "observation = env.reset()  # reset environment for new episode\n",
-    "done = False\n",
     "for i_episode in range(num_episodes):\n",
     "    print(i_episode)\n",
+    "    observation = env.reset()  # reset environment for new episode\n",
+    "    done = False\n",
     "    while not done:\n",
-    "        #env.render()\n",
+    "        env.render()\n",
     "        action = np.argmax(root.eval([observation.astype(np.float32)]))\n",
-    "        observation, reward, done, info = env.step(action)\n",
-    "    if done:\n",
-    "        observation = env.reset()  # reset environment for new episode    "
+    "        observation, reward, done, info = env.step(action)\n"
    ]
   },
   {


### PR DESCRIPTION
a) The order of loss function arguments was incorrect, causing crash in training
b) env resetting moved from outside to inside the loop to allow visualization on all iterations
c) env rendering uncomented to allow visualization of the model