### PR TITLE
restore_from_checkpoint description mistake

### DIFF
--- a/bindings/python/cntk/trainer.py
+++ b/bindings/python/cntk/trainer.py
@@ -160,7 +160,7 @@ class Trainer(cntk_py.Trainer):
 
     def restore_from_checkpoint(self, filename):
         '''
-        Saves a checkpoint of the model and other Trainer state at the
+        Restores a checkpoint of the model and Trainer state from the
         specified file location.
 
         Args:


### PR DESCRIPTION
The documentation for this function, at line 163 was the same as the one for save_checkpoint. It has been corrected.