### PR TITLE
Fix a dangling pointer problem in CNTKv2LibraryDll.

### DIFF
--- a/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
+++ b/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
@@ -1629,7 +1629,7 @@ private:
 
         CNTK_API static Variable Deserialize(const Dictionary& dictionary, const ::CNTK::DeviceDescriptor& device = DeviceDescriptor::UseDefaultDevice());
 
-        void SetOwner(Function* ownerFunction);
+        void SetOwner(const std::weak_ptr<Function>& ownerFunction);
 
         Variable CompositePreservingCopy(const std::shared_ptr<const Function>& composite) const;
 

--- a/Source/CNTKv2LibraryDll/Function.cpp
+++ b/Source/CNTKv2LibraryDll/Function.cpp
@@ -22,9 +22,9 @@ namespace CNTK
             for (auto outputVar : outputs)
             {
                 if (outputVar.IsOutput() && !outputVar.Owner())
-                    outputVar.SetOwner(this);
+                    outputVar.SetOwner(shared_from_this());
 
-                if (m_rootFunction == nullptr && outputVar.IsOutput() && outputVar.m_dataFields->m_ownerFunction == this)
+                if (m_rootFunction == nullptr && outputVar.IsOutput() && outputVar.m_dataFields->m_ownerFunction.lock().get() == this)
                 {
                     // in case of a primitive function, set uid of output vars to owner function uid + "_Output_" + output index.
                     outputVar.m_dataFields->m_uid = m_uid + L"_" + VariableKindName(outputVar.Kind()) + L"_" + std::to_wstring(m_outputs.size());

--- a/Source/CNTKv2LibraryDll/Variable.h
+++ b/Source/CNTKv2LibraryDll/Variable.h
@@ -18,7 +18,7 @@ namespace CNTK
         NDShape m_shape;
         VariableKind m_varKind;
         ::CNTK::DataType m_dataType;
-        Function* m_ownerFunction; // Variable does not keep the Function alive
+        std::weak_ptr<Function> m_ownerFunction;
         std::unique_ptr<std::once_flag> m_initValueFlag;
         NDArrayViewPtr m_value;
         std::unique_ptr<ParameterInitializer> m_valueInitializer;
@@ -31,7 +31,7 @@ namespace CNTK
         std::atomic<size_t> m_valueTimeStamp;
         Variable m_blockFunctionVariableMapping;
 
-        VariableFields(const NDShape& shape, VariableKind varType, ::CNTK::DataType type, Function* ownerFunction, const NDArrayViewPtr& value, bool needsGradient, const std::vector<Axis>& dynamicAxes, bool isSparse, const std::wstring& name, const std::wstring& uid)
+        VariableFields(const NDShape& shape, VariableKind varType, ::CNTK::DataType type, const std::weak_ptr<Function>& ownerFunction, const NDArrayViewPtr& value, bool needsGradient, const std::vector<Axis>& dynamicAxes, bool isSparse, const std::wstring& name, const std::wstring& uid)
             : m_shape(shape), m_varKind(varType), m_dataType(type), m_ownerFunction(ownerFunction), m_value(value), m_needsGradient(needsGradient), m_dynamicAxes(dynamicAxes), m_isSparse(isSparse), m_name(name), m_uid(uid), m_valueTimeStamp(0)
         {
             if (value && (type != value->GetDataType()))
@@ -49,7 +49,7 @@ namespace CNTK
 
         std::shared_ptr<VariableFields> Clone() const
         {
-            if (m_ownerFunction != nullptr)
+            if (m_ownerFunction.lock() != nullptr)
                 InvalidArgument("Output variables cannot be cloned");
 
             // Note: We do not clone m_blockFunctionVariableMapping


### PR DESCRIPTION
There is a dangling pointer problem in code below.
```cpp
...
CNTK::Variable elementVariable;
CNTK::FunctionPtr functionPtr;
{
    CNTK::FunctionPtr funcPtr = CNTK::ElementDivide(leftOperand, rightOperand);

    elementVariable = funcPtr;
    // functionPtr = funcPtr;     // (A)

    elementVariable.Owner();   // not error.
}
elementVariable.Owner();       // error. (dangling pointer)
                               // but not error when (A) is not commented.
...
```

The reason is that ```m_ownerFunction``` is a raw pointer in ```VariableFields```.
https://github.com/Microsoft/CNTK/blob/fd2e7969a56777345fc8b7007b03e95edc35036f/Source/CNTKv2LibraryDll/Variable.h#L21

I know that it is for resolving circular reference problem.
But raw pointer is very dangerous. In this case, using std::weak_ptr is good practice.
The std::weak_ptr does not affect reference count like raw pointer. But the std::weak_ptr can detect whether pointer is valid or not.

I fix a dangling pointer problem using std::weak_ptr. 