### PR TITLE
Small language change to comments

### DIFF
--- a/Tutorials/CNTK_204_Sequence_To_Sequence.ipynb
+++ b/Tutorials/CNTK_204_Sequence_To_Sequence.ipynb
@@ -1035,7 +1035,7 @@
     "    i = 0\n",
     "    mbs = 0\n",
     "\n",
-    "    # Set epoch size to a larger number of lower training error\n",
+    "    # Set epoch size to a larger number for lower training error\n",
     "    epoch_size = 5000 if isFast else 908241\n",
     "\n",
     "    training_progress_output_freq = 100\n",


### PR DESCRIPTION
I think you meant "Set epoch size to a larger number for lower training error" rather than "Set epoch size to a larger number of lower training error"
Thanks for the tutorials!