### PR TITLE
Add another check for end of epoch.

### DIFF
--- a/Source/Readers/ReaderLib/BlockRandomizer.cpp
+++ b/Source/Readers/ReaderLib/BlockRandomizer.cpp
@@ -121,12 +121,12 @@ Sequences BlockRandomizer::GetNextSequences(size_t globalSampleCount, size_t loc
     {
         assert(globalSampleCount > numGlobalSamplesLoaded && localSampleCount > numLocalSamplesLoaded);
         bool atTheSweepBoundary = result.m_endOfSweep;
-        // in case when we continue filling up a minibatch that crosses a sweep boundary, 
+        // in case when we continue filling up a minibatch that crosses a sweep boundary,
         // make sure that it does not exceed the required number of samples. Set the atLeastOnceSequenceNeeded
         // flag to false.
         size_t numGlobalSamples = 0, numLocalSamples = 0;
-        std::tie(numGlobalSamples, numLocalSamples) = 
-            LoadSequenceData(globalSampleCount - numGlobalSamplesLoaded, 
+        std::tie(numGlobalSamples, numLocalSamples) =
+            LoadSequenceData(globalSampleCount - numGlobalSamplesLoaded,
                              localSampleCount - numLocalSamplesLoaded,
                              result, !atTheSweepBoundary);
 
@@ -138,7 +138,7 @@ Sequences BlockRandomizer::GetNextSequences(size_t globalSampleCount, size_t loc
         numGlobalSamplesLoaded += numGlobalSamples;
         numLocalSamplesLoaded += numLocalSamples;
 
-    } while (m_config.m_allowMinibatchesToCrossSweepBoundaries && 
+    } while (m_config.m_allowMinibatchesToCrossSweepBoundaries &&
              !result.m_endOfEpoch &&
              result.m_endOfSweep &&
              globalSampleCount > numGlobalSamplesLoaded &&
@@ -151,14 +151,14 @@ Sequences BlockRandomizer::GetNextSequences(size_t globalSampleCount, size_t loc
 
 std::pair<size_t, size_t> BlockRandomizer::LoadSequenceData(size_t globalSampleCount, size_t localSampleCount, Sequences& sequences, bool atLeastOneSequenceNeeded)
 {
-    ClosedOpenChunkInterval windowRange;    
+    ClosedOpenChunkInterval windowRange;
     m_sequenceBuffer.clear();
-    size_t numGlobalSamples = 0, numLocalSamples = 0; // actual number of samples to load (filled in from the sequence descriptions) 
+    size_t numGlobalSamples = 0, numLocalSamples = 0; // actual number of samples to load (filled in from the sequence descriptions)
     bool endOfSweep, endOfEpoch;
     std::tie(endOfSweep, endOfEpoch, numGlobalSamples, numLocalSamples) = GetNextSequenceDescriptions(globalSampleCount, localSampleCount, m_sequenceBuffer, windowRange, atLeastOneSequenceNeeded);
     sequences.m_endOfSweep |= endOfSweep;
     sequences.m_endOfEpoch |= endOfEpoch;
-    
+
     assert(atLeastOneSequenceNeeded || (numGlobalSamples <= globalSampleCount && numLocalSamples <= localSampleCount));
 
     if (numGlobalSamples == 0)
@@ -179,13 +179,13 @@ std::pair<size_t, size_t> BlockRandomizer::LoadSequenceData(size_t globalSampleC
     }
     else
     {
-        // sequence data is not empty, we're appending new items to exiting 
+        // sequence data is not empty, we're appending new items to exiting
         // sequence data vectors.
         offset = data.front().size();
         for (auto& sequenceDataVector : data)
         {
             // make sure that all streams contain the same number of sequences
-            assert(sequenceDataVector.size() == offset); 
+            assert(sequenceDataVector.size() == offset);
             sequenceDataVector.resize(offset + m_sequenceBuffer.size());
         }
     }
@@ -285,7 +285,7 @@ std::tuple<bool, bool, size_t, size_t> BlockRandomizer::GetNextSequenceDescripti
     // set "reachedEndOfSweep" to true if the minibatch is last in a sweep
     auto reachedEndOfSweep = (sweepPosition + actualNumberOfGlobalSamples >= m_sweepSizeInSamples);
     // set "reachedEndOfEpoch" to true if the current batch is last in an epoch.
-    auto reachedEndOfEpoch = (m_globalSamplePosition + actualNumberOfGlobalSamples >= epochEndPosition);
+    auto reachedEndOfEpoch = (m_globalSamplePosition + actualNumberOfGlobalSamples >= epochEndPosition || localSampleCount >= (epochEndPosition - m_globalSamplePosition));
 
     // Update the global sample position.
     m_globalSamplePosition += actualNumberOfGlobalSamples;


### PR DESCRIPTION
Currently, CNTK has strange behavior at the end of epoch when loading sequence data.

Assume reading lots of sequences of length 3. If we set `epochSize = 100`, `minibatchSize = 90`, we get
```
minibatch 1:90 samples
minibatch 2:9 samples
minibatch 3:3 samples
Samples in epoch: 102
```
Following is CNTK definition of `minibatchSize` and `epochSize`:
> Despite our clear definition of `minibatchSize` being the number of samples between model updates, there are two occasions where we must relax the definition:
> 
> sequential data: Variable-length sequences do not generally sum up to exactly the requested minibatch size. In this case, as many sequences as possible are packed into a minibatch without exceeding the requested minibatch size (with one exception: If the next one sequence in the randomized corpus exceeds the length of the minibatch size, the minibatch size will consist of this sequence).
> 
> data parallelism: Here, the minibatch size is approximate, as our chunk-based randomization algorithm cannot guarantee that each worker receives precisely the same number of samples.
> 
> All of the above considerations also apply to `epochSize`.

New behavior after this change:
```
minibatch 1:90 samples
minibatch 2:9 samples
Samples in epoch: 99
```

Note that there might be similar behavior need further investigation in 'end of sweep' check and in NoRandomizer.
