### PR TITLE
Fix for Stochastic CUDNN_STATUS_EXECUTION_FAILED

### DIFF
--- a/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_205_Artistic_Style_Transfer_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_205_Artistic_Style_Transfer_test.py
@@ -16,7 +16,7 @@ def test_cntk_205_artistic_style_transfer_noErrors(nb):
     assert errors == []
 
 expected_objective = 316284.22
-relative_tolerance = 3e-2 # would be tighter if specific to python 2 vs. 3
+relative_tolerance = 1e-1 # would be tighter if specific to python 2 vs. 3
 
 def test_cntk_205_artistic_style_transfer_evalCorrect(nb):
     testCell = [cell for cell in nb.cells


### PR DESCRIPTION
There are two main changes in this PR.
1. `cudnnFindConvolutionXXXAlgorithmEx` is now used instead of `cudnnFindConvolutionXXXAlgorithm`. This change will avoid the failed malloc inside Find, which is likely the cause of cudnn failure 8:`CUDNN_STATUS_EXECUTION_FAILED`
2. All cudnn convolution calls now uses a shared workspace. This will allow better memory usage control and help enabling faster algorithm.

There are 3 noticeable improvement testing with Resnet50/Titan XP. Note that the test script I use is not up to date, but similar behavior should be expected with current CNTK stock script.
1. TOT master can run at most with `minibatchsize=112`, and then crush with `CUDNN_STATUS_EXECUTION_FAILED`. This PR allow to run up to `minibatchsize=135` with full speed and then crush with `CUDA failure 2: out of memory`. This is the expected error since we are really reaching the 12GB memory limitation in this case.
2. During initialization phase, TOT uses a lot more memory than after initialization(running phase). While this PR ensure a steady memory foot print(running phase memory usage is the max usage).
3. After 100MB memory is reseved for GPU to run correctly, CNTK now will use `min(free memory, 1GB)` as a shared workspace for convolution. Overall, we lose some memory when small batchsize is used(up to 1GB, usually several hundred MB), but for larger batchsize, we save memory. For Resnet 50 from `minibatchsize=64`, we start to see memory saving(TOT:7124MB vs PR:7058MB).

Other things need discussion:
- Cleaning up old workspace API because they are no longer needed
- Cudnn **DOES NOT** assume that same workspace and algorithm will work when reducing batch size, it is not safe to assume that. We need to change that part
- Expose the 1GB memory limit to user via `maxTempMemSizeInSamples`
