### PR TITLE
fix workspace corner case and reduce memory footprint

### DIFF
--- a/Source/Math/CuDnnConvolutionEngine.cu
+++ b/Source/Math/CuDnnConvolutionEngine.cu
@@ -366,10 +366,10 @@ private:
         m_outT.UpdateBatchSize(batchSize);
 
         // keep running if nothing changes
-        if (!algo.NeedAutotuning(batchSize)) return;
+        if ((!algo.NeedAutotuning(batchSize)) && (workspace.BufferSize() >= algo.AlgoWorkspaceSize)) return;
 
-        // if batchsize changes again win just finish init, go back to init again
-        if (algo.autotuningState == AutotuningState::PendingTuning && batchSize != algo.MBSizeForCurrentAlgo)
+        // if batchsize changes again when just finish init, go back to init again
+        if (algo.autotuningState == AutotuningState::PendingTuning && batchSize > algo.MBSizeForCurrentAlgo)
             algo.autotuningState = AutotuningState::Init;
 
         // batchSize is bigger than the one when initialize current workspace, need free up space and go back to init
@@ -398,13 +398,15 @@ private:
         {
             // Reserve 100MB and give workspace size of m_MaxWorkspaceSize
             size_t free, total, resizeTo = 0;
+            size_t curSize = workspace.BufferSize();
             CUDA_CALL(cudaMemGetInfo(&free, &total));
+            free += workspace.BufferSize();
             // If we have more than 100MB, reserve that and assign rest to workspace
-            if(free > 100000000) resizeTo = free - 100000000 + sizeof(ElemType);
+            if(free > (total/50)) resizeTo = free - (total/50) + sizeof(ElemType);
             // We don't need memory more than MAX
             if(resizeTo > algo.AlgoWorkspaceSize) resizeTo = algo.AlgoWorkspaceSize;
             if(resizeTo > 0) workspace.Resize(resizeTo/sizeof(ElemType), 1);
-            algo.MBSizeForCurrentWorkspace = batchSize;
+            algo.MBSizeForCurrentWorkspace = algo.MBSizeForCurrentAlgo;
 
             // Pending State now, let's do a find and get algorithm Perfs
             typename TAlgo::typeT algoPerf[MaxAlgoCount];
@@ -426,8 +428,11 @@ private:
             algo.selectedAlgo = (*res).algo;
             algo.maxAlgo = algo.selectedAlgo;
             algo.autotuningState = AutotuningState::Running;
+            algo.AlgoWorkspaceSize = (*res).memory;
+            resizeTo = curSize > algo.AlgoWorkspaceSize ? curSize : algo.AlgoWorkspaceSize;
+            workspace.Resize(resizeTo/sizeof(ElemType), 1, 0, false);
         } // Use stored algo when batchsize go back to max. Likely happen when last batch in epoch lacking data
-        else if (batchSize == algo.MBSizeForCurrentWorkspace)
+        else if (batchSize == algo.MBSizeForCurrentWorkspace && workspace.BufferSize() >= algo.AlgoWorkspaceSize)
         {
             algo.selectedAlgo = algo.maxAlgo;
             algo.MBSizeForCurrentAlgo = batchSize;
@@ -454,6 +459,8 @@ private:
             algo.MBSizeForCurrentAlgo = batchSize;
             algo.selectedAlgo = (*res).algo;
             algo.autotuningState = AutotuningState::Running;
+            algo.AlgoWorkspaceSize = (*res).memory;
+            workspace.Resize(algo.AlgoWorkspaceSize/sizeof(ElemType), 1);
         } // use fast method to get algorithm when batchsize get smaller. Avoid severe slowdown when batchsize change frequently
         else
         {


### PR DESCRIPTION
This fixes several corner case that lead to error when batchSize changes frequently.

I also found a way to reduce the workspace size after everything is settled, which will reduce the running phase memory usage. This will avoid cntk error out with 'out of memory' when workspace is allocated and some other matrix are resized to larger size.

I also tested with master so this commit can be merged into master without issue.