### PR TITLE
Adding dilated convolution support

### DIFF
--- a/Source/CNTK/BrainScript/CNTKCoreLib/CNTK.core.bs
+++ b/Source/CNTK/BrainScript/CNTKCoreLib/CNTK.core.bs
@@ -82,7 +82,7 @@ ConvolutionalLayer {numOutputChannels,   # e.g. (1) or BS.Constants.None
                     initValueScale = 1,          # TODO: rename to initScale
                     initBias = 0,
                     #reductionRank = 1,          # TODO: support this
-                    stride = 1, pad = false,
+                    stride = 1, dilation=1, pad = false,
                     lowerPad = 0, upperPad = 0,
                     maxTempMemSizeInSamples = 0} =
 {
@@ -94,7 +94,7 @@ ConvolutionalLayer {numOutputChannels,   # e.g. (1) or BS.Constants.None
     b = ParameterTensor(_ConcatArrays (Repeat (Length (filterShape), 1), outputChannelsShape), initValue = initBias)                                                       # [ 1 x 1 x     K ]
     sharing = true    # TODO: support this
     apply (x) = {
-        c = Convolution (W, x, filterShape, mapDims = numOutputChannels, stride = stride, sharing = sharing, autoPadding = pad, lowerPad = lowerPad, upperPad = upperPad, maxTempMemSizeInSamples = maxTempMemSizeInSamples)
+        c = Convolution (W, x, filterShape, mapDims = numOutputChannels, stride = stride, dilation = dilation, sharing = sharing, autoPadding = pad, lowerPad = lowerPad, upperPad = upperPad, maxTempMemSizeInSamples = maxTempMemSizeInSamples)
         res = activation (if bias then c + b else c)
     }.res
 }.apply
@@ -103,19 +103,19 @@ ConvolutionalLayer {numOutputChannels,   # e.g. (1) or BS.Constants.None
 ConvolutionTransposeLayer {numOutputChannels,
                            filterShape,         # e.g. (3:3)
                            numInputChannels,
-                           bias = true, 
-                           activation = (x=>x), 
-                           init = 'glorotUniform', 
-                           initValueScale = 0.001, 
-                           initBias = 0, 
-                           stride = 1, pad = false, 
-                           lowerPad = 0, upperPad = 0, 
-                           outputShape = None, 
+                           bias = true,
+                           activation = (x=>x),
+                           init = 'glorotUniform',
+                           initValueScale = 0.001,
+                           initBias = 0,
+                           stride = 1, pad = false,
+                           lowerPad = 0, upperPad = 0,
+                           outputShape = None,
                            maxTempMemSizeInSamples = 0} =
 {
     outputChannelsShape = _AsArray (numOutputChannels)
-    kernelShape = _ConcatArrays (filterShape, outputChannelsShape) 
-    paramShape = _ConcatArrays (kernelShape, _AsArray (numInputChannels)) 
+    kernelShape = _ConcatArrays (filterShape, outputChannelsShape)
+    paramShape = _ConcatArrays (kernelShape, _AsArray (numInputChannels))
     W = ParameterTensor{paramShape, init=init, initValueScale=initValueScale, initOnCPUOnly=true}
     b = ParameterTensor(_ConcatArrays (Repeat (Length (filterShape), 1), outputChannelsShape), initValue = initBias)
     sharing = true    # TODO: support this
@@ -151,14 +151,14 @@ AveragePoolingLayer {filterShape, stride = 1, pad = false, lowerPad = 0, upperPa
     _PoolingLayer {"average", filterShape, stride = stride, pad = pad, lowerPad = lowerPad, upperPad = upperPad, ceilOutDim = ceilOutDim, includePad = includePad}
 
 MaxUnpoolingLayer {filterShape,     # e.g. (3:3)
-                   stride = 1, 
+                   stride = 1,
                    pad = false,
-                   lowerPad = 0, 
-                   upperPad = 0} = 
+                   lowerPad = 0,
+                   upperPad = 0} =
 {
     apply (unpoolInput, poolInput) = MaxUnpooling (unpoolInput, poolInput, filterShape, stride = stride, autoPadding = pad, lowerPad = lowerPad, upperPad = upperPad)
 }.apply
-    
+
 # RecurrentLSTMLayer -- create an LSTM layer
 RecurrentLSTMLayer {outputDim,
                     cellShape = None, # if set then use a projection
@@ -393,10 +393,10 @@ _AsNodes (inputs) = {
 }.arr
 
 ##############################################################################
-# "Stable API" with the purpose of staying compatible towards 2.0. 
+# "Stable API" with the purpose of staying compatible towards 2.0.
 # - Use only tensors as concept. Move away from matrices.
 # - Main input goes first
-# - Main input is called "_" (becomes either self, or is moved to the end, 
+# - Main input is called "_" (becomes either self, or is moved to the end,
 #   depending on language binding)
 # - tensor shape is called "shape"
 # - output shape before input shape
@@ -413,11 +413,11 @@ CNTK2 = [
 
     // 2. Variables and constants
     // Changes: ParameterTensor -> _Parameter; "dims" -> "shape"
-    // Python API: 
+    // Python API:
     // - constant(value, name=None) - value: the tensor constant passed as numpy array. Forwards to parameter() with learningRateMultiplier=0 and initFromLiteral
     // - parameter: Like below, but can take an NDArray on the "init_from_literal" parameter, in which case it is serialized and turned into "initFromLiteral".
     //              (TODO: should be the value parameter instead)
-    // TODO: The API for Parameter is different in current 2.0 design, getting a constant as input for the initial values. 
+    // TODO: The API for Parameter is different in current 2.0 design, getting a constant as input for the initial values.
     // This needs to be fixed to follow the way the Constant() is exposed in Python
     // Making this an internal node with "_" until we agree on the final interface:
     _Parameter(shape, value = 0, initValue = '', learningRateMultiplier = 1.0, init = ''/*|uniform|fixedValue|gaussian|fromFile|fromLiteral*/, initValueScale = 1, initFilterRank = 0, initOutputRank = 1, initFromFilePath = '', initFromLiteral = '', initOnCPUOnly=true, randomSeed=-1, tag='') = new ComputationNode [ operation = 'LearnableParameter' ; shape = new TensorShape [ /*shape */ ] /*plus the function args*/ ]
@@ -467,7 +467,7 @@ CNTK2 = [
     Square(_, tag='') = ElementTimes(_, _, tag=tag)
     Tanh(_, tag='') = new ComputationNode [ operation = 'Tanh' ; inputs = _AsNodes (_) /*plus the function args*/ ]
 
-    // 6. Reductions    
+    // 6. Reductions
     ReduceSum   (_, axis=None, tag='') = { axis1 = if BS.Constants.IsNone (axis) then 0 else axis ; r = new ComputationNode [ operation = 'ReduceElements' ; inputs = _AsNodes (_) ; axis = axis1 ; reductionOp = "Sum"    /*plus the function args*/ ]}.r
     ReduceLogSum(_, axis=None, tag='') = { axis1 = if BS.Constants.IsNone (axis) then 0 else axis ; r = new ComputationNode [ operation = 'ReduceElements' ; inputs = _AsNodes (_) ; axis = axis1 ; reductionOp = "LogSum" /*plus the function args*/ ]}.r
     ReduceMean  (_, axis=None, tag='') = { axis1 = if BS.Constants.IsNone (axis) then 0 else axis ; r = new ComputationNode [ operation = 'ReduceElements' ; inputs = _AsNodes (_) ; axis = axis1 ; reductionOp = "Mean"   /*plus the function args*/ ]}.r
@@ -494,9 +494,9 @@ CNTK2 = [
     Dropout(_, tag='') = new ComputationNode [ operation = 'Dropout' ; inputs = _AsNodes (_) /*plus the function args*/ ]
 
     // 11. Criterion nodes
-    // No changes here - we said the default input would be the label sequence here, against which the 
+    // No changes here - we said the default input would be the label sequence here, against which the
     // empirical sequence is compared to. Keeping this for now.
-    CrossEntropyWithSoftmax(labelSequence, outProbVectorSequence, axis=0, tag='') = 
+    CrossEntropyWithSoftmax(labelSequence, outProbVectorSequence, axis=0, tag='') =
         if axis==0 then new ComputationNode [ operation = 'CrossEntropyWithSoftmax' ; inputs = _AsNodes (labelSequence : outProbVectorSequence) /*plus the function args*/ ]
         else [ tag1 = tag; out = Minus (ReduceLogSum (outProbVectorSequence, axis=axis), ReduceSum (labelSequence .* outProbVectorSequence, axis=axis), tag=tag1) ].out
     # Classification error along a specific axis: account only for missed labels, i.e.
@@ -530,7 +530,7 @@ CNTK2 = [
     Pass(_, tag='') = new ComputationNode [ operation = 'Pass' ; inputs = _AsNodes (_) /*plus the function args*/ ]
     Identity = Pass
 
-    // The value of GetRandomSample(weights /* vector of length nClasses */, numSamples, sampleWithReplacement) randomly samples numSamples using the specified sampling weights. 
+    // The value of GetRandomSample(weights /* vector of length nClasses */, numSamples, sampleWithReplacement) randomly samples numSamples using the specified sampling weights.
     // The result is a sparse matrix of num samples one-hot vectors as columns.
     GetRandomSample(_ ,numSamples, sampleWithReplacement, tag='') = new ComputationNode [
                                                                                         operation = 'RandomSample' ;
@@ -551,7 +551,7 @@ CNTK2 = [
 # Parameter{} can do several forms of initialization.
 #  - initValue=scalar, value=array --> initialize from this value  --array form not implemented yet
 #  - initFromFilePath="..." --> read from a data file
-#  - init="uniform|gaussian" (random init scaled by initValueScale). 
+#  - init="uniform|gaussian" (random init scaled by initValueScale).
 #  - init="zero"
 # deprecated:
 #  - initFromLiteral="..." (deprecated) --> parse a string literal (obsolete with value=array form)
@@ -605,9 +605,9 @@ Slice(beginIndex, endIndex, input, axis=1, tag='') =
     else new ComputationNode [ operation = 'Slice' ; inputs = _AsNodes (input) /*plus the function args*/ ] # non-time axis
 Reshape(input, numRows, imageWidth = 0, imageHeight = 0, imageChannels = 0, tag='') = new ComputationNode [ operation = 'LegacyReshape' ; inputs = _AsNodes (input) /*plus the function args*/ ]
 NewReshape(input, dims, beginAxis=0, endAxis=0, tag='') = new ComputationNode [ operation = 'Reshape' ; inputs = _AsNodes (input) ; shape = new TensorShape [ /*dims*/ ] /*plus the function args*/ ]
-ReshapeDimension(x, axis, tensorShape) = NewReshape(x, tensorShape, beginAxis=axis, endAxis=axis + 1) 
-FlattenDimensions(x, axis, num) = NewReshape(x, 0, beginAxis=axis, endAxis=axis + num) 
-SplitDimension(x, axis, N) = ReshapeDimension(x, axis, 0:N) 
+ReshapeDimension(x, axis, tensorShape) = NewReshape(x, tensorShape, beginAxis=axis, endAxis=axis + 1)
+FlattenDimensions(x, axis, num) = NewReshape(x, 0, beginAxis=axis, endAxis=axis + num)
+SplitDimension(x, axis, N) = ReshapeDimension(x, axis, 0:N)
 # TODO: make input the last arg!
 Transpose(x) = TransposeDimensions(x, 1, 2)
 LambdaRank(gain, prediction, queryId, tag='') = new ComputationNode [ operation = 'LambdaRank' ; inputs = _AsNodes (gain : prediction : queryId) /*plus the function args*/ ]
@@ -618,17 +618,17 @@ ReconcileDynamicAxis(dataInput, layoutInput, tag='') = new ComputationNode [ ope
 ReconcileMBLayout = ReconcileDynamicAxis # back compat
 CastAs (type, data) = ReconcileDynamicAxis (data, type) # read as CastAs<type>(data) where the cast may consist of rearranging the data w.r.t. MBLayout or broadcasting across sequence items
 # ND convo & pooling/unpooling   --why is autoPadding true? Normally one would want to reduce dimensions, no?
-Convolution(weightNode, inputValueNode, kernelDims, mapDims = 0, stride = 1, sharing = true, autoPadding = true, lowerPad = 0, upperPad = 0, imageLayout='CHW', maxTempMemSizeInSamples = 0, tag='') = new ComputationNode [ operation = 'Convolution' ; inputs = _AsNodes (weightNode : inputValueNode); kernelShape = new TensorShape [ dims = kernelDims ] ; mapCount = new TensorShape [ dims = mapDims ] ; strideShape = new TensorShape [ dims = stride ] ; dimSharing = new BoolVector [ items = sharing ] ; dimPadding = new BoolVector [ items = autoPadding ] ; dimPadLower = new TensorShape [ dims = lowerPad ] ; dimPadUpper = new TensorShape [ dims = upperPad ] ; transpose = false; dimOutputShape = new TensorShape [ dims = 0 ]  /*plus the function args*/ ]
-ConvolutionTranspose(weightNode, inputValueNode, kernelDims, mapDims = 0, stride = 1, sharing = true, autoPadding = true, lowerPad = 0, upperPad = 0, outputShape = None, imageLayout='CHW', maxTempMemSizeInSamples = 0, tag='') = new ComputationNode [ operation = 'Convolution' ; inputs = _AsNodes (weightNode : inputValueNode); kernelShape = new TensorShape [ dims = kernelDims ] ; mapCount = new TensorShape [ dims = mapDims ] ; strideShape = new TensorShape [ dims = stride ] ; dimSharing = new BoolVector [ items = sharing ] ; dimPadding = new BoolVector [ items = autoPadding ] ; dimPadLower = new TensorShape [ dims = lowerPad ] ; dimPadUpper = new TensorShape [ dims = upperPad ] ; transpose = true; dimOutputShape = new TensorShape [ dims = if BS.Constants.IsNone (outputShape) then 0 else outputShape ]  /*plus the function args*/ ]
+Convolution(weightNode, inputValueNode, kernelDims, mapDims = 0, stride = 1, dilation = 1, sharing = true, autoPadding = true, lowerPad = 0, upperPad = 0, imageLayout='CHW', maxTempMemSizeInSamples = 0, tag='') = new ComputationNode [ operation = 'Convolution' ; inputs = _AsNodes (weightNode : inputValueNode); kernelShape = new TensorShape [ dims = kernelDims ] ; mapCount = new TensorShape [ dims = mapDims ] ; strideShape = new TensorShape [ dims = stride ] ; dimSharing = new BoolVector [ items = sharing ] ; dimPadding = new BoolVector [ items = autoPadding ] ; dimPadLower = new TensorShape [ dims = lowerPad ] ; dimPadUpper = new TensorShape [ dims = upperPad ] ; dimDilation = new TensorShape [ dims = dilation ] ; transpose = false; dimOutputShape = new TensorShape [ dims = 0 ]  /*plus the function args*/ ]
+ConvolutionTranspose(weightNode, inputValueNode, kernelDims, mapDims = 0, stride = 1, dilation = 1, sharing = true, autoPadding = true, lowerPad = 0, upperPad = 0, outputShape = None, imageLayout='CHW', maxTempMemSizeInSamples = 0, tag='') = new ComputationNode [ operation = 'Convolution' ; inputs = _AsNodes (weightNode : inputValueNode); kernelShape = new TensorShape [ dims = kernelDims ] ; mapCount = new TensorShape [ dims = mapDims ] ; strideShape = new TensorShape [ dims = stride ] ; dimSharing = new BoolVector [ items = sharing ] ; dimPadding = new BoolVector [ items = autoPadding ] ; dimPadLower = new TensorShape [ dims = lowerPad ] ; dimPadUpper = new TensorShape [ dims = upperPad ] ; dimDilation = new TensorShape [ dims = dilation ] ; transpose = true; dimOutputShape = new TensorShape [ dims = if BS.Constants.IsNone (outputShape) then 0 else outputShape ]  /*plus the function args*/ ]
 Pooling(input, poolKind/*'max'|'average'*/, kernelDims, stride=1, autoPadding = true, lowerPad = 0, upperPad = 0, ceilOutDim = false, includePad = false, imageLayout='CHW', tag='') = new ComputationNode [ operation = 'Pooling' ; inputs = _AsNodes (input); pool = poolKind ; kernelShape = new TensorShape [ dims = kernelDims ] ; strideShape = new TensorShape [ dims = stride ] ; dimPadding = new BoolVector [ items = autoPadding ] ; dimPadLower = new TensorShape [ dims = lowerPad ] ; dimPadUpper = new TensorShape [ dims = upperPad ] ; ceilOut = ceilOutDim ; poolIncludePad = includePad /*plus the function args*/ ]
 MaxUnpooling(unpoolInput, poolInput, kernelDims, stride=1, autoPadding = true, lowerPad = 0, upperPad = 0, imageLayout='CHW', tag='') = new ComputationNode [ operation = 'MaxUnpooling' ; inputs = _AsNodes (unpoolInput : poolInput); kernelShape = new TensorShape [ dims = kernelDims ] ; strideShape = new TensorShape [ dims = stride ] ; dimPadding = new BoolVector [ items = autoPadding ] ; dimPadLower = new TensorShape [ dims = lowerPad ] ; dimPadUpper = new TensorShape [ dims = upperPad ] /*plus the function args*/ ]
 # 2D pooling
 MaxPooling(input, windowWidth, windowHeight, horizontalSubsample, verticalSubsample, imageLayout='CHW', tag='') = new ComputationNode [ operation = 'MaxPooling' ; inputs = _AsNodes (input) /*plus the function args*/ ]
 AveragePooling(input, windowWidth, windowHeight, horizontalSubsample, verticalSubsample, imageLayout='CHW', tag='') = new ComputationNode [ operation = 'AveragePooling' ; inputs = _AsNodes (input) /*plus the function args*/ ]
-ROIPooling (input, ROIs, shape, spatialScale = 0.0625) = new ComputationNode { operation = 'ROIPooling' ; inputs = _AsNodes (input : ROIs) ; pool = 'max' ; roiOutputShape = new TensorShape [ dims = shape ] ; featureScale = spatialScale ; tag='' /*plus the function args*/ } 
-ColumnwiseCrossProduct = KhatriRaoProduct // deprecated 
+ROIPooling (input, ROIs, shape, spatialScale = 0.0625) = new ComputationNode { operation = 'ROIPooling' ; inputs = _AsNodes (input : ROIs) ; pool = 'max' ; roiOutputShape = new TensorShape [ dims = shape ] ; featureScale = spatialScale ; tag='' /*plus the function args*/ }
+ColumnwiseCrossProduct = KhatriRaoProduct // deprecated
 ErrorPrediction = ClassificationError   # legacy name
-Delay = PastValue 
+Delay = PastValue
 
 Acos(x, tag='') = new ComputationNode [ operation = 'Acos' ; inputs = _AsNodes (x) /*plus the function args*/ ]
 Asin(x, tag='') = new ComputationNode [ operation = 'Asin' ; inputs = _AsNodes (x) /*plus the function args*/ ]
@@ -707,13 +707,13 @@ Where(cond, tag='') = new ComputationNode [ operation = 'Where' ; inputs = _AsNo
 # non-neural-network functions
 ##############################################################################
 
-Print(value, format='') = new PrintAction [ what = value /*; how = format*/ ] 
+Print(value, format='') = new PrintAction [ what = value /*; how = format*/ ]
 Fail(what) = new FailAction [ /*what*/ ]
-Format(value, format) = new StringFunction [ what = 'Format' ; arg = value ; how = format ] 
-Replace(s, from, to) = new StringFunction [ what = 'Replace' ; arg = s ; replacewhat = from ; withwhat = to ] 
-Substr(s, begin, num) = new StringFunction [ what = 'Substr' ; arg = s ; pos = begin ; chars = num ] 
-Chr(c) = new StringFunction [ what = 'Chr' ;  arg = c ] 
-Length(x) = new NumericFunction [ what = 'Length' ; arg = x ] 
+Format(value, format) = new StringFunction [ what = 'Format' ; arg = value ; how = format ]
+Replace(s, from, to) = new StringFunction [ what = 'Replace' ; arg = s ; replacewhat = from ; withwhat = to ]
+Substr(s, begin, num) = new StringFunction [ what = 'Substr' ; arg = s ; pos = begin ; chars = num ]
+Chr(c) = new StringFunction [ what = 'Chr' ;  arg = c ]
+Length(x) = new NumericFunction [ what = 'Length' ; arg = x ]
 Repeat (N, what) = if N <= 0 then BS.Constants.None else (Repeat (N-1, what) : what) # can also be used to turn a scalar into a 1-element array
 _ForceResizeArray (N, arrayOrScalar) = { # bring an array to a given length, either by chopping or by duplicating its last value
     arr = _AsArray (arrayOrScalar)
@@ -744,14 +744,14 @@ IntDiv(x, y) = new NumericFunction [ what = 'IntDiv' ;  args = (x:y) ]
 ##############################################################################
 
 # deprecated--use LinearLayer{} and DenseLayer{} instead
-BFF(in, rows, cols) = [ B = Parameter(rows, 1, initValue = 0) ; W = Parameter(rows, cols) ; z = W*in+B ] 
-SBFF(in, rows, cols) = [ Eh = Sigmoid(BFF(in, rows, cols).z) ] 
+BFF(in, rows, cols) = [ B = Parameter(rows, 1, initValue = 0) ; W = Parameter(rows, cols) ; z = W*in+B ]
+SBFF(in, rows, cols) = [ Eh = Sigmoid(BFF(in, rows, cols).z) ]
 
 # deprecated--use FeatureMVNLayer{} instead
-MeanVarNorm(feat) = PerDimMeanVarNormalization(feat, Mean(feat), InvStdDev(feat)) 
+MeanVarNorm(feat) = PerDimMeanVarNormalization(feat, Mean(feat), InvStdDev(feat))
 
 # deprecated--use LogPriorLayer{} instead
-LogPrior(labels) = Log(Mean(labels)) 
+LogPrior(labels) = Log(Mean(labels))
 
 # specify one of these two for initialization:
 #  - init = "uniform"|"gaussian"
@@ -1181,7 +1181,7 @@ RNNs =
        c = Loop.Next (lstmState.c, initialState=if BS.Constants.IsNone (initialState) then None else initialState.c)  # cell(t-1)
        dim = lstmState.dim
     }
-    
+
     PreviousHCWithTrainedInitialState{shape=(0)} = {  # default (0) will infer to all elements for inputs of rank 0
         initialH = ParameterTensor {shape, initValue=0}
         initialC = ParameterTensor {shape, initValue=0}
@@ -1260,7 +1260,7 @@ RNNs =
     # GRU -- GRU function with projection and self-stabilization
     # It returns a dictionary with three members: the hidden state h, the cell state c, and dim=h.dim.
     # While c isn't required, we return it for implementations like seq2seq that expect it so that this can be a proper drop-in replacement for LSTM
-    # Like the LSTM function, it also takes an optional auxiliary input, e.g. for supporting attention models.  
+    # Like the LSTM function, it also takes an optional auxiliary input, e.g. for supporting attention models.
     GRU (outputDim, cellDim=outputDim, x, inputDim=x.dim, aux=Constants.None, auxDim=aux.dim, prevState, enableSelfStabilization=false) =
     [
         S(x) = Parameters.Stabilize (x, enabled=enableSelfStabilization)
@@ -1269,7 +1269,7 @@ RNNs =
         _ = [     // encapsulate the inner workings
 
             dh = prevState.h   // previous value
-            dhs = S(dh)        // previous value, stabilized       
+            dhs = S(dh)        // previous value, stabilized
             # note: input does not get a stabilizer here, user is meant to do that outside
 
             // parameter macros
@@ -1305,8 +1305,8 @@ RNNs =
             htp = Wmr * S(_.ht)
         ].htp
         else _.ht                       // no projection
-        
-        c = _.ct        
+
+        c = _.ct
         dim = outputDim
     ]
 
@@ -1593,8 +1593,8 @@ Seq2Seq =
         # tokens.from:
         # before dropping the first dimension: [V x Dprev x Dnew]
         #   +-----+
-        #   |0 1 0|       means input hyp[1] gave rise to the best    
-        #   +-----+-+  
+        #   |0 1 0|       means input hyp[1] gave rise to the best
+        #   +-----+-+
         #     |1 0 0|     means input hyp[0] gave rise to second best
         #     +-----+-+
         #       |0 0 1|   means input hyp[2] gave rise to third best

--- a/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
+++ b/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
 //
-// This is the main header of the CNTK library API containing the entire public API definition. 
+// This is the main header of the CNTK library API containing the entire public API definition.
 //
 
 #pragma once
@@ -394,7 +394,7 @@ namespace CNTK
     /// Checked mode enables additional runtime verification such as:
     /// - Tracking NaN occurrences in sequence gaps.
     /// - Function graph verification after binding of free static axes to actual values at runtime
-    /// 
+    ///
     /// Enabling checked mode incurs additional runtime costs and is meant to be used as a debugging aid.
     ///
     CNTK_API void SetCheckedMode(bool enable);
@@ -477,28 +477,28 @@ namespace CNTK
         ///
         CNTK_API static DeviceDescriptor GPUDevice(unsigned int deviceId);
 
-        /// 
+        ///
         /// This static method freezes the default device of the current CNTK process disallowing further changes
-        /// through calls to TrySetDefaultDevice. This default device will used for all CNTK operations 
+        /// through calls to TrySetDefaultDevice. This default device will used for all CNTK operations
         /// where a device needs to be specified and where none was explicitly provided. If no default device has been specified
-        /// with a call to TrySetDefaultDevice, on the first invocation, this methods will auto-select one 
+        /// with a call to TrySetDefaultDevice, on the first invocation, this methods will auto-select one
         /// of the available (non-locked) devices as the default. Returns a descriptor of the globally default device.
         ///
         CNTK_API static DeviceDescriptor UseDefaultDevice();
 
         ///
-        /// This static method tries to set the specified device as the globally default, optionally acquiring an exclusive 
-        /// (cooperative) lock on the device (GPU). The default device can only be changed if it has not yet been frozen by being 
+        /// This static method tries to set the specified device as the globally default, optionally acquiring an exclusive
+        /// (cooperative) lock on the device (GPU). The default device can only be changed if it has not yet been frozen by being
         /// implicitly used in any previous CNTK operation.
         ///
-        /// CNTK uses cooperative locking for the device access, whereby only a single process can acquire 
+        /// CNTK uses cooperative locking for the device access, whereby only a single process can acquire
         /// a device lock. This locking mechanism allows CNTK processes to avoid device oversubscription only if they collectively
         /// choose so. In other words, the device locked by one CNTK process, can still be accessed by another CNTK process without
-        /// acquiring any locks (i.e, the existing device lock can be ignored by other CNTK processes). This cooperative 
-        /// locking mechanism does not guarantee any kind of exclusive access to the device. The proper way to ensure exclusivity 
+        /// acquiring any locks (i.e, the existing device lock can be ignored by other CNTK processes). This cooperative
+        /// locking mechanism does not guarantee any kind of exclusive access to the device. The proper way to ensure exclusivity
         /// is to use tools provided by NVIDIA (nvidia smi).
         ///
-        /// This methods returns false if  
+        /// This methods returns false if
         /// * the specified device appears in the list of excluded devices;
         /// * 'acquireDeviceLock' is true and another process already holds a lock on the device;
         /// * 'acquireDeviceLock' is true and 'newDefaultDevice' corresponds to a CPU device (which cannot be locked).
@@ -506,15 +506,15 @@ namespace CNTK
         CNTK_API static bool TrySetDefaultDevice(const DeviceDescriptor& newDefaultDevice, bool acquireDeviceLock = false);
 
         ///
-        /// Static method to retrieve additional properties (total memory, number of CUDA cores, etc.) for the specified GPU 
+        /// Static method to retrieve additional properties (total memory, number of CUDA cores, etc.) for the specified GPU
         /// device. This method will raise an exception if a CPU device is specified as an argument.
         ///
         CNTK_API static const GPUProperties& GetGPUProperties(const DeviceDescriptor& device);
 
         ///
         /// Static method to specify a list of excluded devices that cannot be used as globally default (neither auto-selected
-        /// nor explicitly specified by 'TrySetDefaultDevice'). For example, to avoid auto-selecting the CPU, invoke 
-        /// 'SetExcludedDevices({DeviceDescriptor::CPUDevice()})'. However, after the default device has been selected and 
+        /// nor explicitly specified by 'TrySetDefaultDevice'). For example, to avoid auto-selecting the CPU, invoke
+        /// 'SetExcludedDevices({DeviceDescriptor::CPUDevice()})'. However, after the default device has been selected and
         /// frozen (by a call to UseDefaultDevice()), invoking this methods has no effect, it becomes essentially a no-op.
         ///
         CNTK_API static void SetExcludedDevices(const std::vector<DeviceDescriptor>& excluded);
@@ -533,7 +533,7 @@ namespace CNTK
         DeviceDescriptor(unsigned int deviceId, DeviceKind deviceType)
             : m_deviceId(deviceId), m_deviceType(deviceType)
         {}
-        
+
         /// Resets static properties, needed for unit-tests.
         CNTK_API static void Reset();
 
@@ -564,9 +564,9 @@ namespace CNTK
         CNTK_API virtual Dictionary Serialize() const = 0;
 
         ///
-        /// Returns the current version (e.g. model, checkpoint version) of the class 
+        /// Returns the current version (e.g. model, checkpoint version) of the class
         /// implementing this interface. The version number must be incremented each time
-        /// when Serialize() implementation is modified (for instance, when a new field is added to 
+        /// when Serialize() implementation is modified (for instance, when a new field is added to
         /// the class that needs to be captured in the dictionary generated by the Serialize method).
         ///
         CNTK_API virtual size_t CurrentVersion() const = 0;
@@ -679,7 +679,7 @@ namespace CNTK
         }
 
         ///
-        /// Construct a NDArrayView over newly allocated dense storage on the specified device and 
+        /// Construct a NDArrayView over newly allocated dense storage on the specified device and
         /// assign the specified value to each element of the view.
         ///
         template <typename ElementType>
@@ -721,19 +721,19 @@ namespace CNTK
         ///
         /// Returns a writable pointer to the data buffer underlying 'this' view
         /// Throws an exception if 'this' view is read-only
-        /// 
+        ///
         template <typename ElementType>
         CNTK_API ElementType* WritableDataBuffer();
 
         ///
         /// Returns a read-only pointer to the data buffer underlying 'this' view
-        /// 
+        ///
         template <typename ElementType>
         CNTK_API const ElementType* DataBuffer() const;
 
         ///
         /// Returns a read-only pointer to the data buffer in sparse CSC format underlying 'this' view
-        /// 
+        ///
         template <typename ElementType>
         CNTK_API std::tuple<const ElementType *, const SparseIndexType*, const SparseIndexType*, size_t> SparseCSCDataBuffers() const;
 
@@ -908,7 +908,7 @@ namespace CNTK
     public:
         ///
         /// Construct a new Mask object of specified shape
-        /// 
+        ///
         CNTK_API explicit NDMask(const NDShape& shape, const DeviceDescriptor& device = DeviceDescriptor::CPUDevice());
 
         ///
@@ -925,7 +925,7 @@ namespace CNTK
         }
 
         ///
-        /// Mark the specified position in 'this' mask as sequence begin 
+        /// Mark the specified position in 'this' mask as sequence begin
         ///
         void MarkSequenceBegin(const std::vector<size_t>& offset)
         {
@@ -934,7 +934,7 @@ namespace CNTK
         }
 
         ///
-        /// Mark the specified sub-section of 'this' mask as sequence begin 
+        /// Mark the specified sub-section of 'this' mask as sequence begin
         ///
         void MarkSequenceBegin(const std::vector<size_t>& offset, const NDShape& sectionShape)
         {
@@ -963,7 +963,7 @@ namespace CNTK
 
         ///
         /// Returns a read-only pointer to the data buffer underlying 'this' Mask object
-        /// 
+        ///
         CNTK_API const MaskKind* DataBuffer() const;
 
         ///
@@ -1009,8 +1009,8 @@ namespace CNTK
 
     ///
     /// Denotes an Axis of a Variable and is used for specifying the axes parameters of certain Functions such as reductions.
-    /// Besides the static axes corresponding to each of the axes of the Variable's shape, Variables of kind 'Input' and any 
-    /// 'Output' Variables dependent on an 'Input' Variable also have 2 additional dynamic axes whose dimensions are known only 
+    /// Besides the static axes corresponding to each of the axes of the Variable's shape, Variables of kind 'Input' and any
+    /// 'Output' Variables dependent on an 'Input' Variable also have 2 additional dynamic axes whose dimensions are known only
     /// when the Variable is bound to actual data during compute (viz. sequence axis and batch axis denoting the axis along which
     /// multiple sequences are batched)
     ///
@@ -1080,7 +1080,7 @@ namespace CNTK
         ///
         /// Returns a boolean indicating if 'this' Axis corresponds to a static axis
         ///
-        bool IsStaticAxis() const 
+        bool IsStaticAxis() const
         {
             return ((m_staticAxisIdx != SentinelStaticAxisIndexValueForDynamicAxes) &&
                     (m_staticAxisIdx != SentinelStaticAxisIndexValueForAllStaticAxes) &&
@@ -1666,8 +1666,8 @@ namespace CNTK
 
         size_t Size() const { return m_dictionaryData->size();  }
 
-        std::unordered_set<std::wstring> Keys() 
-        { 
+        std::unordered_set<std::wstring> Keys()
+        {
             std::unordered_set<std::wstring> keys;
             for (const auto& kv : *m_dictionaryData)
                 keys.insert(kv.first);
@@ -1782,10 +1782,10 @@ namespace CNTK
         ///
         CNTK_API operator FunctionPtr() const;
 
-        /// 
-        /// Default constructor for creating an invalid/null Variable instance. 
+        ///
+        /// Default constructor for creating an invalid/null Variable instance.
         /// Required for use in a std::vector container.
-        /// 
+        ///
         Variable() {}
 
         ///
@@ -1865,7 +1865,7 @@ namespace CNTK
         CNTK_API std::wstring AsString() const;
 
         ///
-        /// Returns this Variable's timestamp. 
+        /// Returns this Variable's timestamp.
         /// Timestamps are used to determine if a Variable's value is up to date and, if not, computations that depend on this Variable's value will be re-executed.
         ///
         CNTK_API size_t CurrentValueTimeStamp() const;
@@ -2137,7 +2137,7 @@ private:
         }
 
         ///
-        /// Copies the contents of the 'value' NDArrayView into the view backing 'this' 
+        /// Copies the contents of the 'value' NDArrayView into the view backing 'this'
         /// parameter's value. The shapes of both views must be identical.
         ///
         CNTK_API void SetValue(const NDArrayViewPtr& value)
@@ -2157,7 +2157,7 @@ private:
         }
     };
 
-    // Implementation note: The Variable type is a value type and not polymorphic in nature. 
+    // Implementation note: The Variable type is a value type and not polymorphic in nature.
     // However we have a couple of derivatives of the type to extend the base interface and thus we ensure that the derived types do not have additional fields.
     // This check is weak in that the derives types may sneak in some additional fields if the base type had some padding at the end, without changing the object size
     // but it should be good enough for catching any accidental addition of fields.
@@ -2199,7 +2199,7 @@ private:
         {}
 
         ///
-        /// Create a clone of 'this' constant with the specified DataType. 
+        /// Create a clone of 'this' constant with the specified DataType.
         /// This only supports converting from a lower precision type to a higher precision type (e.g. DataType::Float to DataType::Double)
         ///
         CNTK_API Constant CloneAs(DataType dataType) const;
@@ -2240,7 +2240,7 @@ private:
         }
 
         ///
-        /// Copies the contents of the 'value' NDArrayView into the view backing 'this' 
+        /// Copies the contents of the 'value' NDArrayView into the view backing 'this'
         /// Constant's value. The shapes of both views must be identical.
         ///
         CNTK_API void SetValue(const NDArrayViewPtr& value);
@@ -2257,7 +2257,7 @@ private:
         CNTK_API Constant(const NDShape& shape, DataType dataType, const ParameterInitializer& initializer, const DeviceDescriptor& device = DeviceDescriptor::UseDefaultDevice(), const std::wstring& name = L"");
     };
 
-    // Implementation note: The Variable type is a value type and not polymorphic in nature. 
+    // Implementation note: The Variable type is a value type and not polymorphic in nature.
     // However we have a couple of derivatives of the type to extend the base interface and thus we ensure that the derived types do not have additional fields.
     // This check is weak in that the derives types may sneak in some additional fields if the base type had some padding at the end, without changing the object size
     // but it should be good enough for catching any accidental addition of fields.
@@ -2265,7 +2265,7 @@ private:
 }
 
 namespace std {
-    
+
     template <> struct hash<::CNTK::NDShape>
     {
         size_t operator()(const ::CNTK::NDShape& x) const
@@ -2331,7 +2331,7 @@ namespace CNTK
 
         ///
         /// Create a new Value object containing a collection of variable length sequences.
-        /// The sequenceStartFlags argument allows specifying for each sequence whether that sequence is a 
+        /// The sequenceStartFlags argument allows specifying for each sequence whether that sequence is a
         /// a new sequence or continuation of a previous sequence at the same index in the
         /// sequences vector from a previous call to this method.
         /// The created Value object contains a copy of the specified 'sequences' data.
@@ -2694,7 +2694,7 @@ namespace CNTK
         virtual void Erase();
 
         ///
-        /// Unpacks sequences in 'this' Value as a vector of NDArrayView objects, each represeting a sequence in the 
+        /// Unpacks sequences in 'this' Value as a vector of NDArrayView objects, each represeting a sequence in the
         /// batch of sequences that 'this' Value object contains data for.
         /// Besides the NDArrayView objects (that represent contents of each sequence), this method also returns
         /// the sequence start information for each sequence, which indicates whether that sequence is the start of
@@ -2737,7 +2737,7 @@ namespace CNTK
         }
 
         ///
-        /// Unpacks sequences in 'this' Value as a vector of NDArrayView objects, each represeting a sequence in the 
+        /// Unpacks sequences in 'this' Value as a vector of NDArrayView objects, each represeting a sequence in the
         /// batch of sequences that 'this' Value object contains data for.
         /// Besides the NDArrayView objects (that represent contents of each sequence), this method also returns
         /// the sequence start information for each sequence, which indicates whether that sequence is the start of
@@ -2967,7 +2967,7 @@ namespace CNTK
         Clone,
 
         ///
-        /// Parameters are cloned and made immutable; i.e. Constants in the new clone 
+        /// Parameters are cloned and made immutable; i.e. Constants in the new clone
         /// (e.g. for use as a fixed feature extractor)
         ///
         Freeze,
@@ -2981,7 +2981,7 @@ namespace CNTK
     ///
     /// Defines a signature of the deserialize callback for user defined functions,
     /// that needs to be provided to Function::Load to inflate user defined functions in the model.
-    /// This callback reconstructs a user defined function given its inputs, name and a dictionary 
+    /// This callback reconstructs a user defined function given its inputs, name and a dictionary
     /// containing its state.
     ///
     typedef std::function<FunctionPtr(const std::vector<Variable>& /*inputs*/,
@@ -2990,14 +2990,14 @@ namespace CNTK
 
     typedef std::shared_ptr<UDFDeserializeCallback> UDFDeserializeCallbackPtr;
 
-    static auto NoOp = [] (const std::vector<Variable>&, const std::wstring&, const Dictionary&) 
+    static auto NoOp = [] (const std::vector<Variable>&, const std::wstring&, const Dictionary&)
     {
         return nullptr;
     };
 
     ///
     /// Represents a function (optionally differentiable w.r.t. its inputs)
-    /// A Function denotes a symbolic computation with zero or more input arguments and one or more outputs. 
+    /// A Function denotes a symbolic computation with zero or more input arguments and one or more outputs.
     /// A Function may be primitive or composite (comprised of other Function instances whose inputs and outputs are wired together).
     /// A Function effectively is a computation graph composed of other primitive Functions (denoting computation) as nodes and Variable objects
     /// (denoting data) as the edges and leaves of the graph.
@@ -3019,13 +3019,13 @@ namespace CNTK
         ///
         /// Computes and stores the values of specified variables in the 'outputs' map, using provided 'inputs' values corresponding
         /// to each leaf variable of the Function of VariableKind 'Input'.
-        /// The variables specified in the 'outputs' map denote the subset of 'this' Function's output variables that the caller wants to obtain values of. 
+        /// The variables specified in the 'outputs' map denote the subset of 'this' Function's output variables that the caller wants to obtain values of.
         /// Callers may specify the storage to be used for storing the 'outputs' Values or pass null in which case the implementation allocates the actual storage
-        /// for the 'outputs' for which the ValuePtr mapping was left null by the caller. If a null Value was specified, the implementation created Value objects 
+        /// for the 'outputs' for which the ValuePtr mapping was left null by the caller. If a null Value was specified, the implementation created Value objects
         /// are temporary and only guaranteed to be valid until the next Forward/Backward call. You must explicitly clone the temporay Values if they need to be accessed later.
         /// The optional 'outputsToRetainBackwardStateFor' parameter specifies the subset of the Function's output variables for which gradients will be specified
         /// in a subsequent Backward call for backpropagation.
-        /// The method returns a BackPropState object containing all intermediate variable values needed during backpropagation of gradients from the 
+        /// The method returns a BackPropState object containing all intermediate variable values needed during backpropagation of gradients from the
         /// 'outputsToRetainBackwardStateFor' outputs of the Function to any of the inputs of the Function, in a subsequent Backward call.
         /// Note that the returned BackPropState instance also stores a reference to the supplied 'inputs' Values and generated 'outputs' Values
         /// and the user is responsible for ensuring that the contents of the inputs and outputs are unchanged until after any uses of the BackPropState instance
@@ -3041,10 +3041,10 @@ namespace CNTK
         /// Backpropagates supplied 'rootGradientValues' for one or more of the output variables of the Function, to produce gradient Values
         /// corresponding to the specified set of input variables in 'backPropagatedGradientValuesForInputs'.
         /// Callers may specify the actual storage to be used for storing the 'backPropagatedGradientValuesForInputs' Values or leave them to be null
-        /// in which case the implementation allocates the actual storage for storing the gradients. If a null Value was specified, the implementation created Value objects 
+        /// in which case the implementation allocates the actual storage for storing the gradients. If a null Value was specified, the implementation created Value objects
         /// are temporary and only guaranteed to be valid until the next Forward/Backward call. You must explicitly clone the temporay Values if they need to be accessed later.
         /// In case an existing storage is specified, the gradients are aggregated with existing values in the specified storage.
-        /// The 'state' parameter is an instance of an BackPropState instance obtained from a previous call to the Forward method on 'this; Function for the 
+        /// The 'state' parameter is an instance of an BackPropState instance obtained from a previous call to the Forward method on 'this; Function for the
         /// computation that this gradient backpropagation corresponds to.
         ///
         CNTK_API virtual void Backward(const BackPropStatePtr& state,
@@ -3054,13 +3054,13 @@ namespace CNTK
     protected:
         ///
         /// Computes and stores the values of specified variables in the 'outputs' map, using provided 'inputs' values for each input of the Function.
-        /// The variables specified in the 'outputs' map denote the subset of 'this' Function's output variables that the caller wants to obtain values of. 
+        /// The variables specified in the 'outputs' map denote the subset of 'this' Function's output variables that the caller wants to obtain values of.
         /// Callers may specify the storage to be used for storing the 'outputs' Values or pass null in which case the implementation allocates the actual storage
-        /// for the 'outputs' for which the ValuePtr mapping was left null by the caller.  If a null Value was specified, the implementation created Value objects 
+        /// for the 'outputs' for which the ValuePtr mapping was left null by the caller.  If a null Value was specified, the implementation created Value objects
         /// are temporary and only guaranteed to be valid until the next Forward/Backward call. You must explicitly clone the temporay Values if they need to be accessed later.
         /// The optional 'outputsToRetainBackwardStateFor' parameter specifies the subset of the Function's output variables for which gradients will be specified
         /// in a subsequent Backward call for backpropagation.
-        /// The method returns a BackPropState object containing all intermediate variable values needed during backpropagation of gradients from the 
+        /// The method returns a BackPropState object containing all intermediate variable values needed during backpropagation of gradients from the
         /// 'outputsToRetainBackwardStateFor' outputs of the Function to any of the inputs of the Function, in a subsequent Backward call.
         /// Note that the returned BackPropState instance also stores a reference to the supplied 'inputs' Values and generated 'outputs' Values
         /// and the user is responsible for ensuring that the contents of the inputs and outputs are unchanged until after any uses of the BackPropState instance
@@ -3073,7 +3073,7 @@ namespace CNTK
                                          const std::unordered_set<Variable>& outputsToRetainBackwardStateFor = {}) = 0;
 
         ///
-        /// Infers the shape, data type and dynamic axes of the outputs of 'this' function based on the 
+        /// Infers the shape, data type and dynamic axes of the outputs of 'this' function based on the
         /// Function's inputs, and returns Output Variable objects containing the inferred information
         /// Result cannot exceed the max number of outputs (128).
         /// The passed "outputs" vector should also reserve 128 elements in order to not cause memory allocation during
@@ -3089,8 +3089,8 @@ namespace CNTK
         CNTK_API virtual std::wstring ModuleName() const;
 
         ///
-        /// Returns the name of the method which should be invoked to deserialize this function. For native functions 
-        /// registered through a call to 'RegisterNativeUserFunction', unless overridden, this method return the value 
+        /// Returns the name of the method which should be invoked to deserialize this function. For native functions
+        /// registered through a call to 'RegisterNativeUserFunction', unless overridden, this method return the value
         /// of the 'factoryMethodName' argument. If overridden, it must have the same signature as the factory method.
         ///
         CNTK_API virtual std::wstring DeserializeMethodName() const;
@@ -3119,7 +3119,7 @@ namespace CNTK
         ///
         CNTK_API virtual Dictionary Serialize() const override { return Attributes(); }
 
-        /// 
+        ///
         /// Creates a clone of this Function instance, using the specified 'inputs' that are inputs of the clone to be constructed.
         ///
         CNTK_API virtual FunctionPtr Clone(const std::vector<Variable>& /*clonedInputs*/) { NOT_IMPLEMENTED; }
@@ -3167,11 +3167,11 @@ namespace CNTK
         CNTK_API FunctionPtr Clone(ParameterCloningMethod parameterCloneMethod = ParameterCloningMethod::Clone, const std::unordered_map<Variable, Variable>& replacements = {}) const;
 
         ///
-        /// Deserializes a Function from the model dictionary, using the specified UDF deserializer to 
-        //  reconstruct user defined functions if the model contains any (in which case an exception will be raised 
+        /// Deserializes a Function from the model dictionary, using the specified UDF deserializer to
+        //  reconstruct user defined functions if the model contains any (in which case an exception will be raised
         /// if deserializer was omitted). If there are no user defined functions in the model, deserializer is ignored.
         ///
-        CNTK_API static FunctionPtr Deserialize(const Dictionary& dictionary, 
+        CNTK_API static FunctionPtr Deserialize(const Dictionary& dictionary,
                                                 const ::CNTK::DeviceDescriptor& device = DeviceDescriptor::UseDefaultDevice());
 
     public:
@@ -3368,7 +3368,7 @@ namespace CNTK
         ///
         /// Load a Function from a model file
         ///
-        CNTK_API static FunctionPtr Load(const std::wstring& filepath, 
+        CNTK_API static FunctionPtr Load(const std::wstring& filepath,
                                          const DeviceDescriptor& computeDevice = DeviceDescriptor::UseDefaultDevice());
 
         ///
@@ -3380,7 +3380,7 @@ namespace CNTK
         ///
         /// Load a Function from an istream. The legacy V1 model is not supported.
         ///
-        CNTK_API static FunctionPtr Load(std::istream& inputStream, 
+        CNTK_API static FunctionPtr Load(std::istream& inputStream,
                                          const DeviceDescriptor& computeDevice = DeviceDescriptor::UseDefaultDevice());
 
         ///
@@ -3388,16 +3388,16 @@ namespace CNTK
         ///
         CNTK_API std::wstring AsString(bool doNotInferOutputs = true) const;
 
-        /// 
+        ///
         /// Allows to change a function attribute. Currently supported:
         ///
-        /// * 'dropoutRate' with the corresponding float or double value. Modifies the dropout rate 
+        /// * 'dropoutRate' with the corresponding float or double value. Modifies the dropout rate
         /// of a dropout function (can only be invoked on a function instance returned from
         /// the Dropout() method or a primitive dropout function returned from FindByName()).
         ///
-        /// * 'rngSeed' with the corresponding int or size_t value. Modifies the seed of a stateful function, 
+        /// * 'rngSeed' with the corresponding int or size_t value. Modifies the seed of a stateful function,
         /// i.e., Dropout, RandomSample or RandomSampleInclusionFrequency (can only be invoked on a
-        /// function instance returned from the Dropout(), RandomSample(), RandomSampleInclusionFrequency() 
+        /// function instance returned from the Dropout(), RandomSample(), RandomSampleInclusionFrequency()
         /// method or a corresponding primitive function returned from FindByName()).
         ///
         CNTK_API void SetAttribute(const std::wstring& name, const DictionaryValue& value);
@@ -3422,8 +3422,8 @@ namespace CNTK
 
         ///
         /// Register a callback function to be invoked when deserializing a user-defined Function with the corresponding op name.
-        /// When loading a model, CNTK will try to automatically reconstruct user-defined Functions (for native functions, CNTK will 
-        /// invoke the same factory method, the Function op name was registered with). This method allows to override 
+        /// When loading a model, CNTK will try to automatically reconstruct user-defined Functions (for native functions, CNTK will
+        /// invoke the same factory method, the Function op name was registered with). This method allows to override
         /// default user-defined Function deserialization behavior by specifying an op name and the corresponding callback that should be invoked
         /// to inflate the Function object.
         ///
@@ -4150,27 +4150,29 @@ namespace CNTK
     }
 
     ///
-    /// Convolution 
+    /// Convolution
     ///
     CNTK_API FunctionPtr Convolution(const Variable& convolutionMap,
-                                     const Variable& operand, 
+                                     const Variable& operand,
                                      const NDShape& strides = { 1 },
                                      const std::vector<bool>& sharing = { true },
                                      const std::vector<bool>& autoPadding = { true },
-                                     size_t maxTempMemSizeInSamples = 0, 
+                                     const NDShape& dilation = { 1 },
+                                     size_t maxTempMemSizeInSamples = 0,
                                      const std::wstring& name = L"");
 
     ///
     /// Convolution transpose
     ///
     CNTK_API FunctionPtr ConvolutionTranspose(const Variable& convolutionMap,
-        const Variable& operand,
-        const NDShape& strides = { 1 },
-        const std::vector<bool>& sharing = { true },
-        const std::vector<bool>& autoPadding = { true },
-        const NDShape& outputShape = { 0 },
-        size_t maxTempMemSizeInSamples = 0,
-        const std::wstring& name = L"");
+                                              const Variable& operand,
+                                              const NDShape& strides = { 1 },
+                                              const std::vector<bool>& sharing = { true },
+                                              const std::vector<bool>& autoPadding = { true },
+                                              const NDShape& dilation = { 1 },
+                                              const NDShape& outputShape = { 0 },
+                                              size_t maxTempMemSizeInSamples = 0,
+                                              const std::wstring& name = L"");
 
     ///
     /// TODO:
@@ -4184,11 +4186,11 @@ namespace CNTK
     ///
     /// Create an instance of the CNTK built-in ROI pooling operation on specified tensor input operands with the specified output shape
     ///
-    CNTK_API FunctionPtr ROIPooling(const Variable& operand, 
-                                    const Variable& rois, 
-                                    PoolingType poolingType, 
-                                    const NDShape& roiOutputShape, 
-                                    double spatialScale, 
+    CNTK_API FunctionPtr ROIPooling(const Variable& operand,
+                                    const Variable& rois,
+                                    PoolingType poolingType,
+                                    const NDShape& roiOutputShape,
+                                    double spatialScale,
                                     const std::wstring& name/* = L""*/);
 
     ///
@@ -4251,7 +4253,7 @@ namespace CNTK
     CNTK_API FunctionPtr Splice(const std::vector<Variable>& operands, const Axis& axis, const std::wstring& name = L"");
 
     ///
-    /// Create a new Function instance which just combines the outputs of the specified list of 'operands' Functions such that the 'Outputs' of the 
+    /// Create a new Function instance which just combines the outputs of the specified list of 'operands' Functions such that the 'Outputs' of the
     /// new 'Function' are union of the 'Outputs' of each of the specified 'operands' Functions.
     /// E.g. When creating a classification model, typically the CrossEntropy loss Function and the ClassificationError Function comprise the two roots
     /// of the computation graph which can be "Combine"d to create a single Function with 2 outputs; viz. CrossEntropy loss and ClassificationError output.
@@ -4270,7 +4272,7 @@ namespace CNTK
     CNTK_API FunctionPtr AsBlock(FunctionPtr&& composite, const std::vector<std::pair<Variable, Variable>>& argumentsMap, const std::wstring& blockOpName, const std::wstring& blockName = L"");
 
     ///
-    /// Creates a new Function instance which output its input as it is and previent any gradient contribution from its output. 
+    /// Creates a new Function instance which output its input as it is and previent any gradient contribution from its output.
     ///
     CNTK_API FunctionPtr StopGradient(const Variable& operand, const std::wstring& name = L"");
 
@@ -4280,7 +4282,7 @@ namespace CNTK
     /// the graph that depend on ref will get the old value. To get the new value, use the one returned by
     /// the assign node.The reason for that is to make ``assign`` have a deterministic behavior.
     /// During inference the value of ref wull be updated after the forward pass and during training the value
-    /// of ref will be updated after backprop. 
+    /// of ref will be updated after backprop.
     ///
     CNTK_API FunctionPtr Assign(Variable& ref, const Variable& operand, const std::wstring& name = L"");
 
@@ -4307,13 +4309,13 @@ namespace CNTK
     CNTK_API FunctionPtr LeakyReLU(const Variable& operand, const std::wstring& name = L"");
 
     ///
-    /// Create an instance of the CNTK built-in elementwise parametric rectified linear Unit operation 
+    /// Create an instance of the CNTK built-in elementwise parametric rectified linear Unit operation
     /// with the specified input operand and learning parameter alpha.
     ///
     CNTK_API FunctionPtr PReLU(const Variable& alpha, const Variable& operand, const std::wstring& name = L"");
 
     ///
-    /// Create an instance of the CNTK built-in elementwise softplus operation 
+    /// Create an instance of the CNTK built-in elementwise softplus operation
     ///
     CNTK_API FunctionPtr Softplus(const Variable& operand, const std::wstring& name = L"");
 
@@ -4326,7 +4328,7 @@ namespace CNTK
     /// Create an instance of the CNTK built-in argmin on specified tensor input operand along the specified axis
     ///
     CNTK_API FunctionPtr Argmin(const Variable& operand, const Axis& axis, const std::wstring& name = L"");
- 
+
     ///
     /// Create an instance of the CNTK built-in operator for converting the specified tensor operand into a sequence
     ///
@@ -4381,7 +4383,7 @@ namespace CNTK
         CNTK_API FunctionPtr BroadcastAs(const Variable& operand, const Variable& broadcastAs, const std::wstring& name = L"");
 
         ///
-        /// Create an instance of the CNTK built-in operator for unpacking the specified sequence operand along 
+        /// Create an instance of the CNTK built-in operator for unpacking the specified sequence operand along
         /// the most significant static axis [-1] and padding any gaps with the specified padding value.
         /// If supressMaskOutput is false, the returned Function has 2 outputs; viz. the unpacked non-sequence data and a mask
         /// denoting the gaps in the unpacked output due to differences across lengths of the sequences in the operand.
@@ -4392,9 +4394,9 @@ namespace CNTK
     ///
     /// A collection of key-value pairs that represents a training parameter schedule
     /// (e.g., learning rate, momentum schedule) in terms of the number of samples.
-    /// This class is designed to simplify Learner's factory methods and provides a number of 
-    /// convenience constructors to allow easy conversion from a single value, a vector of values 
-    /// and a list of pairs to the training schedule. For example, a learning rate schedule 
+    /// This class is designed to simplify Learner's factory methods and provides a number of
+    /// convenience constructors to allow easy conversion from a single value, a vector of values
+    /// and a list of pairs to the training schedule. For example, a learning rate schedule
     /// { { 10, 0.5 }, { 100, 0.3 }, { 20, 0.2 } } indicates that the rate of 0.5 should be
     /// used for the first 10 samples, followed by 0.3 for the next 100 samples, and then 0.2 for
     /// the remaining 20 samples or until the end of training if it takes longer.
@@ -4404,7 +4406,7 @@ namespace CNTK
     {
     public:
         ///
-        /// Indicates whether the values in the schedule are specified on the per-sample or 
+        /// Indicates whether the values in the schedule are specified on the per-sample or
         /// per-minibatch basis.
         ///
         enum class UnitType : unsigned int
@@ -4431,24 +4433,24 @@ namespace CNTK
         CNTK_API TrainingParameterSchedule(const std::vector<T>& schedule, UnitType unit, size_t epochSize = FullDataSweep);
 
         ///
-        /// Create a schedule using the list of key-value pairs, where the key specifies 
+        /// Create a schedule using the list of key-value pairs, where the key specifies
         /// the number of epochs the parameter should maintain the corresponding value,
-        /// (which 'epochSize' samples in each epoch). The value from the last pair is used 
-        /// repeatedly until the end of training. For example, {{1, 0.05}, {2, 0.1}, {1, 0.005}} 
-        /// and epochSize = 100, corresponds to a schedule where the value of '0.05' is used for 
-        /// the first 100 samples, then '0.1' is used for the second 200 samples, 
+        /// (which 'epochSize' samples in each epoch). The value from the last pair is used
+        /// repeatedly until the end of training. For example, {{1, 0.05}, {2, 0.1}, {1, 0.005}}
+        /// and epochSize = 100, corresponds to a schedule where the value of '0.05' is used for
+        /// the first 100 samples, then '0.1' is used for the second 200 samples,
         /// after which the values is switched to '0.005'.
         ///
         CNTK_API TrainingParameterSchedule(const std::vector<std::pair<size_t, T>>& schedule, UnitType unit, size_t epochSize = FullDataSweep);
 
         ///
-        /// Returns a value corresponding to the absolute sample (or sweep) 
+        /// Returns a value corresponding to the absolute sample (or sweep)
         /// count from the beginning of training.
         ///
         CNTK_API const T& operator[](size_t count) const;
 
         ///
-        /// Returns the unit type for 'this' training parameter schedule. 
+        /// Returns the unit type for 'this' training parameter schedule.
         /// In case when the values are specified on the per-Minibatch basis, they are
         /// re-scaled by the learner using the actual minibatch size in samples.
         ///
@@ -4458,9 +4460,9 @@ namespace CNTK
 
         CNTK_API virtual ~TrainingParameterSchedule();
 
-        CNTK_API TrainingParameterSchedule(const TrainingParameterSchedule<T>&); 
-        CNTK_API TrainingParameterSchedule(TrainingParameterSchedule<T>&&); 
-        CNTK_API TrainingParameterSchedule<T>& operator=(const TrainingParameterSchedule<T>&); 
+        CNTK_API TrainingParameterSchedule(const TrainingParameterSchedule<T>&);
+        CNTK_API TrainingParameterSchedule(TrainingParameterSchedule<T>&&);
+        CNTK_API TrainingParameterSchedule<T>& operator=(const TrainingParameterSchedule<T>&);
         CNTK_API TrainingParameterSchedule<T>& operator=(TrainingParameterSchedule<T>&&);
 
         CNTK_API virtual Dictionary Serialize() const override;
@@ -4479,7 +4481,7 @@ namespace CNTK
 
         static const size_t s_serializationVersion = 1;
 
-    protected:           
+    protected:
         std::map<size_t, T> m_schedule;
         UnitType m_unit;
         size_t m_epochSize;
@@ -4493,13 +4495,13 @@ namespace CNTK
             : TrainingParameterSchedule<T>::TrainingParameterSchedule(value, U)
         { }
 
-        TrainingParameterPerUnitSchedule(const std::vector<T>& schedule, 
+        TrainingParameterPerUnitSchedule(const std::vector<T>& schedule,
                                          size_t epochSize = TrainingParameterSchedule<T>::FullDataSweep)
             : TrainingParameterSchedule<T>::TrainingParameterSchedule(schedule, U, epochSize)
         { }
 
 
-        TrainingParameterPerUnitSchedule(const std::vector<std::pair<size_t, T>>& schedule, 
+        TrainingParameterPerUnitSchedule(const std::vector<std::pair<size_t, T>>& schedule,
                                          size_t epochSize = TrainingParameterSchedule<T>::FullDataSweep)
             : TrainingParameterSchedule<T>::TrainingParameterSchedule(schedule, U, epochSize)
         { }
@@ -4538,28 +4540,28 @@ namespace CNTK
     typedef TrainingParameterSchedule<double> MomentumSchedule;
 
     ///
-    /// This class allows to specify momentum as time constant in place of momentum per sample in 
-    /// all of Learners factory methods. The specified values are then automatically converted into 
+    /// This class allows to specify momentum as time constant in place of momentum per sample in
+    /// all of Learners factory methods. The specified values are then automatically converted into
     /// per sample values.
     ///
     class MomentumAsTimeConstantSchedule: public TrainingParameterSchedule<double>
     {
     public:
-        MomentumAsTimeConstantSchedule(double value) 
+        MomentumAsTimeConstantSchedule(double value)
             : TrainingParameterSchedule<double>::TrainingParameterSchedule(value, UnitType::Sample)
-        { 
+        {
             ConvertToPerSampleValues();
         }
-        
-        MomentumAsTimeConstantSchedule(const std::vector<double>& schedule, size_t epochSize = FullDataSweep) 
-            : TrainingParameterSchedule<double>::TrainingParameterSchedule(schedule, UnitType::Sample, epochSize) 
-        { 
-            ConvertToPerSampleValues();
-        }
-        
-        MomentumAsTimeConstantSchedule(const std::vector<std::pair<size_t, double>>& schedule, size_t epochSize = FullDataSweep) 
+
+        MomentumAsTimeConstantSchedule(const std::vector<double>& schedule, size_t epochSize = FullDataSweep)
             : TrainingParameterSchedule<double>::TrainingParameterSchedule(schedule, UnitType::Sample, epochSize)
-        { 
+        {
+            ConvertToPerSampleValues();
+        }
+
+        MomentumAsTimeConstantSchedule(const std::vector<std::pair<size_t, double>>& schedule, size_t epochSize = FullDataSweep)
+            : TrainingParameterSchedule<double>::TrainingParameterSchedule(schedule, UnitType::Sample, epochSize)
+        {
             ConvertToPerSampleValues();
         }
 
@@ -4575,8 +4577,8 @@ namespace CNTK
     };
 
     ///
-    /// A collection of additional options that affect parameter updates and 
-    /// are applicable for all standard learners 
+    /// A collection of additional options that affect parameter updates and
+    /// are applicable for all standard learners
     ///
     struct AdditionalLearningOptions
     {
@@ -4595,22 +4597,22 @@ namespace CNTK
         bool useMeanGradient = false;
     };
 
-    ///  
+    ///
     /// Returns true if by default momentum is applied in the unit-gain fashion.
     ///
     CNTK_API bool DefaultUnitGainValue();
 
-    ///  
+    ///
     /// Sets globally default unit-gain flag value.
     ///
     CNTK_API void SetDefaultUnitGainValue(bool value);
 
-    ///  
+    ///
     /// Returns true if by default input gradient to learner is averaged.
     ///
     CNTK_API bool DefaultUseMeanGradientValue();
 
-    ///  
+    ///
     /// Sets globally default useMeanGradient value.
     ///
     CNTK_API void SetDefaultUseMeanGradientValue(bool value);
@@ -4657,7 +4659,7 @@ namespace CNTK
         ///
         /// Sets a new learning rate overriding the schedule parameter used to construct this learner.
         /// The new schedule is adjusted to be relative to the current number of elapsed samples/sweeps:
-        /// the 0 offset in the new schedule corresponds to the current value of elapsed samples/sweeps, 
+        /// the 0 offset in the new schedule corresponds to the current value of elapsed samples/sweeps,
         /// and it takes effect from the current position in the training process onwards.
         ///
         CNTK_API virtual void ResetLearningRate(const LearningRateSchedule& learningRateSchedule);
@@ -4797,7 +4799,7 @@ namespace CNTK
     ///
     /// A shorthand for the type of a function that takes a Parameter and a Variable as arguments and returns a Function.
     /// It can be used with UniversalLearner.
-    /// 
+    ///
     typedef std::function<FunctionPtr(Parameter, Variable)> ParameterUpdateFunctor;
 
     ///
@@ -4848,7 +4850,7 @@ namespace CNTK
         //
         // Returns the total number of samples needed for warmup.
         // After reaching this number of samples the learner switches to the distributed mode.
-        // Warm up is useful for 
+        // Warm up is useful for
         //
         virtual size_t ParallelizationAfter()
         {
@@ -5029,7 +5031,7 @@ namespace CNTK
         /// Returns false if all parameter learners indicate end of learning (through their Update method's return value).
         ///
         CNTK_API bool TrainMinibatch(const std::unordered_map<Variable, MinibatchData>& arguments, const DeviceDescriptor& computeDevice = DeviceDescriptor::UseDefaultDevice());
-        
+
         ///
         /// An overload of the TrainMinibatch above that takes a map of variables and their values (as its first argument).
         ///
@@ -5037,7 +5039,7 @@ namespace CNTK
 
         ///
         /// Optimize model parameters using the specified 'arguments' minibatch of training samples.
-        /// The variables specified in the 'outputsToFetch' map denote the subset of 'this' Function's output variables that the caller wants to obtain values of. 
+        /// The variables specified in the 'outputsToFetch' map denote the subset of 'this' Function's output variables that the caller wants to obtain values of.
         /// Callers may specify the storage to be used for storing the 'outputs' Values or pass null in which case the implementation allocates the actual storage
         /// for the 'outputs' for which the ValuePtr mapping was left null by the caller.
         /// Returns false if all parameter learners indicate end of learning (through their Update method's return value).
@@ -5119,7 +5121,7 @@ namespace CNTK
         bool TrainLocalMinibatch(const std::unordered_map<Variable, ValuePtr>& arguments, std::unordered_map<Variable, ValuePtr>& outputsToFetch, bool sweepEnd, const DeviceDescriptor& computeDevice);
         bool TrainDistributedMinibatch(const std::unordered_map<Variable, ValuePtr>& arguments, std::unordered_map<Variable, ValuePtr>& outputsToFetch, bool sweepEnd, const DeviceDescriptor& computeDevice);
 
-        void Save(const std::wstring& modelFilePath, const std::vector<DictionaryValue>& learnerState, 
+        void Save(const std::wstring& modelFilePath, const std::vector<DictionaryValue>& learnerState,
             const Dictionary& externalState, const Dictionary& distributedState = {});
 
         void UpdateTrainingProgress(size_t numSamples, const ValuePtr& loss, const ValuePtr& evalCriterion, const DeviceDescriptor& computeDevice);
@@ -5177,7 +5179,7 @@ namespace CNTK
     ///
     /// A struct that combines the minibatch meta-data with the actual minibatch data.
     /// The former includes the number of sequences and samples in the minibatch,
-    /// as well as the sweep-end flag, which is set to true to indicate that the minibatch 
+    /// as well as the sweep-end flag, which is set to true to indicate that the minibatch
     /// concludes a data sweep (i.e, it's the last minibatch at the end of the sweep).
     ///
     struct MinibatchData
@@ -5185,7 +5187,7 @@ namespace CNTK
         MinibatchData() : MinibatchData(nullptr)
         {}
 
-        // a convenience constructor to allow passing ValuePtr arguments in place 
+        // a convenience constructor to allow passing ValuePtr arguments in place
         // of MinibatchData parameter (e.g., in Trainer::TrainMinibatch)
         MinibatchData(ValuePtr value) : MinibatchData(value, 0)
         {}
@@ -5275,7 +5277,7 @@ namespace CNTK
 
     public:
         ///
-        /// Gets the description of the stream with given name. 
+        /// Gets the description of the stream with given name.
         /// Throws an exception of there are none or multiple streams with this same name.
         ///
         CNTK_API const StreamInformation& StreamInfo(const std::wstring& streamName);
@@ -5304,7 +5306,7 @@ namespace CNTK
 
     ///
     /// A configuration required to instantiate the CNTK built-in composite minibatch source.
-    /// 
+    ///
     struct MinibatchSourceConfig
     {
         ///
@@ -5314,31 +5316,31 @@ namespace CNTK
         ///
         CNTK_API MinibatchSourceConfig(const std::vector<Deserializer>& deserializers, bool randomize = true);
 
-        /// 
-        /// The maximum number of input samples (not 'label samples') the reader can produce 
-        /// (the default value is InfinitelyRepeat). After this number has been reached, the reader 
-        /// returns empty minibatches on subsequent calls to GetNextMinibatch(). 'maxSweeps' and 'maxSamples' 
+        ///
+        /// The maximum number of input samples (not 'label samples') the reader can produce
+        /// (the default value is InfinitelyRepeat). After this number has been reached, the reader
+        /// returns empty minibatches on subsequent calls to GetNextMinibatch(). 'maxSweeps' and 'maxSamples'
         /// are mutually exclusive, an exception will be raised if both have non-default values.
-        /// 
+        ///
         size_t maxSamples{ MinibatchSource::InfinitelyRepeat };
 
         ///
-        /// The maximum allowed number of sweeps over the input dataset. After this number has been reached, 
+        /// The maximum allowed number of sweeps over the input dataset. After this number has been reached,
         /// the reader returns empty minibatches on subsequent calls to GetNextMinibatch().
-        /// 'maxSweeps' and 'maxSamples' are mutually exclusive, an exception will be raised if both have 
+        /// 'maxSweeps' and 'maxSamples' are mutually exclusive, an exception will be raised if both have
         /// non-default values.
-        /// 
+        ///
         size_t maxSweeps{ MinibatchSource::InfinitelyRepeat };
 
         ///
-        /// Size of the randomization window in chunks, non-zero value enables randomization. 
+        /// Size of the randomization window in chunks, non-zero value enables randomization.
         /// 'randomizationWindowInChunks' and 'randomizationWindowInSamples' are mutually exclusive,
         /// an exception will be raised if both have non-zero values.
         ///
         size_t randomizationWindowInChunks{ MinibatchSource::DefaultRandomizationWindowInChunks };
 
         ///
-        /// Size of the randomization window in samples, non-zero value enables randomization. 
+        /// Size of the randomization window in samples, non-zero value enables randomization.
         /// 'randomizationWindowInChunks' and 'randomizationWindowInSamples' are mutually exclusive,
         /// an exception will be raised if both have non-zero values.
         ///
@@ -5356,7 +5358,7 @@ namespace CNTK
 
         ///
         /// Truncation length in samples, non-zero value enables the truncation (only applicable for BPTT,
-        /// cannot be used in frame mode, an exception will be raised if frame mode is enabled and the 
+        /// cannot be used in frame mode, an exception will be raised if frame mode is enabled and the
         /// truncation length is non-zero).
         ///
         size_t truncationLength{ 0 };
@@ -5369,8 +5371,8 @@ namespace CNTK
         bool isFrameModeEnabled{ false };
 
         ///
-        /// Specifies if the deserialization should be done on a single or multiple threads. 
-        /// Defaults to 'auto' (multhithreading is disabled unless ImageDeserializer is present 
+        /// Specifies if the deserialization should be done on a single or multiple threads.
+        /// Defaults to 'auto' (multhithreading is disabled unless ImageDeserializer is present
         /// in the deserializers list). 'false' and 'true' faithfully turn the multithreading off/on.
         ///
         Internal::Optional<bool> isMultithreaded;
@@ -5416,9 +5418,9 @@ namespace CNTK
 
     typedef Dictionary ImageTransform;
 
-    /// 
+    ///
     /// Create a crop transform with the specified options to be used with a reader
-    /// 
+    ///
     CNTK_API ImageTransform ReaderCrop(const wchar_t* cropType = L"center",
         std::pair<int, int> cropSize = std::make_pair(0, 0),
         std::pair<float, float> sideRatio = std::make_pair(0.0f, 0.0f),
@@ -5426,55 +5428,55 @@ namespace CNTK
         std::pair<float, float> aspectRatio = std::make_pair(1.0f, 1.0f),
         const wchar_t* jitterType = L"none");
 
-    /// 
+    ///
     /// Create a scale transform with the specified options to be used with a reader
-    /// 
+    ///
     CNTK_API ImageTransform ReaderScale(int width,
         int height, int channels, const wchar_t* interpolations = L"linear",
         const wchar_t* scaleMode = L"fill", int padValue = -1);
 
-    /// 
+    ///
     /// Create a mean subtraction transform with the specified options to be used with a reader
-    /// 
+    ///
     CNTK_API ImageTransform ReaderMean(const wchar_t* meanFile);
 
-    /// 
+    ///
     /// Create a color transform with the specified options to be used with a reader
-    /// 
+    ///
     CNTK_API ImageTransform ReaderColor(float brightnessRadius = 0.0f,
         float contrastRadius = 0.0f, float saturationRadius = 0.0f);
 
-    /// 
+    ///
     /// Create an ImageDeserializer with the specified options
-    /// 
+    ///
     CNTK_API  Deserializer ImageDeserializer(const std::wstring& fileName, const std::wstring& labelStreamName, size_t numLabels, const std::wstring& imageStreamName, const std::vector<ImageTransform>& transforms = {});
 
-    /// 
+    ///
     /// Create a Base64ImageDeserializer with the specified options
-    /// 
+    ///
     CNTK_API  Deserializer Base64ImageDeserializer(const std::wstring& fileName, const std::wstring& labelStreamName, size_t numLabels, const std::wstring& imageStreamName, const std::vector<ImageTransform>& transforms = {});
 
-    /// 
+    ///
     /// Create a CTFDeserializer with the specified options
-    /// 
+    ///
     CNTK_API  Deserializer CTFDeserializer(const std::wstring& fileName, const std::vector<StreamConfiguration>& streams);
 
-    /// 
+    ///
     /// Create a CBFDeserializer with the specified options
-    /// 
+    ///
     CNTK_API  Deserializer CBFDeserializer(const std::wstring& fileName, const std::vector<StreamConfiguration>& streams = {});
 
-    /// 
+    ///
     /// Create an HTKFeatureDeserializer with the specified options
-    /// 
+    ///
     CNTK_API  Deserializer HTKFeatureDeserializer(const std::vector<HTKFeatureConfiguration>& streams);
 
-    /// 
+    ///
     /// Create an HTKMLFDeserializer with the specified options
-    /// 
+    ///
     CNTK_API  Deserializer HTKMLFDeserializer(const std::wstring& streamName, const std::wstring& labelMappingFile, size_t dimension, const std::vector<std::wstring>& mlfFiles, bool phoneBoundaries = false);
 
-    /// 
+    ///
     /// Instantiate the CNTK built-in text format minibatch source
     ///
     inline MinibatchSourcePtr TextFormatMinibatchSource(const std::wstring& dataFilePath, const std::vector<StreamConfiguration>& streamConfigs,
@@ -5548,7 +5550,7 @@ namespace std
 namespace CNTK
 {
     ///
-    /// A communicator interface exposing communication primitives that serve as building blocks 
+    /// A communicator interface exposing communication primitives that serve as building blocks
     /// for distributed training.
     ///
     class DistributedCommunicator
@@ -5578,7 +5580,7 @@ namespace CNTK
             std::vector<DictionaryPtr>& output,
             const std::unordered_set<DistributedWorkerDescriptor>& sendToWorkers) = 0;
 
-        // A collective communication API to aggregate values across each worker of this communicator. 
+        // A collective communication API to aggregate values across each worker of this communicator.
         // The aggregated values are only sent to the specified workers; for all others the returned Values are null
         CNTK_API virtual void AggregateInPlace(
             const std::vector<NDArrayViewPtr>& values,
@@ -5864,7 +5866,7 @@ namespace CNTK
         ///
         /// The frequency arguments control a schedule on which the training/evaluation progress updates are written.
         /// The frequency value of 0 specifies geometric schedule, i.e. write progress after 1, 2, 4, 8, 16... updates.
-        /// The frequency value other than zero specifies arithmetic schedule, i.e. write progress after each 
+        /// The frequency value other than zero specifies arithmetic schedule, i.e. write progress after each
         /// 'frequency' updates.
         ///
         /// The firstUpdatesToWrite arguments only apply on arithemetic schedule. If specified, the first
@@ -5935,7 +5937,7 @@ namespace CNTK
         ///
         CNTK_API size_t TotalTestUpdates() const;
 
-        /// 
+        ///
         /// Updates the writer with the accumulated loss/metric since the start of training.
         ///
         void UpdateTraining(size_t numSamples, const ValuePtr& accumulatedLoss, const ValuePtr& accumulatedMetric);

--- a/Source/CNTKv2LibraryDll/API/CNTKLibraryInternals.h
+++ b/Source/CNTKv2LibraryDll/API/CNTKLibraryInternals.h
@@ -143,7 +143,7 @@ namespace CNTK
 {
     // Forward declarations
     class Utils;
-    class NDShape; 
+    class NDShape;
     class PrimitiveFunction;
     class CompositeFunction;
     class BlockFunction;
@@ -251,6 +251,7 @@ namespace CNTK
         CNTK_API FunctionPtr ReduceElements(const Variable& operand, const std::wstring& reductionOpName, const std::vector<Axis>& axes, bool keepReducedDimensions, const std::wstring& name = L"");
         CNTK_API FunctionPtr CosineDistanceWithNegativeSamples(const Variable& leftOperand, const Variable& rightOperand, const Variable& shiftWindow, const Variable& numberOfNegativeSamples, const std::wstring& name = L"");
         CNTK_API FunctionPtr Convolution(const Variable& convolutionMap, const Variable& operand, const NDShape& strides, const std::vector<bool>& sharing, const std::vector<bool>& autoPadding,
+                                         const NDShape& dilation,
                                          bool transpose, const NDShape& outputShape, size_t maxTempMemSizeInSamples, const std::wstring& name = L"");
 
         // This is meant for debugging purposes only and is very likely to be deprecated in the future.
@@ -322,8 +323,8 @@ namespace CNTK
         LearnerPtr UniversalLearner(const std::vector<::CNTK::Parameter>& parameters, const std::vector<std::pair<::CNTK::Variable, ::CNTK::FunctionPtr> >& updates);
 #else
         /// Convenience constructor that should be used by foreign language bindings.
-        /// Workaround declaration for SWIG. 
-        /// This is for now necessary because it has been elusive to find an equivalent of 
+        /// Workaround declaration for SWIG.
+        /// This is for now necessary because it has been elusive to find an equivalent of
         /// %template() std::vector<std::pair<CNTK::Variable, std::shared_ptr<CNTK::Function>>>;
         /// which will generate correct code (i.e. code that will accept a list of tuples in the foreign language)
         /// when the proper declaration is processed by SWIG.
@@ -410,7 +411,7 @@ namespace CNTK
         };
 
         typedef std::shared_ptr<UDFDeserializeCallbackWrapper> UDFDeserializeCallbackWrapperPtr;
-        
+
         CNTK_API void RegisterUDFDeserializeCallbackWrapper(UDFDeserializeCallbackWrapperPtr callbackPtr);
 
 
@@ -450,7 +451,7 @@ namespace CNTK
             }
 
             Optional(const Optional&) = default; Optional& operator=(const Optional&) = default;
-            Optional(Optional&&) = delete; Optional& operator=(Optional&&) = delete; 
+            Optional(Optional&&) = delete; Optional& operator=(Optional&&) = delete;
         private:
              T m_value;
              bool m_initialized { false };
@@ -458,7 +459,7 @@ namespace CNTK
     }
 
     // Forward-declare test fixtures, so that they can be used as friends.
-    namespace Test 
+    namespace Test
     {
         struct DeviceSelectionTestFixture;
     }

--- a/Source/CNTKv2LibraryDll/Function.cpp
+++ b/Source/CNTKv2LibraryDll/Function.cpp
@@ -154,7 +154,7 @@ namespace CNTK
 
     /*virtual*/ const std::wstring& Function::OpName() const
     {
-        static const std::wstring defaultUserFunctionOpName = L"UserFunction"; 
+        static const std::wstring defaultUserFunctionOpName = L"UserFunction";
         return defaultUserFunctionOpName;
     }
 
@@ -320,7 +320,7 @@ namespace CNTK
         auto primitiveRootFunctionPtr = dynamic_cast<const PrimitiveFunction*>(primitiveRootFunction.get());
         if (primitiveRootFunctionPtr && (primitiveRootFunctionPtr->OpType() == PrimitiveOpType::Combine))
         {
-            // Combine's outputs are just a copy of its inputs and any replacements need to be properly 
+            // Combine's outputs are just a copy of its inputs and any replacements need to be properly
             // reflected in the outputs as well
             for (auto& outputVar : InitOutputs())
                 ReplacePlaceholderInPlace(outputVar, placeholderReplacements, replacedPlaceholders);
@@ -612,7 +612,7 @@ namespace CNTK
         if (placeholders.size() != 1)
             InvalidArgument("ReplacePlaceholder called with a single replacement Variable '%S' but this Function '%S' has %d placeholders '%S'",
                             placeholderReplacement.AsString().c_str(),
-                            this->AsString().c_str(),                            
+                            this->AsString().c_str(),
                             (int)placeholders.size(),
                             NamedListString(placeholders).c_str());
 
@@ -790,7 +790,7 @@ namespace CNTK
             }
 
             // We will not have the block's internal composite create new clones of Parameters/Constants since
-            // in the case we want to really clone, they have been cloned as part of cloning the inputs of the 
+            // in the case we want to really clone, they have been cloned as part of cloning the inputs of the
             // block and will be handled through the replacements
             auto clonedComposite = cloneeComposite->Clone(ParameterCloningMethod::Share, cloneeCompositeReplacements);
 
@@ -810,7 +810,7 @@ namespace CNTK
             auto clonedFunctionInputs = clonedFunction->Inputs();
             if (clonedFunctionInputs != inputs)
                 LogicError("Block Function '%S': Inputs '%S' of the new clone do not match the cloned inputs '%S' of the clonee Block Function.",
-                            clonedFunction->AsString().c_str(), 
+                            clonedFunction->AsString().c_str(),
                             NamedListString(clonedFunctionInputs).c_str(),
                             NamedListString(inputs).c_str());
         }
@@ -829,7 +829,7 @@ namespace CNTK
 
         auto compositeRootFunction = compositeFunction->RootFunction();
 
-        // Handle the scenario when the root Function outputs themselves are specified to be replaced. 
+        // Handle the scenario when the root Function outputs themselves are specified to be replaced.
         auto compositeRootFunctionOutputs = compositeRootFunction->RawOutputs();
         std::vector<Variable> rootFunctionOutputReplacements;
         for (auto output : compositeRootFunctionOutputs)
@@ -925,7 +925,7 @@ namespace CNTK
 
         auto restoredFunction = Function::Deserialize(modelDictionary, DeviceDescriptor::CPUDevice());
         //TODO (backcompat): when loading a stale model we can still pass this test
-        // by patching up restored functions on the fly during deserialization (e.g., by 
+        // by patching up restored functions on the fly during deserialization (e.g., by
         // inserting an extra input for the sample count in case of BatchNorm).
         if (!Internal::AreEquivalent(shared_from_this(), restoredFunction))
             InvalidArgument("Function '%S' being restored is not equivalent (isomorphic) to the Function '%S' loaded from checkpoint.",
@@ -984,20 +984,20 @@ namespace CNTK
         Function* functionPtr = !(this->IsComposite()) ? this : this->RootFunction().get();
         PrimitiveFunction* primitiveFunctionPtr = dynamic_cast<PrimitiveFunction*>(functionPtr);
 
-        if (primitiveFunctionPtr == nullptr) 
+        if (primitiveFunctionPtr == nullptr)
         {
             // Possibly, a udf...
             LogicError("SetAttribute cannot be invoked on an instance of function '%S'.", AsString().c_str());
         }
 
-        if (name == PrimitiveFunction::AttributeNameDropoutRate) 
+        if (name == PrimitiveFunction::AttributeNameDropoutRate)
         {
             double dropout;
             if (value.ValueType() == DictionaryValue::Type::Float)
                 dropout = value.Value<float>();
             else
                 dropout = value.Value<double>();
-            
+
             primitiveFunctionPtr->SetDropoutRate(dropout);
         }
         else if (name == PrimitiveFunction::AttributeNameRngSeed)
@@ -1010,7 +1010,7 @@ namespace CNTK
 
             primitiveFunctionPtr->SetRandomSeed(seed);
         }
-        else 
+        else
         {
             LogicError("SetAttribute: '%S' is not supported (this attribute cannot be updated).", name.c_str());
         }
@@ -1133,7 +1133,7 @@ namespace CNTK
         if (!axis.IsStaticAxis() && (axis != Axis::AllStaticAxes()))
             LogicError("Softmax: support only static axes.");
 
-        if (((operand.Shape().Rank() == 1) && (axis.StaticAxisIndex() == 0)) || 
+        if (((operand.Shape().Rank() == 1) && (axis.StaticAxisIndex() == 0)) ||
             (axis == Axis::AllStaticAxes()))
         {
             return UnaryOp(PrimitiveOpType::Softmax, operand, Dictionary(), name);
@@ -1237,9 +1237,9 @@ namespace CNTK
         additionalProperties[PrimitiveFunction::AttributeNameRngOffset] = size_t(0);
 
         return UnaryOp(PrimitiveOpType::Dropout, operand, std::move(additionalProperties), name);
-    } 
+    }
 
-    Dictionary CreateRandomDistributionAttributes(const wstring& type, const std::vector<double>& args, unsigned long seed) 
+    Dictionary CreateRandomDistributionAttributes(const wstring& type, const std::vector<double>& args, unsigned long seed)
     {
         auto additionalProperties = Dictionary();
 
@@ -1779,6 +1779,7 @@ namespace CNTK
         const NDShape& strides,
         const std::vector<bool>& sharing,
         const std::vector<bool>& autoPadding,
+        const NDShape& dilation,
         size_t maxTempMemSizeInSamples,
         const std::wstring& name)
     {
@@ -1787,6 +1788,7 @@ namespace CNTK
             strides,
             sharing,
             autoPadding,
+            dilation,
             false,
             { 0 },
             maxTempMemSizeInSamples,
@@ -1798,6 +1800,7 @@ namespace CNTK
         const NDShape& strides,
         const std::vector<bool>& sharing,
         const std::vector<bool>& autoPadding,
+        const NDShape& dilation,
         const NDShape& outputShape,
         size_t maxTempMemSizeInSamples,
         const std::wstring& name)
@@ -1807,17 +1810,18 @@ namespace CNTK
             strides,
             sharing,
             autoPadding,
+            dilation,
             true,
             outputShape,
             maxTempMemSizeInSamples,
             name);
     }
 
-    FunctionPtr ROIPooling(const Variable& operand, 
-                           const Variable& rois, 
-                           PoolingType poolingType, 
-                           const NDShape& roiOutputShape, 
-                           double spatialScale, 
+    FunctionPtr ROIPooling(const Variable& operand,
+                           const Variable& rois,
+                           PoolingType poolingType,
+                           const NDShape& roiOutputShape,
+                           double spatialScale,
                            const std::wstring& name/* = L""*/)
     {
         auto additionalProperties = Dictionary();
@@ -2254,7 +2258,7 @@ namespace CNTK
         {
             return Internal::ScatterPacked(operand, Internal::PackedIndex(/*layout of*/ condition, Where(condition, newDerivedSequenceAxisScalingAndAdditiveFactor)), /*layout of*/ condition, name);
         }
-        
+
         FunctionPtr Slice(const Variable& operand, const std::vector<Axis>& axis, const std::vector<int>& beginIndex, const std::vector<int>& endIndex, const std::vector<int>& strides, const std::wstring& name)
         {
             auto additionalProperties = Dictionary();
@@ -2295,7 +2299,7 @@ namespace CNTK
             LogicError("ReduceElements: operand %S; Invalid axis argument provided. To reduce an operand along its ordered dynamic axis use Sequence::ReduceElements.",
                        operand.AsString().c_str());
         }
- 
+
         FunctionPtr ReduceElements(const Variable& operand, const std::wstring& reductionOpName, const Axis& axis, const std::wstring& name)
         {
             bool keepReducedDimensions = true;
@@ -2304,7 +2308,7 @@ namespace CNTK
 
             return ReduceElements(operand, reductionOpName, axis, keepReducedDimensions, name);
         }
-         
+
         FunctionPtr ComposeReduceElements(const Variable& operand, const std::wstring& reductionOpName, const std::vector<Axis>& axes, bool keepReducedDimensions, const std::wstring& name)
         {
             if (
@@ -2374,7 +2378,7 @@ namespace CNTK
             if (!static_axes.empty())
             {
                 res = ComposeReduceElements(res, reductionOpName, static_axes, keepReducedDimensions, name + L"_static_axes_subop");
-            }            
+            }
             if (!sequence_axes.empty())
             {
                 res = CNTK::Sequence::ReduceElements(res, reductionOpName, keepReducedDimensions, name + L"_sequence_axes_subop");
@@ -2401,19 +2405,21 @@ namespace CNTK
             const NDShape& strides,
             const std::vector<bool>& sharing,
             const std::vector<bool>& autoPadding,
+            const NDShape& dilation,
             bool transpose,
             const NDShape& outputShape,
             size_t maxTempMemSizeInSamples,
             const std::wstring& name)
         {
             // Currently we require that the Convolution function's operand have a dynamic axis since otherwise
-            // the internal implementation incorrectly infers the batch axis dimension by picking up the first axis as 
+            // the internal implementation incorrectly infers the batch axis dimension by picking up the first axis as
             // the sample shape and considering the rest to be part of the batch axis
             if (operand.DynamicAxes().empty())
                 LogicError("Convolution currently requires the main operand to have dynamic axes");
 
             auto additionalProperties = Dictionary();
             additionalProperties[PrimitiveFunction::AttributeNameStrides] = strides;
+            additionalProperties[PrimitiveFunction::AttributeNameDilation] = dilation;
             additionalProperties[PrimitiveFunction::AttributeNameSharing] = AsDictionaryValueVector(sharing);
             additionalProperties[PrimitiveFunction::AttributeNameAutoPadding] = AsDictionaryValueVector(autoPadding);
             additionalProperties[PrimitiveFunction::AttributeNameLowerPad] = NDShape({0});

--- a/Source/CNTKv2LibraryDll/PrimitiveFunction.h
+++ b/Source/CNTKv2LibraryDll/PrimitiveFunction.h
@@ -223,6 +223,7 @@ namespace CNTK
         static const std::wstring AttributeNameInferInputRankToMap;
         static const std::wstring AttributeNameOffset;
         static const std::wstring AttributeNameStrides;
+        static const std::wstring AttributeNameDilation;
         static const std::wstring AttributeNameSharing;
         static const std::wstring AttributeNameAutoPadding;
         static const std::wstring AttributeNameLowerPad;
@@ -230,7 +231,7 @@ namespace CNTK
         static const std::wstring AttributeNameCeilOutDim;
         static const std::wstring AttributeNameIncludePad;
         static const std::wstring AttributeNameTranspose;
-        static const std::wstring AttributeNameOutputShape; 
+        static const std::wstring AttributeNameOutputShape;
         static const std::wstring AttributeNameMaxTempMemSizeInSamples;
         static const std::wstring AttributeNameROIOutputShape;
         static const std::wstring AttributeNamePoolingType;
@@ -303,8 +304,8 @@ namespace CNTK
 
         virtual size_t CurrentVersion() const override { return s_serializationVersion; }
 
-        static FunctionPtr Deserialize(const Dictionary& dictionary, 
-                                       const std::unordered_map<std::wstring, Variable>& uidToVariableMap, 
+        static FunctionPtr Deserialize(const Dictionary& dictionary,
+                                       const std::unordered_map<std::wstring, Variable>& uidToVariableMap,
                                        const std::unordered_set<FunctionPtr>& allPrimitiveFunctions,
                                        const std::unordered_map<Variable, Variable>& placeholderReplacements,
                                        const CNTK::DeviceDescriptor& device);
@@ -334,7 +335,7 @@ namespace CNTK
 
     private:
 
-        // The following helper functions are used to determine the output shape for different 
+        // The following helper functions are used to determine the output shape for different
         // types of primitive operations accounting for broadcasting and reductions where applicable.
         static NDShape UnaryElementwiseOpOutputShape(const NDShape& operandShape)
         {
@@ -422,7 +423,7 @@ namespace CNTK
             auto maxInputRank = MaxInputRank(inputs);
 
             // spliceDim may exceed all of them, which will create a new dimension, e.g. stacking column vectors into a matrix
-            size_t maxRank = std::max<size_t>(axis + 1, maxInputRank); 
+            size_t maxRank = std::max<size_t>(axis + 1, maxInputRank);
 
             // The following loop does multiple things:
             //  - Count total dimension along index
@@ -503,7 +504,7 @@ namespace CNTK
                             leftOperandShape.AsString().c_str());
 
                     // Broadcast to a free-dimension, if the right operand axis's dimensionality is 1; otherwise the output axis dimensionality
-                    // is the known right operands axis's dimensionality 
+                    // is the known right operands axis's dimensionality
                     outputDims[i] = (rightOperandShape[i] == 1) ? NDShape::FreeDimension : rightOperandShape[i];
                 }
                 else if (rightOperandShape[i] == NDShape::FreeDimension)
@@ -517,7 +518,7 @@ namespace CNTK
                             rightOperandShape.AsString().c_str());
 
                     // Broadcast to a free-dimension, if the left operand axis's dimensionality is 1; otherwise the output axis dimensionality
-                    // is the known left operands axis's dimensionality 
+                    // is the known left operands axis's dimensionality
                     outputDims[i] = (leftOperandShape[i] == 1) ? NDShape::FreeDimension : leftOperandShape[i];
                 }
                 else if ((leftOperandShape[i] == NDShape::InferredDimension) || (leftOperandShape[i] == 1))
@@ -545,7 +546,7 @@ namespace CNTK
                     outputDims[i] = leftOperandShape[i];
                 }
             }
-                        
+
             // Broadcast in remaining axes
             for (size_t i = shapeWithSmallerNumAxes.Rank(); i < numOutputAxes; ++i)
                 outputDims[i] = shapeWithLargerNumAxes[i];
@@ -591,8 +592,8 @@ namespace CNTK
             if (rightOperand.IsSparse() && (numReductionAxes > 1))
                 LogicError("Times: For a sparse %s operand '%S', cannot reduce multiple (%zu) axes; currently only the %s axis can be reduced for the sparse operand.",
                             Internal::IsReversingTensorShapesInErrorMessagesEnabled() ? "left" : "right",
-                            rightOperand.AsString().c_str(), 
-                            numReductionAxes, 
+                            rightOperand.AsString().c_str(),
+                            numReductionAxes,
                             Internal::IsReversingTensorShapesInErrorMessagesEnabled() ? "trailing" : "leading");
 
             // outputRank dimensions cannot be inferred
@@ -669,7 +670,7 @@ namespace CNTK
                             Internal::IsReversingTensorShapesInErrorMessagesEnabled() ? "right" : "left",
                             leftOperand.AsString().c_str(),
                             leftOperandShape.AsString().c_str());
-                            
+
                     rightOperandShape[i] = leftOperandShape[outputRank + i];
                 }
             }
@@ -713,8 +714,8 @@ namespace CNTK
         static void FixNDShape(size_t filterRank, size_t inputRank, NDShape& shape, size_t deflt, const NDShape& from = NDShape());
 
         static NDShape ConvolutionOpOutputShape(PrimitiveOpType op, const NDShape& operandShape, NDShape& kernelShape, NDShape& outputMapCount, NDShape& strides,
-            std::vector<bool>& sharing, std::vector<bool>& autoPad, NDShape& lowerPad, NDShape& upperPad,
-            bool transpose, bool inferDimensions, bool ceilOutputDim = false);
+                                                std::vector<bool>& sharing, std::vector<bool>& autoPad, NDShape& lowerPad, NDShape& upperPad,
+                                                bool transpose, bool inferDimensions, NDShape dilation = NDShape({1}), bool ceilOutputDim = false);
 
         static NDShape BatchNormalizationOutputShape(std::vector<Variable>& operands, bool spatial, bool inferDimensions)
         {
@@ -726,7 +727,7 @@ namespace CNTK
 
                 // Infer dimensions of learnable parameters
                 auto paramShape = operands[i].Shape();
-              
+
                 if (i < operands.size() - 1)
                 {
                     if (inferDimensions && ((paramShape.Rank() == 1) && paramShape.HasInferredDimension()) && !mainOperandShape.HasUnboundDimension())
@@ -738,11 +739,11 @@ namespace CNTK
                     }
 
                     if (!paramShape.HasInferredDimension() && !operands[1].Shape().HasInferredDimension() && (paramShape != operands[1].Shape()))
-                        InvalidArgument("BatchNormalization: Input[%d] shape '%S' must be identical to Input[1] shape '%S'.", 
+                        InvalidArgument("BatchNormalization: Input[%d] shape '%S' must be identical to Input[1] shape '%S'.",
                                         (int)i,
                                         paramShape.AsString().c_str(),
                                         operands[1].Shape().AsString().c_str());
-                }                
+                }
             }
 
             const auto& runCount = operands[operands.size() - 1];
@@ -777,8 +778,8 @@ namespace CNTK
 
     private:
         PrimitiveOpType m_op;
-        // Increasing s_serializationVersion every time we add more ops allows us to print 
-        // a more meaningful message when trying to load a new model with a stale binary. 
+        // Increasing s_serializationVersion every time we add more ops allows us to print
+        // a more meaningful message when trying to load a new model with a stale binary.
         // version 1: initial version.
         // version 2: Add maxUnpooling.
         // version 3: Add deconvolution.

--- a/Source/ComputationNetworkLib/ConvolutionalNodes.h
+++ b/Source/ComputationNetworkLib/ConvolutionalNodes.h
@@ -17,7 +17,7 @@ namespace Microsoft { namespace MSR { namespace CNTK {
 // -----------------------------------------------------------------------
 
 // ConvolutionNodeBase is a base class for ND-convolution(ConvolutionNode) and ND-pooling(PoolingNode).
-// 
+//
 // 2D convolutions (incl. pooling) support two different storage formats:
 //
 // * legacy ("HWC") mode: Channels are tuples of scalars
@@ -45,7 +45,7 @@ namespace Microsoft { namespace MSR { namespace CNTK {
 //  - K = output channels = dimension of activation vector for each pixel (also called N by NVidia, inconsistently)
 //
 // For ND-convolution/pooling only second format ('cudnn') is supported.
-// 
+//
 template <class ElemType>
 class ConvolutionNodeBase : public ComputationNode<ElemType>
 {
@@ -114,7 +114,7 @@ public:
         }
         if (modelVersion >= CNTK_MODEL_VERSION_20)
         {
-            m_outputShape.Load(fstream); 
+            m_outputShape.Load(fstream);
         }
         if (modelVersion >= CNTK_MODEL_VERSION_21)
         {
@@ -195,7 +195,7 @@ private:
         shape = TensorShape(dims);
     }
 protected:
-    // infer reduction dimensions if m_convolution2D is true, for legacy NDL branch 
+    // infer reduction dimensions if m_convolution2D is true, for legacy NDL branch
     void InferConvolution2DReductionDims(const TensorShape& inputShape, size_t numChannels)
     {
         size_t kW = m_kernelShape[0];
@@ -204,7 +204,7 @@ protected:
         size_t sH = m_stride[1];
         m_kernelShape = TensorShape(kW, kH, numChannels);
         m_stride = TensorShape(sW, sH, numChannels);
-        size_t filterRank = 2; 
+        size_t filterRank = 2;
         FixVectorShape(filterRank, inputShape.size(), m_autoPad, false);
         FixTensorShape(filterRank, inputShape.size(), m_lowerPad, 0);
         FixTensorShape(filterRank, inputShape.size(), m_upperPad, 0);
@@ -253,12 +253,12 @@ protected:
     TensorShape m_lowerPad;
     TensorShape m_upperPad;
     PoolKind m_poolKind;
-    bool m_transpose; 
+    bool m_transpose;
     TensorShape m_outputShape;
     bool m_ceilOutDim;
     bool m_poolIncludePad;
     ImageLayoutKind m_imageLayout;
-    
+
     size_t m_maxTempMemSizeInSamples;
     shared_ptr<Matrix<ElemType>> m_tempMatrixForward;
     shared_ptr<Matrix<ElemType>> m_tempMatrixBackward;
@@ -301,15 +301,24 @@ class ConvolutionNode : public ConvolutionNodeBase<ElemType>, public NumInputs<2
     static const std::wstring TypeName() { return L"Convolution"; }
 public:
     ConvolutionNode(DEVICEID_TYPE deviceId, const wstring& name)
-        : Base(deviceId, name)
+        : Base(deviceId, name), m_dilation(TensorShape(1))
     {
     }
     ConvolutionNode(DEVICEID_TYPE deviceId, const wstring& name, const TensorShape& kernelShape, const TensorShape& mapCount, const TensorShape& strideShape,
                     const std::vector<bool>& sharing, const std::vector<bool>& autoPadding, const TensorShape& lowerPad, const TensorShape& upperPad,
-                    bool transpose, const TensorShape &outputShape, ImageLayoutKind imageLayout, size_t maxTempMemSizeInSamples)
-                    : Base(deviceId, name, kernelShape, mapCount, strideShape, sharing, autoPadding, lowerPad, upperPad, PoolKind::None, false, transpose, outputShape, false, imageLayout, maxTempMemSizeInSamples),
-                    m_convolution2D(false)
+                    bool transpose, const TensorShape &outputShape, ImageLayoutKind imageLayout, size_t maxTempMemSizeInSamples, const TensorShape& dilation=TensorShape(1))
+        : Base(deviceId, name, kernelShape, mapCount, strideShape, sharing, autoPadding, lowerPad, upperPad, PoolKind::None, false, transpose, outputShape, false, imageLayout, maxTempMemSizeInSamples),
+        m_convolution2D(false), m_dilation(dilation)
     {
+        // Make sure not using dilation on CPU
+        if(deviceId < 0)
+        {
+            for(int i = 0; i < dilation.size(); i++)
+            {
+                if(1 != dilation[i])
+                    RuntimeError("Dilated convolution on CPU is not yet implemented.");
+            }
+        }
     }
     ConvolutionNode(DEVICEID_TYPE deviceId, const wstring& name, const size_t kernelWidth, const size_t kernelHeight, const size_t outputChannels,
                     const size_t horizontalSubsample, const size_t verticalSubsample, ImageLayoutKind imageLayout,
@@ -324,12 +333,12 @@ public:
     ConvolutionNode(const ScriptableObjects::IConfigRecordPtr configp)
         : ConvolutionNode(configp->Get(L"deviceId"), L"<placeholder>", configp->Get(L"kernelShape"), configp->Get(L"mapCount"), configp->Get(L"strideShape"),
                           configp->Get(L"dimSharing"), configp->Get(L"dimPadding"), configp->Get(L"dimPadLower"), configp->Get(L"dimPadUpper"),
-                          configp->Get(L"transpose"), configp->Get(L"dimOutputShape"), ImageLayoutKindFrom(configp->Get(L"imageLayout")), configp->Get(L"maxTempMemSizeInSamples"))
+                          configp->Get(L"transpose"), configp->Get(L"dimOutputShape"), ImageLayoutKindFrom(configp->Get(L"imageLayout")), configp->Get(L"maxTempMemSizeInSamples"), configp->Get(L"dimDilation"))
     {
         AttachInputsFromConfig(configp, GetExpectedNumInputs());
     }
 
-    // TODO: the check for NeedsDynamicValidation() is a temporary resolution and needs to be properly handled when we look at support for free dimension convolution inputs. 
+    // TODO: the check for NeedsDynamicValidation() is a temporary resolution and needs to be properly handled when we look at support for free dimension convolution inputs.
     virtual ParentGradientOptimization ImplementsGradientOptimization(const ComputationNodeBase*) const override
     {
         bool overwrite = Base::NeedsDynamicValidation() ? false : m_convEng->ImplementsGradientOverwriteOptimization();
@@ -341,7 +350,7 @@ public:
     {
         Base::Save(fstream);
         fstream << m_convolution2D;
-        TensorShape(1).Save(fstream); // Write out a dummy tensor, so that model created can be used later after implementing reading this tensor in this model version
+        m_dilation.Save(fstream);
     }
 
     void Load(File& fstream, size_t modelVersion) override
@@ -379,9 +388,11 @@ public:
             fstream >> m_convolution2D;
             if (modelVersion >= CNTK_MODEL_VERSION_18)
             {
-                TensorShape dummyTensorHolder;
-                dummyTensorHolder.Load(fstream);
-                if(dummyTensorHolder!=TensorShape(1)) LogicError("Loading tensor that is currently not supported.");
+                m_dilation.Load(fstream);
+            }
+            else
+            {
+                m_dilation = TensorShape(1);
             }
         }
     }
@@ -455,7 +466,7 @@ public:
         TensorShape outputShape;
         // If 2D convolution syntax is used then some of the tensor dimensions need to be inferred.
         if (m_convolution2D)
-        // NOTE: when m_convolution2D is true, it's a legacy branch. Code should not enter here any more. 
+        // NOTE: when m_convolution2D is true, it's a legacy branch. Code should not enter here any more.
         {
             // Need to update some tensors with correct input dims.
             auto inDims = ImageDimensions(GetInputSampleLayout(inputIdx), m_imageLayout);
@@ -495,7 +506,7 @@ public:
             if (!m_transpose)
             {
                 outputShape = ConvolveGeometry::ComputeOutputShape(inputShape, m_kernelShape, m_mapCount, m_stride,
-                                                                    m_sharing, m_autoPad, m_lowerPad, m_upperPad);
+                                                                   m_sharing, m_autoPad, m_lowerPad, m_upperPad, m_dilation);
 
                 if (m_outputShape.GetRank() > 0 && m_outputShape != TensorShape(0))    // user have explicitly set m_outputShape, we check if it's the same as outputShape
                 {
@@ -529,13 +540,13 @@ public:
                             "the provided options %ls", NodeName().c_str(), OperationName().c_str(),
                             static_cast<std::wstring>(inputShape).c_str(),
                             static_cast<std::wstring>(inferredShape).c_str());
-                    outputShape = m_outputShape; 
+                    outputShape = m_outputShape;
                 }
             }
 
-            if (m_imageLayout == ImageLayoutKind::CHW) 
+            if (m_imageLayout == ImageLayoutKind::CHW)
                 SetDims(outputShape, HasMBLayout());
-            else    // legacy format 
+            else    // legacy format
                 SetDims(ImageDimensions(outputShape, ImageLayoutKind::CHW).AsTensorShape(m_imageLayout), HasMBLayout());
         }
 
@@ -563,8 +574,8 @@ public:
             if (m_convEng == nullptr)
             {
                 auto geometry = std::make_shared<ConvolveGeometry>(!m_transpose ? inputShape : outputShape,
-                                                                   m_kernelShape, m_mapCount, m_stride, 
-                                                                   m_sharing, m_autoPad, m_lowerPad, m_upperPad);
+                                                                   m_kernelShape, m_mapCount, m_stride,
+                                                                   m_sharing, m_autoPad, m_lowerPad, m_upperPad, m_dilation);
                 m_convEng = ConvolutionEngine<ElemType>::Create(geometry, m_deviceId, m_imageLayout,
                                                                 m_maxTempMemSizeInSamples, m_poolKind,
                                                                 ConvolutionEngineKind::All, NodeName(), Globals::ShouldForceDeterministicAlgorithms());
@@ -641,6 +652,8 @@ private:
         return (inputIndex == 1);
     }
 
+    TensorShape m_dilation;
+
 protected:
     // Flag that indicates whether the node is created using 2D-syntax.
     bool m_convolution2D;
@@ -658,10 +671,10 @@ protected:
 // we can get a label for it. The ROIs have different spatial sizes,
 // so this node does Max Pooling, but with an adaptive pooling window,
 // so that each ROI output has the spatial size expected by the first
-// fully-connected layer. Images are Input(0). ROIs are Input(1). 
+// fully-connected layer. Images are Input(0). ROIs are Input(1).
 //
 // Input0: Images       [W x H x C x N]
-// Input1: ROIs         [4 x roisPerImage x N], 
+// Input1: ROIs         [4 x roisPerImage x N],
 // output: Pooled ROIs  [PW x PH x C x roisPerImage x N]
 // where PW = Pooled Width, PH = Pooled Height, C = Channels, N = Batch Size
 //
@@ -692,7 +705,7 @@ public:
         RequestMatrixFromPool(m_tempMatrix, matrixPool, matrixSize, true);
     }
 
-    // m_tempMatrix cannot be released after Forward Prop because its content (argmax) is used for back prop. 
+    // m_tempMatrix cannot be released after Forward Prop because its content (argmax) is used for back prop.
 
     void ReleaseMatricesAfterBackprop(MatrixPool& matrixPool) override
     {
@@ -701,11 +714,11 @@ public:
     }
 
     // Input0: Images       [W x H x C x N]
-    // Input1: ROIs         [4 x roisPerImage x N], 
+    // Input1: ROIs         [4 x roisPerImage x N],
     // output: Pooled ROIs  [PW x PH x C x roisPerImage x N]
     // where PW = Pooled Width, PH = Pooled Height, C = Channels, N = Batch Size
     //
-    // Explanation: this node has a target output shape of 
+    // Explanation: this node has a target output shape of
     // [Pooled Width x Pooled Height x Channels], as does any pooling
     // layer. However, we want each /ROI/ to have that output size,
     // not each image. After this node, operations in the network
@@ -714,7 +727,7 @@ public:
     // every ROI, it treats the subset of the image specified by that
     // ROI as a full image and does max pooling over that subset,
     // using whatever window size will correspond to an output of
-    // [Pooled Width x Pooled Height x Channels]. Hence, 
+    // [Pooled Width x Pooled Height x Channels]. Hence,
     // the output tensor is [PW x PH x C x roisPerImage x N]
     // An example validation output looks like this:
     // Validating --> z.roiOut = ROIPooling (z.conv5Out.conv5.y, rois) : [61 x 61 x 256 x *], [4 x 64 x *] -> [6 x 6 x 256 x 64 x *]
@@ -741,7 +754,7 @@ public:
 
         m_tempMatrix->Resize(outW * outH * numChannels * roisPerImage, inputSlice.GetNumCols());
         if (m_poolKind == PoolKind::Max)
-            inputSlice.MaxROIPoolingForward(roisPerImage, inputSlice.GetNumCols(), 
+            inputSlice.MaxROIPoolingForward(roisPerImage, inputSlice.GetNumCols(),
                 numChannels, inputW, inputH, outW, outH, ROIs, outputSlice, *m_tempMatrix, m_spatialScale);
         else
             LogicError("Average ROI pooling is not supported.");
@@ -937,14 +950,14 @@ public:
         InferReductionDims(inputShape, TensorShape());
 
         auto outDims = ConvolveGeometry::ComputeOutputShape(inputShape, m_kernelShape, m_mapCount, m_stride,
-                                                            m_sharing, m_autoPad, m_lowerPad, m_upperPad, m_ceilOutDim);
+                                                            m_sharing, m_autoPad, m_lowerPad, m_upperPad, TensorShape(1), m_ceilOutDim);
         SetDims(outDims, HasMBLayout());
         if (isFinalValidationPass)
         {
             if (m_convEng == nullptr)
             {
                 auto geometry = std::make_shared<ConvolveGeometry>(inputShape, m_kernelShape, m_mapCount, m_stride,
-                                                                   m_sharing, m_autoPad, m_lowerPad, m_upperPad, m_ceilOutDim);
+                                                                   m_sharing, m_autoPad, m_lowerPad, m_upperPad, TensorShape(1), m_ceilOutDim);
                 m_convEng = ConvolutionEngine<ElemType>::Create(geometry, m_deviceId, m_imageLayout,
                                                                 m_maxTempMemSizeInSamples, m_poolKind,
                                                                 ConvolutionEngineKind::All, NodeName(), false, m_poolIncludePad);
@@ -1062,8 +1075,8 @@ public:
         if (inputShape != inferredShape)
             InvalidArgument("%ls %ls the shape of the unpooling operand %ls is different from "
                             "the result of pooling the poolingInput argument using"
-                            "the provided options %ls", NodeName().c_str(), OperationName().c_str(), 
-                            static_cast<std::wstring>(inputShape).c_str(), 
+                            "the provided options %ls", NodeName().c_str(), OperationName().c_str(),
+                            static_cast<std::wstring>(inputShape).c_str(),
                             static_cast<std::wstring>(inferredShape).c_str());
 
         SetDims(outputShape, HasMBLayout());
@@ -1135,13 +1148,13 @@ public:
         ConvertToTensorShape();
     }
     PoolingNodeBase(const ScriptableObjects::IConfigRecordPtr configp, PoolKind poolKind)
-        : PoolingNodeBase(configp->Get(L"deviceId"), 
-            L"<placeholder>", 
-            configp->Get(L"windowWidth"), 
-            configp->Get(L"windowHeight"), 
-            configp->Get(L"horizontalSubsample"), 
+        : PoolingNodeBase(configp->Get(L"deviceId"),
+            L"<placeholder>",
+            configp->Get(L"windowWidth"),
+            configp->Get(L"windowHeight"),
+            configp->Get(L"horizontalSubsample"),
             configp->Get(L"verticalSubsample"),
-            ImageLayoutKindFrom(configp->Get(L"imageLayout")), 
+            ImageLayoutKindFrom(configp->Get(L"imageLayout")),
             poolKind)
     {
         // input, windowWidth, windowHeight, horizontalSubsample, verticalSubsample
@@ -1221,7 +1234,7 @@ public:
         // get input tensor shape and interpret as image dimensions
         auto inDims = ImageDimensions(GetInputSampleLayout(0), m_imageLayoutKind);
 
-        if (isFinalValidationPass && (inDims.m_width < m_windowWidth || inDims.m_height < m_windowHeight)) 
+        if (isFinalValidationPass && (inDims.m_width < m_windowWidth || inDims.m_height < m_windowHeight))
             InvalidArgument("PoolingNodeBase: inputWidth must >= windowWidth and inputHeight must >= windowHeight.");
 
         // determine output tensor shape
@@ -1400,7 +1413,7 @@ public:
         if (isFinalValidationPass && m_convEng == nullptr)
         {
             m_convEng = ConvolutionEngine<ElemType>::Create(m_geometry, m_deviceId, m_imageLayoutKind,
-                                                            0, PoolKind::Average, 
+                                                            0, PoolKind::Average,
                                                             ConvolutionEngineKind::All, NodeName());
         }
     }

--- a/Source/Math/ConvolveGeometry.h
+++ b/Source/Math/ConvolveGeometry.h
@@ -77,9 +77,9 @@ public:
     size_t KernelCount() const { return m_kernelCount; }
 
     ConvolveGeometry(const TensorShape& inputShape, const TensorShape& kernelShape, const TensorShape& mapCount, const TensorShape& stride,
-                     const BoolVec& sharing, const BoolVec& autoPad, const TensorShape& lowerPad, const TensorShape& upperPad, const bool ceilOutDim = false)
+                     const BoolVec& sharing, const BoolVec& autoPad, const TensorShape& lowerPad, const TensorShape& upperPad, const TensorShape& dilation=TensorShape(1), const bool ceilOutDim = false)
                      : m_inputShape(inputShape), m_kernelShape(kernelShape), m_mapCount(mapCount), m_stride(stride), m_sharing(sharing),
-                     m_autoPad(autoPad), m_lowerPad(lowerPad), m_upperPad(upperPad)
+                     m_autoPad(autoPad), m_lowerPad(lowerPad), m_upperPad(upperPad), m_dilation(dilation)
     {
         // Note: this ctor is a bit long so sit back and relax.
 
@@ -90,9 +90,9 @@ public:
         assert(m_autoPad.size() == 1 || m_autoPad.size() == m_inputShape.GetRank());
         assert(m_lowerPad.GetRank() == 1 || m_lowerPad.GetRank() == m_inputShape.GetRank());
         assert(m_upperPad.GetRank() == 1 || m_upperPad.GetRank() == m_inputShape.GetRank());
-        
+
         m_outputShape = ComputeOutputShape(m_inputShape, m_kernelShape, m_mapCount, m_stride,
-                                           m_sharing, m_autoPad, m_lowerPad, m_upperPad, ceilOutDim);
+                                           m_sharing, m_autoPad, m_lowerPad, m_upperPad, m_dilation, ceilOutDim);
         assert(m_inputShape.GetRank() == m_outputShape.GetRank());
 
         size_t dimCount = inputShape.GetRank();
@@ -111,9 +111,9 @@ public:
         {
             assert((m_outputShape[i] % GetMapCount(i)) == 0);
             int outPerMap = (int)(m_outputShape[i] / GetMapCount(i));
-            // Number of cells between first and last "centers", inclusive. 
+            // Number of cells between first and last "centers", inclusive.
             int cells = (int)((outPerMap - 1) * GetStride(i) + 1); assert(m_inputShape[i] >= cells);
-            // Extra cells, to the left and right of "cells". 
+            // Extra cells, to the left and right of "cells".
             int extra = (int)m_inputShape[i] - cells;
             assert(extra >= 0);
 
@@ -130,7 +130,7 @@ public:
                 if (lo != 0 || hi != 0)
                 {
                     m_start[i] -= lo;
-                    assert(m_start[i] >= 0); 
+                    assert(m_start[i] >= 0);
                     assert(m_start[i] + cells + (int)m_kernelShape[i] - 1 == m_inputShape[i] + hi + lo);
                 }
             }
@@ -138,7 +138,7 @@ public:
             m_startIndex = m_startIndex * (int)m_inputShape[i] + m_start[i];
             m_originIndex = m_originIndex * (int)m_inputShape[i] + ((int)m_kernelShape[i] - 1) / 2;
         }
-        
+
         // Compute support, mapping from the index into the kernel to offset into source.
         // Support consists of the column deltas of the kernels, as offsets from MpRowCol[row].
         IntVec support(kernelSize);
@@ -164,7 +164,7 @@ public:
             assert(ivSrc < m_inputShape.GetNumElements());
             support[idx] = ivSrc - m_originIndex;
         }
-        
+
         size_t outputSize = m_outputShape.GetNumElements();
         // Compute the mappings (where row = output node index, col = source node index):
         // * from row to the index of the first weight to use for that row.
@@ -347,6 +347,12 @@ public:
         return m_stride[m_stride.size() == 1 ? 0 : dim];
     }
 
+    size_t GetDilation(size_t dim) const
+    {
+        assert(m_dilation.size() == 1 || dim < m_dilation.size());
+        return m_dilation[m_dilation.size() == 1 ? 0 : dim];
+    }
+
     size_t GetMapCount(size_t dim) const
     {
         assert(m_mapCount.size() == 1 || dim < m_mapCount.size());
@@ -405,13 +411,13 @@ public:
         int cells = (outSize - 1) * stride + 1;
         // Extra cells, to the left and right of "cells".
         int extra = inpSize - cells;
-        int center = extra / 2; 
-        return (kernSize - 1) - (kernSize - 1) / 2 - (extra - center); 
+        int center = extra / 2;
+        return (kernSize - 1) - (kernSize - 1) / 2 - (extra - center);
     }
 
     // Computes output shape given input shape and other convolution parameters.
     static TensorShape ComputeOutputShape(const TensorShape& inputShape, const TensorShape& kernelShape, const TensorShape& mapCount, const TensorShape& stride,
-                                          const BoolVec& sharing, const BoolVec& autoPad, const TensorShape& lowerPad, const TensorShape& upperPad, const bool ceilOutDim = false)
+                                          const BoolVec& sharing, const BoolVec& autoPad, const TensorShape& lowerPad, const TensorShape& upperPad, const TensorShape& dilation=TensorShape(1), const bool ceilOutDim = false)
     {
         if (inputShape.GetRank() != kernelShape.GetRank())
             InvalidArgument("Convolution input and kernel tensors must have the same rank.");
@@ -440,16 +446,19 @@ public:
             bool autoPadCur = autoPad[autoPad.size() == 1 ? 0 : i];
             size_t lo = lowerPad[lowerPad.size() == 1 ? 0 : i];
             size_t hi = upperPad[upperPad.size() == 1 ? 0 : i];
+            size_t dil = dilation[dilation.GetRank() == 1 ? 0 : i];
             if (autoPadCur)
             {
-                dim += kernelShape[i] - 1;
+                dim += dil * (kernelShape[i] - 1);
             }
             else
             {
                 dim += lo + hi;
             }
-            float preciseDimOut = (float)(dim - kernelShape[i]) / delta + 1;
+            float preciseDimOut = (float)(dim - (kernelShape[i]-1) * dil - 1) / delta + 1;
+            float preciseDimOutNoDilation = (float)(dim - kernelShape[i]) / delta + 1;
             size_t dimOut = static_cast<size_t>(ceilOutDim ? ceil(preciseDimOut) : floor(preciseDimOut));
+            size_t dimOutNoDilation = static_cast<size_t>(ceilOutDim ? ceil(preciseDimOutNoDilation) : floor(preciseDimOutNoDilation));
             // When LowerPad and/or UpperPad are specified (i.e. > 0), we insist that the kernel applications
             // fill the entire space.
             if (!autoPadCur && (lo > 0 || hi > 0))
@@ -461,8 +470,7 @@ public:
             if (mapCount.size() > 1)
                 dimOut *= mapCount[i];
             else if (i == inputShape.GetRank() - 1)
-                dimOut *= mapCount[0];
-
+                dimOut = dimOutNoDilation*mapCount[0];
             dimsOutput[i] = dimOut;
         }
 
@@ -480,9 +488,10 @@ public:
     // Computes input shape given output shape and other convolution parameters.
     // Used in deconvolution operation.
     static TensorShape ComputeInputShape(const TensorShape& outputShape, const TensorShape& kernelShape, const TensorShape& mapCount, const TensorShape& stride,
-                                         const BoolVec& sharing, const BoolVec& autoPad, const TensorShape& lowerPad, const TensorShape& upperPad, bool ceilOutDim = false)
+                                         const BoolVec& sharing, const BoolVec& autoPad, const TensorShape& lowerPad, const TensorShape& upperPad, const TensorShape& dilation=TensorShape(1), bool ceilOutDim = false)
     {
         UNUSED(ceilOutDim);
+        UNUSED(dilation);
         if (outputShape.GetRank() != kernelShape.GetRank())
             InvalidArgument("Convolution output and kernel tensors must have the same rank.");
         if (mapCount.GetRank() != 1 && outputShape.GetRank() != mapCount.GetRank())
@@ -519,7 +528,7 @@ public:
             size_t hi = upperPad[upperPad.size() == 1 ? 0 : i];
             size_t dimIn = (dim - 1) * delta;
             // We need to be able to restore any input size from the output, not just the one
-            // that does not require padding. For example, if output is 14, stride 2 and 
+            // that does not require padding. For example, if output is 14, stride 2 and
             // desired input is 28 then padded input will be 31. In this case if autopadding is enabled,
             // the input will 27 as (27 - 1) / 2 + 1 == 14.
             if (autoPadCur)
@@ -569,6 +578,7 @@ private:
     TensorShape m_kernelShape;
     TensorShape m_mapCount;
     TensorShape m_stride;
+    TensorShape m_dilation;
     BoolVec m_sharing;
     BoolVec m_autoPad;
     TensorShape m_lowerPad;
@@ -578,7 +588,7 @@ private:
     // 1. Many of these vectors contain offsets which can be negative.
     // 2. Most of these vectors will be copied into device memory (GPU) so the smaller the size - the better.
     //    Also, 64-bit operations are slower on GPU.
-    // 3. If you are still not convinced, we don't expect convolutions to be more than 2B in size anyway. 
+    // 3. If you are still not convinced, we don't expect convolutions to be more than 2B in size anyway.
     // See description to corresponding getter functions to understand what these are.
     IntVec m_mpRowCol;
     IntVec m_mpRowIwht;

--- a/Source/Math/CuDnnConvolutionEngine.cu
+++ b/Source/Math/CuDnnConvolutionEngine.cu
@@ -92,14 +92,15 @@ public:
         size_t dim_size = std::max(stride_size, minDimSize);
         SmallVector<int> stride(dim_size, 1);
         SmallVector<int> pad(dim_size, 0);
+        SmallVector<int> dilation(dim_size, 1);
         for (int i = 0; i < stride_size; i++)
         {
             stride[dim_size - 1 - i] = (int)geometry.GetStride(i);
             pad[dim_size - 1 - i] = geometry.GetLowerPad(i);
+            dilation[dim_size - 1 - i] = (int)geometry.GetDilation(i);
         }
-        SmallVector<int> upscale(dim_size, 1);
         CUDNN_CALL(cudnnSetConvolutionNdDescriptor(m_conv, (int)dim_size, pad.data(),
-                                                   stride.data(), upscale.data(),
+                                                   stride.data(), dilation.data(),
                                                    CUDNN_CROSS_CORRELATION, dataType));
     }
 

--- a/bindings/python/cntk/ops/__init__.py
+++ b/bindings/python/cntk/ops/__init__.py
@@ -220,7 +220,7 @@ def forward_backward(graph, features, blankTokenId, delayConstraint=-1, name='')
 
 @typemap
 def convolution(convolution_map, operand, strides=(1,), sharing=[True],
-                auto_padding=[True], max_temp_mem_size_in_samples=0, name=''):
+                auto_padding=[True], dilation=(1,), max_temp_mem_size_in_samples=0, name=''):
     '''
     Computes the convolution of ``convolution_map`` (typically a tensor of learnable parameters) with
     ``operand`` (commonly an image or output of a previous convolution/pooling operation).
@@ -274,12 +274,13 @@ def convolution(convolution_map, operand, strides=(1,), sharing=[True],
     from cntk.cntk_py import convolution
     operand = sanitize_input(operand)
     strides, sharing, auto_padding = sanitize_convolution_args(strides, sharing, auto_padding)
-    return convolution(convolution_map, operand, strides, sharing, auto_padding,
+    dilation = sanitize_shape(dilation)
+    return convolution(convolution_map, operand, strides, sharing, auto_padding, dilation,
                        max_temp_mem_size_in_samples, name)
 
 @typemap
 def convolution_transpose(convolution_map, operand, strides=(1,), sharing=[True],
-                          auto_padding=[True], output_shape=None, max_temp_mem_size_in_samples=0, name=''):
+                          auto_padding=[True], dilation=(1,), output_shape=None, max_temp_mem_size_in_samples=0, name=''):
     '''
     Computes the transposed convolution of ``convolution_map`` (typically a tensor of learnable parameters) with
     ``operand`` (commonly an image or output of a previous convolution/pooling operation).
@@ -338,7 +339,8 @@ def convolution_transpose(convolution_map, operand, strides=(1,), sharing=[True]
     if output_shape is None:
         output_shape = (0,)
     output_shape = sanitize_shape(output_shape)
-    return convolution_transpose(convolution_map, operand, strides, sharing, auto_padding,
+    dilation = sanitize_shape(dilation)
+    return convolution_transpose(convolution_map, operand, strides, sharing, auto_padding, dilation,
                                  output_shape, max_temp_mem_size_in_samples, name)
 
 from cntk.cntk_py import PoolingType_Max, PoolingType_Average


### PR DESCRIPTION
This commit has following changes:
Remove deprecated call to support cudnn v6:
Now code should compile properly with cudnn v6.

Adding dilated convolution:
Default behavior of convolution remain unchanged. Dilated convolution support is exposed through BrainScript.
User can add `dilation =` in BrainScript ConvolutionalLayer definition. Example:
`ConvolutionalLayer {96, (11:11), stride=(4:4), pad=false, dilation=1}`
`diltaion = 1` means normal convolution, which is also the default value.

Adding check on auto padding:
When (inputSize-1) is divisible by stride and filter size is even in any dimension, asymmetric padding is needed in auto padding.
Since cudnn does not support asymmetric padding, a check is added to print error in this case to avoid user getting random results. 

