### PR TITLE
Converted MPICommunicatorImpl to singleton.

### DIFF
--- a/Source/CNTKv2LibraryDll/DistributedCommunicator.cpp
+++ b/Source/CNTKv2LibraryDll/DistributedCommunicator.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
 // Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
 //
 
@@ -31,11 +32,27 @@ namespace CNTK
 
     DistributedCommunicatorPtr MPICommunicator(size_t packThresholdSizeInBytes)
     {
-        return std::make_shared<MPICommunicatorImpl>(packThresholdSizeInBytes);
+        return MPICommunicatorImpl::GetInstance(packThresholdSizeInBytes);
+    }
+
+    DistributedCommunicatorPtr MPICommunicatorImpl::s_comm = nullptr;
+
+    DistributedCommunicatorPtr MPICommunicatorImpl::GetInstance(size_t packThresholdSizeInBytes)
+    {
+        if(s_comm == nullptr)
+            s_comm = std::make_shared<MPICommunicatorImpl>(packThresholdSizeInBytes);
+        return s_comm;
+    }
+
+    void MPICommunicatorImpl::Finalize()
+    {
+        s_comm = nullptr;
     }
 
     void DistributedCommunicator::Finalize()
     {
+        MPICommunicatorImpl::Finalize();
+
         auto mpi = MPIWrapper::GetInstance(false);
         if (mpi)
             mpi->Finalize();

--- a/Source/CNTKv2LibraryDll/DistributedCommunicator.h
+++ b/Source/CNTKv2LibraryDll/DistributedCommunicator.h
@@ -25,6 +25,10 @@ namespace CNTK
     public:
         MPICommunicatorImpl(size_t packThresholdSizeInBytes = DEFAULT_PACK_THRESHOLD_SIZE_IN_BYTES);
 
+        static DistributedCommunicatorPtr GetInstance(size_t packThresholdSizeInBytes);
+
+        static void Finalize();
+
         virtual const std::unordered_set<DistributedWorkerDescriptor>& Workers() const override;
 
         virtual const DistributedWorkerDescriptor& CurrentWorker() const override;
@@ -63,6 +67,9 @@ namespace CNTK
         virtual ~MPICommunicatorImpl() {}
 
     private:
+
+        static DistributedCommunicatorPtr s_comm;
+
         void Initialize(const std::vector<NDArrayViewPtr>& values);
 
         void AggregateImpl(


### PR DESCRIPTION
Avoids repeated initalization of NCCL in evaluator's test methods.