### PR TITLE
Bugfix for get_data_type

### DIFF
--- a/bindings/python/cntk/internal/tests/utils_test.py
+++ b/bindings/python/cntk/internal/tests/utils_test.py
@@ -74,6 +74,12 @@ def test_get_data_type():
     assert get_data_type(pa64, n64) == np.float64
     assert get_data_type(pa32, pl, n64) == np.float32
     assert get_data_type(pa64, pl, n64) == np.float64
+    
+    assert get_data_type(np.float64(1)) == np.float64
+    assert get_data_type(np.float32(1)) == np.float32
+    assert get_data_type(np.int64(1)) == np.float32  # special case for cntk
+    assert get_data_type(1) == np.float32
+    assert get_data_type(1.0) == np.float32
 
 def test_sanitize_batch_sparse():
     batch = [csr([[1,0,2],[2,3,0]]),

--- a/bindings/python/cntk/internal/utils.py
+++ b/bindings/python/cntk/internal/utils.py
@@ -39,7 +39,7 @@ def get_data_type(*args):
                 cntk_dtypes.add(np.float64)
             elif cntk_py.DataType_Float == arg.get_data_type():
                 cntk_dtypes.add(np.float32)
-        elif isinstance(arg, np.inexact):
+        elif isinstance(arg, (np.ndarray, np.inexact)):
             # https://docs.scipy.org/doc/numpy/reference/arrays.scalars.html
             # integer are not np.inexact -> np.float32
             # only accepts numpy types

--- a/bindings/python/cntk/internal/utils.py
+++ b/bindings/python/cntk/internal/utils.py
@@ -39,7 +39,10 @@ def get_data_type(*args):
                 cntk_dtypes.add(np.float64)
             elif cntk_py.DataType_Float == arg.get_data_type():
                 cntk_dtypes.add(np.float32)
-        elif isinstance(arg, np.ndarray):
+        elif isinstance(arg, np.inexact):
+            # https://docs.scipy.org/doc/numpy/reference/arrays.scalars.html
+            # integer are not np.inexact -> np.float32
+            # only accepts numpy types
             if arg.dtype not in (np.float32, np.float64):
                 raise ValueError(
                     'NumPy type "%s" is not supported' % arg.dtype)


### PR DESCRIPTION
get_data_type returns the wrong dtype for np.float64(1).

Example code:
``` python
import cntk
import numpy as np
for a in [
    np.float64(1),
    np.float32(1),
    np.int64(1),
    1,
    1.,
]:
    print(isinstance(a, np.inexact), cntk.utils.get_data_type(a))


```
Old output:
```
True <class 'numpy.float32'>
True <class 'numpy.float32'>
False <class 'numpy.float32'>
False <class 'numpy.float32'>
False <class 'numpy.float32'>
```

New output:
```
True <class 'numpy.float64'>
True <class 'numpy.float32'>
False <class 'numpy.float32'>
False <class 'numpy.float32'>
False <class 'numpy.float32'>
```