### PR TITLE
Fix broadcast_as_operand for float64 and scalar

### DIFF
--- a/bindings/python/cntk/ops/sequence/__init__.py
+++ b/bindings/python/cntk/ops/sequence/__init__.py
@@ -594,7 +594,7 @@ def broadcast_as(operand, broadcast_as_operand, name=''):
         :class:`~cntk.ops.functions.Function`
     '''
     from cntk.cntk_py import broadcast_as
-    operand = sanitize_input(operand, get_data_type(operand))
+    operand = sanitize_input(operand, get_data_type(operand, broadcast_as_operand))
     broadcast_as_operand = sanitize_input(
         broadcast_as_operand, get_data_type(broadcast_as_operand))
     return broadcast_as(operand, broadcast_as_operand, name)


### PR DESCRIPTION
The following code was not executable:
```
broadcast_as(1, cntk.sequence.input_variable(3, dtype=np.float64))
```