### PR TITLE
Bug: You can not borrow a temporary array.

### DIFF
--- a/bindings/python/cntk/core.py
+++ b/bindings/python/cntk/core.py
@@ -35,7 +35,8 @@ class NDArrayView(cntk_py.NDArrayView):
         data_type (np.float32, np.float64): data type of the data
         device (:class:`~cntk.device.DeviceDescriptor`): device this value
          should be put on
-    '''
+
+'''
 
     def __init__(self, shape, data_type, device=None):
         from cntk.internal import sanitize_shape, sanitize_dtype_cntk
@@ -73,6 +74,8 @@ class NDArrayView(cntk_py.NDArrayView):
                           'data/computation to avoid costly data conversions',
                           RuntimeWarning)
             np_array = np.ascontiguousarray(np_array)
+            # You can not borrow a temporary array.
+            borrow = False
 
         if device is None:
             device = use_default_device()


### PR DESCRIPTION
When np.ascontiguousarray is called a temporary array is created. This will be deleted after the function and cntk can not borrow the array without holding the object.

Here some example code to produce the bug (may need more the one execution):
```
import cntk
import numpy as np

np_array = np.ones((6, 400, 513))
y = cntk.cntk_py.NDArrayView(np_array, cntk.device.use_default_device(), False, True)

del np_array

from time import sleep
sleep(0.05)

print(y.to_ndarray())
```

The error happen, when the input for a cntk function is not c contiguous.

