### PR TITLE
Fix typos

### DIFF
--- a/Documentation/Documents/Configuration Files.md
+++ b/Documentation/Documents/Configuration Files.md
@@ -232,7 +232,7 @@ stderr=c:\cntk\log\cntk # “_mnistTrain_mnistTest.log” would be appended
 traceLevel=0 # larger values mean more output
 ```
 
-The **traceLevel** parameter is uniformly used by the code in CNTK to specify how much extra output (verbosity) is desired. The default value is 0 (zero) and specifies minimal output, the higher the number the more output can be expected. Currently 0-limited output, 1-medium ouput, 2-verbose output are the only values supported.
+The **traceLevel** parameter is uniformly used by the code in CNTK to specify how much extra output (verbosity) is desired. The default value is 0 (zero) and specifies minimal output, the higher the number the more output can be expected. Currently 0-limited output, 1-medium output, 2-verbose output are the only values supported.
 
 ### Top Level Parameters
 

--- a/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKLibraryCSEvalExamples.cs
+++ b/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKLibraryCSEvalExamples.cs
@@ -72,7 +72,7 @@ namespace CNTKLibraryCSEvalExamples
                 var inputVal = Value.CreateBatch(inputVar.Shape, resizedCHW, device);
                 inputDataMap.Add(inputVar, inputVal);
 
-                // Create ouput data map. Using null as Value to indicate using system allocated memory.
+                // Create output data map. Using null as Value to indicate using system allocated memory.
                 // Alternatively, create a Value object and add it to the data map.
                 outputDataMap.Add(outputVar, null);
 
@@ -158,7 +158,7 @@ namespace CNTKLibraryCSEvalExamples
                 // Create input data map.
                 inputDataMap.Add(inputVar, inputVal);
 
-                // Create ouput data map. Using null as Value to indicate using system allocated memory.
+                // Create output data map. Using null as Value to indicate using system allocated memory.
                 // Alternatively, create a Value object and add it to the data map.
                 outputDataMap.Add(outputVar, null);
 
@@ -248,7 +248,7 @@ namespace CNTKLibraryCSEvalExamples
                     var inputVal = Value.CreateBatch(inputVar.Shape, resizedCHW, device);
                     inputDataMap.Add(inputVar, inputVal);
 
-                    // Create ouput data map. Using null as Value to indicate using system allocated memory.
+                    // Create output data map. Using null as Value to indicate using system allocated memory.
                     // Alternatively, create a Value object and add it to the data map.
                     outputDataMap.Add(outputVar, null);
 
@@ -326,7 +326,7 @@ namespace CNTKLibraryCSEvalExamples
                 var inputVal = Value.CreateBatch(inputVar.Shape, resizedCHW, device);
                 inputDataMap.Add(inputVar, inputVal);
 
-                // Create ouput data map. Using null as Value to indicate using system allocated memory.
+                // Create output data map. Using null as Value to indicate using system allocated memory.
                 // Alternatively, create a Value object and add it to the data map.
                 outputDataMap.Add(outputVar, null);
 
@@ -444,7 +444,7 @@ namespace CNTKLibraryCSEvalExamples
                 // Prepare output
                 Variable outputVar = modelFunc.Output;
 
-                // Create ouput data map. Using null as Value to indicate using system allocated memory.
+                // Create output data map. Using null as Value to indicate using system allocated memory.
                 var outputDataMap = new Dictionary<Variable, Value>();
                 outputDataMap.Add(outputVar, null);
 
@@ -567,7 +567,7 @@ namespace CNTKLibraryCSEvalExamples
 
                 // Prepare output
                 Variable outputVar = modelFunc.Output;
-                // Create ouput data map. Using null as Value to indicate using system allocated memory.
+                // Create output data map. Using null as Value to indicate using system allocated memory.
                 var outputDataMap = new Dictionary<Variable, Value>();
                 outputDataMap.Add(outputVar, null);
 
@@ -687,7 +687,7 @@ namespace CNTKLibraryCSEvalExamples
                 // Prepare output
                 Variable outputVar = modelFunc.Output;
 
-                // Create ouput data map. Using null as Value to indicate using system allocated memory.
+                // Create output data map. Using null as Value to indicate using system allocated memory.
                 var outputDataMap = new Dictionary<Variable, Value>();
                 outputDataMap.Add(outputVar, null);
 

--- a/Source/CNTK/BrainScript/BrainScriptParser.cpp
+++ b/Source/CNTK/BrainScript/BrainScriptParser.cpp
@@ -245,7 +245,7 @@ public:
             return currentLine[cursor.charPos];
     }
 
-    // we chan also return the address of the current character, e.g. for passing it to a C stdlib funcion such as wcstod()
+    // we chan also return the address of the current character, e.g. for passing it to a C stdlib function such as wcstod()
     const wchar_t* GotCharPtr() const
     {
         return currentLine + cursor.charPos;

--- a/Source/Common/Eval.cpp
+++ b/Source/Common/Eval.cpp
@@ -114,7 +114,7 @@ void Eval<ElemType>::GetNodeDimensions(std::map<std::wstring, size_t>& dimension
 }
 
 // StartEvaluateMinibatchLoop - Prepare network for Evaluate() calls.
-// ouputNodeName - name of node that will be evaluated
+// outputNodeName - name of node that will be evaluated
 template <class ElemType>
 void Eval<ElemType>::StartEvaluateMinibatchLoop(const std::wstring& outputNodeName)
 {

--- a/Source/Common/Include/Eval.h
+++ b/Source/Common/Include/Eval.h
@@ -148,7 +148,7 @@ public:
     virtual void GetNodeDimensions(std::map<std::wstring, size_t>& dimensions, NodeGroup nodeGroup);
 
     // StartEvaluateMinibatchLoop - Prepare network for Evaluate() calls.
-    // ouputNodeName - name of node that will be evaluated
+    // outputNodeName - name of node that will be evaluated
     virtual void StartEvaluateMinibatchLoop(const std::wstring& outputNodeName);
 
     // Evaluate - Evaluate using the model with the given inputs and outputs

--- a/Source/ComputationNetworkLib/LinearAlgebraNodes.h
+++ b/Source/ComputationNetworkLib/LinearAlgebraNodes.h
@@ -244,7 +244,7 @@ template class MinusNode<double>;
 // -----------------------------------------------------------------------
 // ElementTimesNode (factor1, factor2)
 // This allows broadcasting, and can thus also scale with a row, a column, or a scalar,
-// as well as mutliplying with a diagonal matrix (if represented as a column vector).
+// as well as multiplying with a diagonal matrix (if represented as a column vector).
 // -----------------------------------------------------------------------
 
 template <class ElemType>

--- a/Source/ComputationNetworkLib/ReshapingNodes.h
+++ b/Source/ComputationNetworkLib/ReshapingNodes.h
@@ -708,11 +708,11 @@ private:
     // Helper structure to store input/output views which define parts of input and output we work with.
     struct CroppedIOViews
     {
-        CroppedIOViews(CropNode* cropNode, MatrixGetter matrixGetter, TensorShape inputShapeCropped, TensorShape ouputShape) :
+        CroppedIOViews(CropNode* cropNode, MatrixGetter matrixGetter, TensorShape inputShapeCropped, TensorShape outputShape) :
             // Input view is derived from first input.
             inputViewCropped((cropNode->Input(0).get()->*matrixGetter)(), inputShapeCropped),
             // Output view corresponds to single output.
-            outputView((cropNode->*matrixGetter)(), ouputShape)
+            outputView((cropNode->*matrixGetter)(), outputShape)
         {}
 
         TensorView<ElemType> inputViewCropped;

--- a/Source/EvalDll/CNTKEval.cpp
+++ b/Source/EvalDll/CNTKEval.cpp
@@ -148,7 +148,7 @@ void CNTKEval<ElemType>::GetNodeDimensions(std::map<std::wstring, size_t>& dimen
 }
 
 // StartEvaluateMinibatchLoop - Prepare network for Evaluate() calls.
-// ouputNodeName - name of node that will be evaluated
+// outputNodeName - name of node that will be evaluated
 template <typename ElemType>
 void CNTKEval<ElemType>::StartEvaluateMinibatchLoop(const std::wstring& outputNodeName)
 {

--- a/Source/Extensibility/EvalWrapper/EvalWrapperAssemblyInfo.cpp
+++ b/Source/Extensibility/EvalWrapper/EvalWrapperAssemblyInfo.cpp
@@ -5,7 +5,7 @@
 // EvalWrapperAssemblyInfo.cpp -- Provides Strong Name for EvalWrapper assembly.
 // 
 // Note that the key pair (including secret key) is stored in the same folder as this source file.
-// The Strong Name serves for identity puposes and for the applications that require it.
+// The Strong Name serves for identity purposes and for the applications that require it.
 // The Strong Name does NOT enable trust scenario. Use the compiled and Authenticode signed dll version of this assembly
 // provided with the CNTK NuGet package if you need trust. See CNTK Releases web page for NuGet package name and location:
 // https://github.com/Microsoft/CNTK/releases

--- a/Source/Math/CPUMatrixImpl.h
+++ b/Source/Math/CPUMatrixImpl.h
@@ -7051,7 +7051,7 @@ static void TensorOpWithFn(ElemType beta, array<ElemType*, N> pointers, ElemType
         CaseTensorOpWithFnAndReduction(Max);
         CaseTensorOpWithFnAndReduction(ElementwiseProduct);
     default:
-        LogicError("Specified ElementWiseOperator op %d not suported as reduction operation.", (int)reductionOp);
+        LogicError("Specified ElementWiseOperator op %d not supported as reduction operation.", (int)reductionOp);
     }
 }
 

--- a/Source/Readers/ImageReader/ImageDeserializerBase.h
+++ b/Source/Readers/ImageReader/ImageDeserializerBase.h
@@ -16,7 +16,7 @@ namespace Microsoft { namespace MSR { namespace CNTK {
     class ImageDeserializerBase : public DataDeserializerBase
     {
     public:
-        // Number of mutlicrop versions to produce.
+        // Number of multicrop versions to produce.
         // Currently the default value of 10 is used as in AlexNet paper,
         // Possibly we should make this configurable.
         const static uint8_t NumMultiViewCopies = 10;

--- a/Tests/EndToEndTests/CNTKv2Library/EndToEndTests/FrameMode.cpp
+++ b/Tests/EndToEndTests/CNTKv2Library/EndToEndTests/FrameMode.cpp
@@ -19,7 +19,7 @@ namespace
     struct FeedForwardClassifier
     {
         size_t inputDim;
-        size_t ouputDim;
+        size_t outputDim;
         Variable features;
         Variable labels;
         FunctionPtr output;
@@ -44,7 +44,7 @@ namespace
     {
         return TextFormatMinibatchSource(g_inputFile,
             { { g_featureStreamName, classifier.inputDim },
-              { g_labelsStreamName, classifier.ouputDim } },
+              { g_labelsStreamName, classifier.outputDim } },
             totalNumberOfSamples, true);
     }
 

--- a/Tutorials/CNTK_200_GuidedTour.ipynb
+++ b/Tutorials/CNTK_200_GuidedTour.ipynb
@@ -953,7 +953,7 @@
     "In our examples above, we use the `train()` function to train, and `test()` for evaluating.\n",
     "In this section, we want to walk you through the advanced options of `train()`:\n",
     "\n",
-    " 1. **Distributed Training** on mutliple GPUs using MPI.\n",
+    " 1. **Distributed Training** on multiple GPUs using MPI.\n",
     " 2. Callbacks for **Progress Tracking**, **TensorBoard visualization**, **Checkpointing**,**Cross-validation**-based training control, and **Testing** for the final model.\n",
     "\n",
     "### 1. Distributed Training\n",

--- a/Tutorials/FunctionalAPI/CNTK_200_GuidedTour.ipynb
+++ b/Tutorials/FunctionalAPI/CNTK_200_GuidedTour.ipynb
@@ -933,7 +933,7 @@
     "In our examples above, we use the `train()` function to train, and `test()` for evaluating.\n",
     "In this section, we want to walk you through the advanced options of `train()`:\n",
     "\n",
-    " 1. **Distributed Training** on mutliple GPUs using MPI.\n",
+    " 1. **Distributed Training** on multiple GPUs using MPI.\n",
     " 2. Callbacks for **Progress Tracking**, **TensorBoard visualization**, **Checkpointing**,**Cross-validation**-based training contro, and **Testing** for the final model.\n",
     "\n",
     "### 1. Distributed Training\n",

--- a/bindings/csharp/CNTKLibraryManagedDll/CNTKLibraryManagedDll-CPUOnly-AssemblyInfo.cs
+++ b/bindings/csharp/CNTKLibraryManagedDll/CNTKLibraryManagedDll-CPUOnly-AssemblyInfo.cs
@@ -5,7 +5,7 @@
 // CNTKLibraryManagedDll-CPUONly-AssemblyInfo.cpp -- Provides Strong Name for CNTKLibraryManagedDll (CPUOnly flavor) assembly.
 //
 // Note that the key pair (including secret key) is stored in the same folder as this source file.
-// The Strong Name serves for identity puposes and for the applications that require it.
+// The Strong Name serves for identity purposes and for the applications that require it.
 // The Strong Name does NOT enable trust scenario. Use the compiled and Authenticode signed dll version of this assembly
 // provided with the CNTK NuGet package if you need trust. See CNTK Releases web page for NuGet package name and location:
 // https://github.com/Microsoft/CNTK/releases

--- a/bindings/csharp/CNTKLibraryManagedDll/CNTKLibraryManagedDll-GPU-AssemblyInfo.cs
+++ b/bindings/csharp/CNTKLibraryManagedDll/CNTKLibraryManagedDll-GPU-AssemblyInfo.cs
@@ -5,7 +5,7 @@
 // CNTKLibraryManagedDll-GPU-AssemblyInfo.cpp -- Provides Strong Name for CNTKLibraryManagedDll (GPU flavor) assembly.
 //
 // Note that the key pair (including secret key) is stored in the same folder as this source file.
-// The Strong Name serves for identity puposes and for the applications that require it.
+// The Strong Name serves for identity purposes and for the applications that require it.
 // The Strong Name does NOT enable trust scenario. Use the compiled and Authenticode signed dll version of this assembly
 // provided with the CNTK NuGet package if you need trust. See CNTK Releases web page for NuGet package name and location:
 // https://github.com/Microsoft/CNTK/releases

--- a/bindings/python/cntk/core.py
+++ b/bindings/python/cntk/core.py
@@ -64,7 +64,7 @@ class NDArrayView(cntk_py.NDArrayView):
             np_array (numpy.ndarray): NumPy array
             device (:class:`~cntk.device.DeviceDescriptor`): device this value
              should be put on
-            borrow (bool, default False): whether nd_arrary memory can be
+            borrow (bool, default False): whether nd_array memory can be
              borrowed internally to speed up the data creation
             read_only (bool, optional): whether the data can be modified or
              not (default False)
@@ -103,7 +103,7 @@ class NDArrayView(cntk_py.NDArrayView):
              should be put on
             read_only (bool, optional): whether the data can be modified or
              not (default False)
-            borrow (bool, default False): whether nd_arrary memory can be
+            borrow (bool, default False): whether nd_array memory can be
              borrowed internally to speed up the data creation
             shape (tuple, default None): shape of the created NDArrayView.
              If unspecified, the created NDArrayView has the same shape as the csr_matrix.
@@ -153,7 +153,7 @@ class NDArrayView(cntk_py.NDArrayView):
              should be put on
             read_only (bool, optional): whether the data can be modified or
              not (default False)
-            borrow (bool, default False): whether nd_arrary memory can be
+            borrow (bool, default False): whether nd_array memory can be
              borrowed internally to speed up the data creation
 
         Returns:

--- a/bindings/python/cntk/layers/layers.py
+++ b/bindings/python/cntk/layers/layers.py
@@ -95,7 +95,7 @@ def Dense(shape, activation=default_override_or(identity), init=default_override
      input_rank (int, defaults to `None`): number of inferred axes to add to W (`map_rank` must not be given)
      map_rank (int, defaults to `None`): expand W to leave exactly `map_rank` axes (`input_rank` must not be given)
      bias (bool, optional, defaults to `True`): the layer will have no bias if `False` is passed here
-     init_bias (scalar or NumPy array or :mod:`cntk.initializer`, defualts to 0): initial value of weights `b`
+     init_bias (scalar or NumPy array or :mod:`cntk.initializer`, defaults to 0): initial value of weights `b`
      name (str, defaults to ''): the name of the function instance in the network
 
     Returns:

--- a/bindings/python/cntk/ops/functions.py
+++ b/bindings/python/cntk/ops/functions.py
@@ -622,7 +622,7 @@ class Function(cntk_py.Function):
              passing input data.
 
         Returns:
-           dict or NumPy Array: Dict with keys of ouput variable names and values of
+           dict or NumPy Array: Dict with keys of output variable names and values of
            output variable. A single NumPy array if there is only one output value.
         '''
         if outputs is None:


### PR DESCRIPTION
This PR fixes some typos: `funcion`, `mutliplying`, `mutlicrop`, `mutliple`, `arrary`, `puposes`, `ouput`, `defualt`, and `suported`.