### PR TITLE
Fix typos

### DIFF
--- a/Documentation/CNTK-TechReport/lyx/CNTKBook_ASRDecoder_Chapter.lyx
+++ b/Documentation/CNTK-TechReport/lyx/CNTKBook_ASRDecoder_Chapter.lyx
@@ -860,7 +860,7 @@ The decoder uses a Viterbi beam search algorithm, in which unlikely hypotheses
  are pruned at each frame.
  The -beam parameter prevents unlikely hypotheses from being pursued.
  Any hypothesis that differs from the best hypothesis by more than this
- amount will be be discarded.
+ amount will be discarded.
  The -max-tokens parameter controls the number of active hypotheses.
  If the -beam parameter causes more than max-tokens hypotheses to be generated,
  then only this many of the best hypotheses will be retained.

--- a/Documentation/CNTK-TechReport/lyx/CNTKBook_CN_Chapter.lyx
+++ b/Documentation/CNTK-TechReport/lyx/CNTKBook_CN_Chapter.lyx
@@ -10194,7 +10194,7 @@ reference "fig:CN-WithDelayNode"
 .
  Different from the CN without a directed loop, a CN with a loop cannot
  be computed for a sequence of samples as a batch since the next sample's
- value depends on the the previous samples.
+ value depends on the previous samples.
  A simple way to do forward computation and backpropagation in a recurrent
  network is to unroll all samples in the sequence over time.
  Once unrolled, the graph is expanded into a DAG and the forward computation

--- a/Documentation/CNTK-TechReport/lyx/CNTKBook_ExampleSetup_Chapter.lyx
+++ b/Documentation/CNTK-TechReport/lyx/CNTKBook_ExampleSetup_Chapter.lyx
@@ -1505,7 +1505,7 @@ In this script, the initial model is loaded and set as the default model.
  Note that through the use of configuration variables, this same script
  can be reused anytime a new layer can be added.
  If different layer sizes were desired, the HDim variable could be set by
- the higher level configuration file in the the appropriate edit block,
+ the higher level configuration file in the appropriate edit block,
  rather than from within the MEL script.
  
 \end_layout

--- a/Examples/Image/Detection/FastRCNN/CNTK_FastRCNN_Eval.ipynb
+++ b/Examples/Image/Detection/FastRCNN/CNTK_FastRCNN_Eval.ipynb
@@ -115,7 +115,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fast-RCNN Grocery model loaded succesfully!\n"
+      "Fast-RCNN Grocery model loaded successfully!\n"
      ]
     }
    ],
@@ -149,7 +149,7 @@
     "# apply the cloned nodes to the input nodes\n",
     "frcnn_model = cloned_nodes(image_input, roi_input)\n",
     "\n",
-    "print(\"Fast-RCNN Grocery model loaded succesfully!\")"
+    "print(\"Fast-RCNN Grocery model loaded successfully!\")"
    ]
   },
   {

--- a/Source/ComputationNetworkLib/TrainingNodes.h
+++ b/Source/ComputationNetworkLib/TrainingNodes.h
@@ -1449,7 +1449,7 @@ public:
 private:
     // Approximates the expected number of occurences of a class in the sampled set.
     // Assuming (falsely) that the number of tries to get a sampled set with the requested number of distinct values is always estimatedNumTries
-    // the probability that a specific class in in the sampled set is (1 - (1-p)^estimatedNumTries), where p is the probablity to pick the clas in one draw.
+    // the probability that a specific class in the sampled set is (1 - (1-p)^estimatedNumTries), where p is the probablity to pick the clas in one draw.
     // The estimate can be quite a bit off but should be better than nothing. Better alternatives?
     double EstimateInSampleFrequency(double p, double estimatedNumTries) const;
 

--- a/Source/Math/CPUSparseMatrix.h
+++ b/Source/Math/CPUSparseMatrix.h
@@ -166,7 +166,7 @@ public:
 
 
     // Allocate actually allocates the storage space for numNZElemToReserve elements. This is different than resizing, which changes the dimensions of the underlying matrix.
-    // Unfortunately numRows/numCols need to be passed in in the case of various matrix formats (e.g., SparseCSC), because some of the dimensions allocated depend on the
+    // Unfortunately numRows/numCols need to be passed in the case of various matrix formats (e.g., SparseCSC), because some of the dimensions allocated depend on the
     // dimensions of the matrix.
     void Allocate(const size_t numRows, const size_t numCols, const size_t numNZElemToReserve = 10000, const bool growOnly = true, bool keepExistingValues = false); // matrix format will affect the size to allocate
     // RequireSizeAndAllocate is required by SpasreMatrix since resizing the dimensions and allocating storage are different operations. Since a Resize can entail changing

--- a/Source/Math/Matrix.cpp
+++ b/Source/Math/Matrix.cpp
@@ -231,7 +231,7 @@ void Matrix<ElemType>::SetDataLocation(CurrentDataLocation location, MatrixType 
     //       -> FORBIDDEN to write into
     //     - CPU or GPU -> BOTH: current state is CPU or GPU
     //       and a view onto it is put into BOTH state
-    //       -> OK but inefficent to read, since this is likely happening over again; but we cannot put all views into BOTH state
+    //       -> OK but inefficient to read, since this is likely happening over again; but we cannot put all views into BOTH state
     //     - BOTH -> BOTH:
     //        - read case: OK
     //        - write case: forbidden to call this function in this way

--- a/Source/Readers/CompositeDataReader/CompositeDataReader.cpp
+++ b/Source/Readers/CompositeDataReader/CompositeDataReader.cpp
@@ -295,7 +295,7 @@ void CompositeDataReader::CreateTransforms(const ConfigParameters& deserializerC
         ConfigParameters input = inputs[i](inputSections.front());
         std::wstring inputName = msra::strfun::utf16(input.ConfigName());
 
-        // Read tranformers in order and appending them to the transformer pipeline.
+        // Read transformers in order and appending them to the transformer pipeline.
         argvector<ConfigParameters> transforms = input("transforms");
         for (size_t j = 0; j < transforms.size(); ++j)
         {

--- a/Source/SGDLib/Criterion.h
+++ b/Source/SGDLib/Criterion.h
@@ -46,7 +46,7 @@ struct EpochCriterion : public std::pair<double, size_t>
     // main way of reading this out: compute the actual average criterion value from the aggregate and sample count
     double Average() const { return second > 0 ? first / second : 0.0; } // compute the epoch-average
 
-    // a few more handy operations that occured multiple times
+    // a few more handy operations that occurred multiple times
     bool IsNan() const { return std::isnan(first); }
     EpochCriterion operator-(const EpochCriterion& other) const { return EpochCriterion(first - other.first, second - other.second); }
     void operator+=(const EpochCriterion& other) { first += other.first; second += other.second; }

--- a/Source/SGDLib/PostComputingActions.h
+++ b/Source/SGDLib/PostComputingActions.h
@@ -38,7 +38,7 @@ public:
 
     // This function is used for evaluating the mean and variance of all batch normalization nodes after training. 
     // Details will link to the wiki https://docs.microsoft.com/en-us/cognitive-toolkit/Post-Batch-Normalization-Statistics
-    // The reason why put it into evalute is the action take place after trainning and non-backprop processing, which makes me believe 
+    // The reason why put it into evalute is the action take place after training and non-backprop processing, which makes me believe 
     // this function is like a kind of evaluate function.
     // In this function,  
     // 1. since all other weights are fix except the un-pbn nodes, I set the networkoperationMode into inferring.

--- a/Tools/devInstall/Windows/buildZlibVS15.bat
+++ b/Tools/devInstall/Windows/buildZlibVS15.bat
@@ -94,7 +94,7 @@ goto FIN
 
 :HELP
 @echo.
-@echo Use this script to build the the compression library used by the CNTK image reader
+@echo Use this script to build the compression library used by the CNTK image reader
 @echo The script requires three parameter
 @echo   Parameter 1: The complete path to the LibZip source directory 
 @echo                e.g C:\local\src\libzip-1.1.3

--- a/Tools/generate_build_info
+++ b/Tools/generate_build_info
@@ -7,7 +7,7 @@
 # ==============================================================================
 #
 # Description: this script is used to generated buildinfo.h in Source/CNTK
-# which will contain the following infomation to be displayed at runtime:
+# which will contain the following information to be displayed at runtime:
 #   BUILDTYPE       (release/debug)
 #   BUILDTYPE       (GPU/CPU-only)
 #   WITH_1BITSGD    (whether 1bit-SGD support was enabled)

--- a/Tutorials/CNTK_201B_CIFAR-10_ImageHandsOn.ipynb
+++ b/Tutorials/CNTK_201B_CIFAR-10_ImageHandsOn.ipynb
@@ -480,7 +480,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let us write the the training and validation loop."
+    "Now let us write the training and validation loop."
    ]
   },
   {

--- a/Tutorials/FunctionalAPI/CNTK_200_GuidedTour.ipynb
+++ b/Tutorials/FunctionalAPI/CNTK_200_GuidedTour.ipynb
@@ -1092,7 +1092,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Unfortunately, MPI cannot be used from a Jupyter notebook; hence, the the `distributed_learner` above actually has no effect.\n",
+    "Unfortunately, MPI cannot be used from a Jupyter notebook; hence, the `distributed_learner` above actually has no effect.\n",
     "You can find the same example\n",
     "as a standalone Python script under `Examples/1stSteps/MNIST_Complex_Training.py` to run under MPI, for example under MSMPI as\n",
     "\n",

--- a/bindings/csharp/Swig/cntk_cs.i
+++ b/bindings/csharp/Swig/cntk_cs.i
@@ -509,7 +509,7 @@
     // Returns hash code value.
     public override int GetHashCode()
     {
-        // Todo: the hash value in C++ is size_t, but only in in C#
+        // Todo: the hash value in C++ is size_t, but only in C#
         return (int)_GetHashValue();
     }
 %}

--- a/bindings/python/cntk/io/__init__.py
+++ b/bindings/python/cntk/io/__init__.py
@@ -564,7 +564,7 @@ class MinibatchSourceFromData(UserMinibatchSource):
         data_streams: name-value pairs
         max_samples (`int`, defaults to :const:`cntk.io.INFINITELY_REPEAT`): The maximum number of samples
           the reader can produce. If inputs are sequences, and the different streams have different
-          lengths, then each sequence counts with the the maximum length.
+          lengths, then each sequence counts with the maximum length.
           After this number has been reached, the reader
           returns empty minibatches on subsequent calls to :meth:`next_minibatch`.
           **Important:**

--- a/bindings/python/cntk/layers/layers.py
+++ b/bindings/python/cntk/layers/layers.py
@@ -119,7 +119,7 @@ def Dense(shape, activation=default_override_or(identity), init=default_override
     #  - by default, equal to the dimensions of the input passed to Dense()
     #  - if input_rank is given, then the last 'input_rank' dimensions of the input (all others are not reduced over)
     #  - if map_rank is given, then the all but the first 'map_rank' dimensions of the input (those are not reduced over)
-    # where input_rank and map_rank are mutuallly exclusive.
+    # where input_rank and map_rank are mutually exclusive.
 
     output_rank = len(output_shape)   # support outputs with tensor layouts
 
@@ -158,7 +158,7 @@ def Embedding(shape=None, init=default_override_or(C.glorot_uniform()), weights=
     Layer factory function to create a embedding layer.
 
     An embedding is conceptually a lookup table. For every input token (e.g. a word or any category label), the corresponding
-    entry in in the lookup table is returned.
+    entry in the lookup table is returned.
 
     In CNTK, discrete items such as words are represented as one-hot vectors.
     The table lookup is realized as a matrix product, with a matrix

--- a/bindings/python/cntk/ops/__init__.py
+++ b/bindings/python/cntk/ops/__init__.py
@@ -2468,7 +2468,7 @@ def random_sample_inclusion_frequency(
     '''
     For weighted sampling with the specifed sample size (`num_samples`)
     this operation computes the expected number of occurences of each class
-    in the the sampled set. In case of sampling without replacement
+    in the sampled set. In case of sampling without replacement
     the result is only an estimate which might be quite rough in the
     case of small sample sizes.
     Intended uses are e.g. sampled softmax, noise contrastive


### PR DESCRIPTION
This PR fixes some typos: `be be`, `the the`, `succesfully`, `in in`, `inefficent`, `tranformers`, `occured`, `trainning`, `infomation`, and `mutuallly`.