### PR TITLE
Fix typos

### DIFF
--- a/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
+++ b/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
@@ -2200,7 +2200,7 @@ private:
     // Implementation note: The Variable type is a value type and not polymorphic in nature. 
     // However we have a couple of derivatives of the type to extend the base interface and thus we ensure that the derived types do not have additional fields.
     // This check is weak in that the derives types may sneak in some additional fields if the base type had some padding at the end, without changing the object size
-    // but it should be good enough for catching any accidental addiiton of fields.
+    // but it should be good enough for catching any accidental addition of fields.
     static_assert(sizeof(Constant) == sizeof(Variable), "The Constant type should not have any data fields beyond what its base type 'Variable' has.");
 }
 
@@ -4963,7 +4963,7 @@ namespace CNTK
         CNTK_API const std::vector<LearnerPtr>& ParameterLearners() const;
 
         ///
-        /// Total number of samples seen from the begining of the training.
+        /// Total number of samples seen from the beginning of the training.
         ///
         CNTK_API size_t TotalNumberOfSamplesSeen() const;
 

--- a/Source/CNTKv2LibraryDll/CompositeFunction.cpp
+++ b/Source/CNTKv2LibraryDll/CompositeFunction.cpp
@@ -336,7 +336,7 @@ namespace CNTK
 
     void CompositeFunction::CopyState(const CompositeFunction& source)
     {
-        // Collect a vector of stateful funciton uids using a pre-order traversal of a function graphs.
+        // Collect a vector of stateful function uids using a pre-order traversal of a function graphs.
         auto collectStatefulFunctionUIDs = [](const Function& function) -> vector<wstring> {
             vector<wstring> uids;
             PreorderTraverseFunctions(function.RootFunction(), [&uids](const FunctionPtr& funcPtr) {

--- a/Source/Common/Include/ASGDHelper.h
+++ b/Source/Common/Include/ASGDHelper.h
@@ -58,7 +58,7 @@ ASGDHelper<ElemType>* NewASGDHelper(
     bool useAsyncBuffered = true,                                            // Using asynchonous buffer to hide communication cost
     bool isSimulatedModelAveragingSGD = false,                               // Using parameter server-based MA rather than ASGD
     AdjustLearningRateAtBeginning adjusttype =
-    AdjustLearningRateAtBeginning::None,                                     // Adjust learning per minibatches at very begining of training process
+    AdjustLearningRateAtBeginning::None,                                     // Adjust learning per minibatches at very beginning of training process
     double adjustCoef = 0.2,                                                 // see in DecayCoefficient()
     size_t adjustPerMinibatches = 600,                                       //
     int traceLevel = 0,                                                      // log level

--- a/Source/ComputationNetworkLib/ComputationNetworkAnalysis.cpp
+++ b/Source/ComputationNetworkLib/ComputationNetworkAnalysis.cpp
@@ -43,7 +43,7 @@ void ComputationNetwork::FormRecurrentLoops(const ComputationNodeBasePtr& rootNo
     const list<ComputationNodeBasePtr>& nodes = GetEvalOrder(rootNode);
 
     // initialize the node state owned by us
-    // TODO: Verify that the other call to this function is unecessary, then inline this function here.
+    // TODO: Verify that the other call to this function is unnecessary, then inline this function here.
     for (auto& node : nodes)
         node->PurgeStateForFormingRecurrentLoops();
 

--- a/Source/ComputationNetworkLib/ComputationNode.h
+++ b/Source/ComputationNetworkLib/ComputationNode.h
@@ -1791,7 +1791,7 @@ public:
     }
 
     // request matrices needed to do node function value evaluation
-    // for memory pool utilization optimizaiton, the requested pointer is not immediately useable until the entire network has gone through all requests 
+    // for memory pool utilization optimization, the requested pointer is not immediately useable until the entire network has gone through all requests 
     virtual void RequestMatricesBeforeForwardProp(MatrixPool& matrixPool) override
     {
         size_t matrixSize = m_sampleLayout.GetNumElements();

--- a/Source/Readers/LMSequenceReader/SequenceReader.cpp
+++ b/Source/Readers/LMSequenceReader/SequenceReader.cpp
@@ -182,7 +182,7 @@ bool SequenceReader<ElemType>::EnsureDataAvailable(size_t mbStartSample, bool /*
                 // check for end of sequence marker
                 if (!bSentenceStart && (EqualCI(labelValue, m_labelInfo[labelInfoIn].endSequence) || ((label - 1) % m_mbSize == 0)))
                 {
-                    // ignore those cases where $</s> is put in the begining, because those are used for initialization purpose
+                    // ignore those cases where $</s> is put in the beginning, because those are used for initialization purpose
                     spos.flags |= seqFlagStopLabel;
                     sequencesRead++;
 
@@ -276,7 +276,7 @@ bool SequenceReader<ElemType>::EnsureDataAvailable(size_t mbStartSample, bool /*
                 int jEnd = (int) m_labelIdData.size() - 1;
                 LabelIdType index;
                 if (CheckIdFromLabel(labelInfo.endSequence, labelInfo, index) == false)
-                    RuntimeError("cannot find sentence begining label");
+                    RuntimeError("cannot find sentence beginning label");
 
                 if (m_labelIdData[jEnd] != index)
                     // for language model, the first word/letter has to be <s>
@@ -966,7 +966,7 @@ bool SequenceReader<ElemType>::SentenceEnd()
     {
         LabelIdType index;
         if (CheckIdFromLabel(labelInfo.endSequence, labelInfo, index) == false)
-            RuntimeError("cannot find sentence begining label");
+            RuntimeError("cannot find sentence beginning label");
 
         if (m_labelIdData[jEnd] == index)
             return true;
@@ -979,7 +979,7 @@ bool SequenceReader<ElemType>::SentenceEnd()
 /// the output label is a [4 x T] matrix, where T is the number of words observed
 /// the first row is the word index
 /// the second row is the class id of this word
-/// the third row is begining index of the class for this word
+/// the third row is beginning index of the class for this word
 /// the fourth row is the ending index + 1 of the class for this word
 template <class ElemType>
 void SequenceReader<ElemType>::GetLabelOutput(StreamMinibatchInputs& matrices,
@@ -1023,8 +1023,8 @@ void SequenceReader<ElemType>::GetLabelOutput(StreamMinibatchInputs& matrices,
             if (m_classSize > 0)
             {
                 labels.SetValue(1, j, (ElemType) clsidx);
-                // save the [begining ending_indx) of the class
-                labels.SetValue(2, j, (*m_classInfoLocal)(0, clsidx)); // begining index of the class
+                // save the [beginning ending_indx) of the class
+                labels.SetValue(2, j, (*m_classInfoLocal)(0, clsidx)); // beginning index of the class
                 labels.SetValue(3, j, (*m_classInfoLocal)(1, clsidx)); // end index of the class
             }
         }
@@ -2081,8 +2081,8 @@ bool BatchSequenceReader<ElemType>::DataEnd()
 // the following comments are obsolete now
 // 1st row is the word id
 // 2nd row is the class id of this word
-// 3rd and 4th rows are the begining and ending indices of this class
-// notice that indices are defined as follows [begining ending_indx) of the class
+// 3rd and 4th rows are the beginning and ending indices of this class
+// notice that indices are defined as follows [beginning ending_indx) of the class
 // i.e., the ending_index is 1 plus of the true ending index
 // This is a subroutine to GetMinibatch() and is only called from there.
 template <class ElemType>
@@ -2134,7 +2134,7 @@ void BatchSequenceReader<ElemType>::GetLabelOutput(StreamMinibatchInputs& matric
             {
                 labels.SetValue(1, j, (ElemType) clsidx);
 
-                // save the [begining ending_indx) of the class
+                // save the [beginning ending_indx) of the class
                 size_t lft = (size_t) (*m_classInfoLocal)(0, clsidx);
                 size_t rgt = (size_t) (*m_classInfoLocal)(1, clsidx);
                 if (wrd < lft || lft > rgt || wrd >= rgt)
@@ -2142,7 +2142,7 @@ void BatchSequenceReader<ElemType>::GetLabelOutput(StreamMinibatchInputs& matric
                     LogicError("LMSequenceReader::GetLabelOutput word %d should be at least equal to or larger than its class's left index %d; right index %d of its class should be larger or equal to left index %d of its class; word index %d should be smaller than its class's right index %d.\n",
                                (int) wrd, (int) lft, (int) rgt, (int) lft, (int) wrd, (int) rgt);
                 }
-                labels.SetValue(2, j, (*m_classInfoLocal)(0, clsidx)); // begining index of the class
+                labels.SetValue(2, j, (*m_classInfoLocal)(0, clsidx)); // beginning index of the class
                 labels.SetValue(3, j, (*m_classInfoLocal)(1, clsidx)); // end index of the class
             }
         }

--- a/Source/Readers/LUSequenceReader/LUSequenceParser.cpp
+++ b/Source/Readers/LUSequenceReader/LUSequenceParser.cpp
@@ -70,7 +70,7 @@ long BatchLUSequenceParser<NumType, LabelType>::Parse(size_t recordsRequested, s
         {
             if (canMultiplePassData)
             {
-                ParseReset(); // restart from the corpus begining
+                ParseReset(); // restart from the corpus beginning
                 continue;
             }
             else

--- a/Source/Readers/LUSequenceReader/LUSequenceReader.cpp
+++ b/Source/Readers/LUSequenceReader/LUSequenceReader.cpp
@@ -699,7 +699,7 @@ bool BatchLUSequenceReader<ElemType>::EnsureDataAvailable(size_t /*mbStartSample
         if (mSentenceEndAt.size() != mToProcess.size())
             RuntimeError("LUSequenceReader : need to preallocate mSentenceEnd");
         if (mMaxSentenceLength > m_mbSize)
-            RuntimeError("LUSequenceReader : minibatch size needs to be large enough to accomodate the longest sentence");
+            RuntimeError("LUSequenceReader : minibatch size needs to be large enough to accommodate the longest sentence");
 
         // reset all sentence-end indices to NO_INPUT, which is negative
         mSentenceEndAt.assign(mSentenceEndAt.size(), NO_INPUT);
@@ -1019,7 +1019,7 @@ bool BatchLUSequenceReader<ElemType>::DataEnd()
     for (size_t i = 0; i < mToProcess.size(); i++)
     {
         if (mSentenceEndAt[i] == NO_INPUT)
-            LogicError("BatchLUSequenceReader: Minibatch should be large enough to accomodate the longest sentence.");
+            LogicError("BatchLUSequenceReader: Minibatch should be large enough to accommodate the longest sentence.");
         size_t k = mToProcess[i];
         mProcessed[k] = true;
     }

--- a/Source/SGDLib/ASGDHelper.cpp
+++ b/Source/SGDLib/ASGDHelper.cpp
@@ -87,7 +87,7 @@ public:
         size_t nodeNumRanks,                                                            // Number of working nodes
         bool useAsyncBuffer = true,                                                   // Using asynchonous buffer to hide communication cost
         bool isSimulatedModelAveragingSGD = false,                                      // Using parameter server-based MA rather than ASGD
-        AdjustLearningRateAtBeginning adjusttype = AdjustLearningRateAtBeginning::None, // Adjust learning per minibatches at very begining of training process
+        AdjustLearningRateAtBeginning adjusttype = AdjustLearningRateAtBeginning::None, // Adjust learning per minibatches at very beginning of training process
         // this could be used to tackle the unstableness of ASGD
         double adjustCoef = 0.2,                                                        // see in DecayCoefficient()
         size_t adjustPerMinibatches = 600,                                              //

--- a/Source/SequenceTrainingLib/latticeforwardbackward.cpp
+++ b/Source/SequenceTrainingLib/latticeforwardbackward.cpp
@@ -1249,7 +1249,7 @@ void sMBRdiagnostics(const msra::math::ssematrixbase &errorsignal, const_array_r
         // for each frame, print error signal for ground truth and runner up (second largest abs value)
         size_t sneg = SIZE_MAX; // competitor
         float eneg = 0.0f;
-        size_t spos = SIZE_MAX; // best postive competitor
+        size_t spos = SIZE_MAX; // best positive competitor
         float epos = 0.0f;
         foreach_row (s, errorsignal)
         {

--- a/Tests/UnitTests/V2LibraryTests/FunctionTests.cpp
+++ b/Tests/UnitTests/V2LibraryTests/FunctionTests.cpp
@@ -932,7 +932,7 @@ void TestFindName(const DeviceDescriptor& device)
     CheckFindByNameResult(minusFunc3->FindByName(minusFuncName), minusFunc3);
     CheckFindByNameResult(minusFunc3->FindByName(blockFuncName), blockFunc);
 
-    // Test FindByName with block funcitons, nestedSearchInsideBlockFunction is true
+    // Test FindByName with block functions, nestedSearchInsideBlockFunction is true
     CheckFindByNameResult(minusFunc3->FindByName(anotherPlusFuncName, true), anotherPlusFunc1);
     CheckFindByNameResult(minusFunc3->FindByName(anotherMinusFuncName, true), anotherMinusFunc1);
     CheckFindByNameResult(minusFunc3->FindByName(nonExistingFuncName, true), nullptr);
@@ -978,7 +978,7 @@ void TestFindName(const DeviceDescriptor& device)
     CheckFindAllWithNameResult(minusFunc3->FindAllWithName(minusFuncName), minusFuncName, 1);
     CheckFindAllWithNameResult(minusFunc3->FindAllWithName(blockFuncName), blockFuncName, 1);
 
-    // Test FindAllWithName with block funcitons, nestedSearchInsideBlockFunction is true
+    // Test FindAllWithName with block functions, nestedSearchInsideBlockFunction is true
     CheckFindAllWithNameResult(minusFunc3->FindAllWithName(anotherPlusFuncName, true), anotherPlusFuncName, 1);
     CheckFindAllWithNameResult(minusFunc3->FindAllWithName(anotherMinusFuncName, true), anotherMinusFuncName, 1);
     CheckFindAllWithNameResult(minusFunc3->FindAllWithName(nonExistingFuncName, true), nonExistingFuncName, 0);


### PR DESCRIPTION
This PR fixes some typos: `addiiton`, `begining`, `funciton`, `unecessary`, `optimizaiton`, `accomodate`, and `postive`.