### PR TITLE
Fix typos

### DIFF
--- a/Source/Common/Include/ssematrix.h
+++ b/Source/Common/Include/ssematrix.h
@@ -519,7 +519,7 @@ public:
     }
 
 private:
-    // guess how many colunmns of this matrix will fit into the cache
+    // guess how many columns of this matrix will fit into the cache
     // This is a helper function for matrix matprod and variants.
     // Result also gets aligned to 4 because matprod benefits from it.
     size_t cacheablecols() const

--- a/Source/ComputationNetworkLib/ComputationNetworkEditing.cpp
+++ b/Source/ComputationNetworkLib/ComputationNetworkEditing.cpp
@@ -37,7 +37,7 @@ ComputationNodeBasePtr ComputationNetwork::CopyNode(const ComputationNetwork& fr
     ComputationNodeBasePtr pFromNode = fromNet.GetNodeFromName(fromName);
     ComputationNodeBasePtr pToNode;
 
-    // don't allow cross network child copy unless caller explicity handles children fixup
+    // don't allow cross network child copy unless caller explicitly handles children fixup
     if ((flags & CopyNodeFlags::copyNodeInputLinks) &&
         this != &fromNet && !(flags & CopyNodeFlags::copyNodeAcrossNetworks))
     {

--- a/Source/Math/CPUMatrixImpl.h
+++ b/Source/Math/CPUMatrixImpl.h
@@ -6090,7 +6090,7 @@ void CPUMatrix<ElemType>::RCRFBackwardCompute(const CPUMatrix<ElemType>& alpha, 
 // phoneBound (input): phone boundary (frame index) of each phone for each utterance in this minibatch, each col is one utterance 
 // uttToChanInd (input):  map from utterance ID to minibatch channel ID. We need this because each channel may contain more than one utterance.
 // uttFrameNum (input): the frame number of each utterance. The size of this vector =  the number of all utterances in this minibatch
-// uttBeginFrame(input): the positon of the first frame of each utterance in the minibatch channel. We need this because each channel may contain more than one utterance.
+// uttBeginFrame(input): the position of the first frame of each utterance in the minibatch channel. We need this because each channel may contain more than one utterance.
 // uttPhoneNum (input): the phone number of each utterance. The size of this vector =  the number of all utterances in this minibatch
 // numChannels (input): channel number in this minibatch
 // uttNum (input): number of utterances

--- a/Source/Math/GPUMatrix.cu
+++ b/Source/Math/GPUMatrix.cu
@@ -4511,7 +4511,7 @@ GPUMatrix<ElemType>& GPUMatrix<ElemType>::GetARowByIndex(const GPUMatrix<ElemTyp
 // phoneBoundary (input): phone boundary (frame index) of each phone for each utterance in this minibatch, each col is one utterance 
 // totalScore (output): total CTC score
 // uttToChanInd (input):  map from utterance ID to minibatch channel ID. We need this because each channel may contain more than one utterance.
-// uttBeginFrame(input): the positon of the first frame of each utterance in the minibatch channel. We need this because each channel may contain more than one utterance.
+// uttBeginFrame(input): the position of the first frame of each utterance in the minibatch channel. We need this because each channel may contain more than one utterance.
 // uttFrameNum (input): the frame number of each utterance. The size of this vector =  the number of all utterances in this minibatch
 // uttPhoneNum (input): the phone number of each utterance. The size of this vector =  the number of all utterances in this minibatch
 // numParallelSequences (input): channel number in this minibatch

--- a/Source/Math/GPUMatrixCUDAKernels.cuh
+++ b/Source/Math/GPUMatrixCUDAKernels.cuh
@@ -5375,7 +5375,7 @@ __global__ void _adadelta4BlockSparseCol(CUDA_LONG size,
 // phoneBound (input): phone boundary (frame index) of each phone for each utterance in this minibatch, each col is one utterance 
 // uttToChanInd (input):  map from utterance ID to minibatch channel ID. We need this because each channel may contain more than one utterance.
 // uttFrameNum (input): the frame number of each utterance. The size of this vector =  the number of all utterances in this minibatch
-// uttBeginFrame(input): the positon of the first frame of each utterance in the minibatch channel. We need this because each channel may contain more than one utterance.
+// uttBeginFrame(input): the position of the first frame of each utterance in the minibatch channel. We need this because each channel may contain more than one utterance.
 // uttPhoneNum (input): the phone number of each utterance. The size of this vector =  the number of all utterances in this minibatch
 // numChannels (input): channel number in this minibatch
 // uttNum (input): number of utterances

--- a/Source/Math/Matrix.cpp
+++ b/Source/Math/Matrix.cpp
@@ -5875,7 +5875,7 @@ Matrix<ElemType>& Matrix<ElemType>::AssignSequenceError(const ElemType hsmoothin
 // phoneBound (input): phone boundary (frame index) of each phone for each utterance in this minibatch, each col is one utterance 
 // totalScore (output): total CTC score
 // uttToChanInd (input):  map from utterance ID to minibatch channel ID. We need this because each channel may contain more than one utterance.
-// uttBeginFrame(input): the positon of the first frame of each utterance in the minibatch channel. We need this because each channel may contain more than one utterance.
+// uttBeginFrame(input): the position of the first frame of each utterance in the minibatch channel. We need this because each channel may contain more than one utterance.
 // uttFrameNum (input): the frame number of each utterance. The size of this vector =  the number of all utterances in this minibatch
 // uttPhoneNum (input): the phone number of each utterance. The size of this vector =  the number of all utterances in this minibatch
 // numParallelSequences (input): num of parallel sequences

--- a/Source/Readers/HTKDeserializers/ConfigHelper.h
+++ b/Source/Readers/HTKDeserializers/ConfigHelper.h
@@ -58,7 +58,7 @@ public:
         std::vector<std::wstring>& hmms,
         std::vector<std::wstring>& lattices);
 
-    // Gets mlf file paths from the configuraiton.
+    // Gets mlf file paths from the configuration.
     std::vector<std::wstring> GetMlfPaths() const;
 
     // Gets utterance paths from the configuration.

--- a/Source/Readers/Kaldi2Reader/ssematrix.h
+++ b/Source/Readers/Kaldi2Reader/ssematrix.h
@@ -511,7 +511,7 @@ public:
     }
 
 private:
-    // guess how many colunmns of this matrix will fit into the cache
+    // guess how many columns of this matrix will fit into the cache
     // This is a helper function for matrix matprod and variants.
     // Result also gets aligned to 4 because matprod benefits from it.
     size_t cacheablecols() const

--- a/Source/SGDLib/DataReaderHelpers.h
+++ b/Source/SGDLib/DataReaderHelpers.h
@@ -263,7 +263,7 @@ namespace Microsoft { namespace MSR { namespace CNTK {
     // TODO: Can this just exist inside SGD.cpp?
     // ===================================================================
 
-    // A sub-minibathc is a part of a minibatch which helps computing large minibatches that cannot load into GPU memory in one forward-backward computation
+    // A sub-minibatch is a part of a minibatch which helps computing large minibatches that cannot load into GPU memory in one forward-backward computation
     // The usage would be :
     //        SubminibatchHelpers sbhelper;
     //        for (;;)

--- a/Source/SGDLib/SGD.h
+++ b/Source/SGDLib/SGD.h
@@ -194,7 +194,7 @@ protected:
     // Due to the GPU memory limitations, it is sometime not possible to hold the m_mbSize in RAM.
     // To mitigate this issue, we adopt the sub-minibatch implementation, where
     // each m_mbSize[epoch] is divided by a few sub-minibatch of which size will be no more than m_maxSamplesInRAM
-    // a forward-backward is performed for each sub-minibathch; a model update is performed after each minibatch
+    // a forward-backward is performed for each sub-minibatch; a model update is performed after each minibatch
     size_t m_numSubminiBatches;
     // alternative method to specify how to split minibatches into subminibatches
     // default is 1, which means no subminibatch is used

--- a/Source/SequenceTrainingLib/gammacalculation.h
+++ b/Source/SequenceTrainingLib/gammacalculation.h
@@ -290,7 +290,7 @@ public:
         size_t mbsize = numCols / numParallelSequences;
 
         // Prepare data structures from the reader
-        // the positon of the first frame of each utterance in the minibatch channel. We need this because each channel may contain more than one utterance.
+        // the position of the first frame of each utterance in the minibatch channel. We need this because each channel may contain more than one utterance.
         std::vector<size_t> uttBeginFrame;
         // the frame number of each utterance. The size of this vector =  the number of all utterances in this minibatch
         std::vector<size_t> uttFrameNum;


### PR DESCRIPTION
This PR fixes some typos: `colunmns`, `explicity`, `positon`, `configuraiton`, and `minibathch`.