### PR TITLE
Improve exception msg for load_model

### DIFF
--- a/bindings/python/cntk/ops/functions.py
+++ b/bindings/python/cntk/ops/functions.py
@@ -1517,7 +1517,7 @@ class Function(cntk_py.Function):
         if is_file:
             return cntk_py.Function.load(model, device)
 
-        raise ValueError('Cannot load a model that is neither a file nor a byte buffer.')
+        raise ValueError('Cannot load the model {} that is neither a file nor a byte buffer.'.format(model))
 
     @staticmethod
     def with_signature(*args, **kwargs):


### PR DESCRIPTION
Currently the exception msg for load_model does not contain the model name, but with model name it is faster to debug code.

old:
```python
>>> cntk.load_model('path/to/non/exsisting/model')
Selected CPU as the process wide default device.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...\Anaconda3\lib\site-packages\cntk\internal\swig_helper.py", line 69, in wrapper
    result = f(*args, **kwds)
  File "...\Anaconda3\lib\site-packages\cntk\ops\functions.py", line 1272, in load_model
    return Function.load(model, device)
  File "...\Anaconda3\lib\site-packages\cntk\internal\swig_helper.py", line 69, in wrapper
    result = f(*args, **kwds)
  File "...\Anaconda3\lib\site-packages\cntk\ops\functions.py", line 1222, in load
    raise ValueError('Cannot load a model that is neither a file nor a byte buffer.')
ValueError: Cannot load a model that is neither a file nor a byte buffer.
```

new:
```python
>>> cntk.load_model('path/to/non/exsisting/model')
Selected CPU as the process wide default device.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File .../cntk/bindings/python/cntk/internal/swig_helper.py", line 74, in wrapper
    result = f(*args, **kwds)
  File .../cntk/bindings/python/cntk/ops/functions.py", line 1627, in load_model
    return Function.load(model, device)
  File ".../cntk/bindings/python/cntk/internal/swig_helper.py", line 74, in wrapper
    result = f(*args, **kwds)
  File ".../cntk/bindings/python/cntk/ops/functions.py", line 1543, in load
    raise ValueError('Cannot load the model {} that is neither a file nor a byte buffer.'.format(model))
ValueError: Cannot load the model path/to/non/exsisting/model that is neither a file nor a byte buffer.
```

