### PR TITLE
Fix load_model for python3.6 with pathlib

### DIFF
--- a/bindings/python/cntk/ops/functions.py
+++ b/bindings/python/cntk/ops/functions.py
@@ -1515,7 +1515,7 @@ class Function(cntk_py.Function):
             return cntk_py.Function.load_from_buffer(model, device)
 
         if is_file:
-            return cntk_py.Function.load(model, device)
+            return cntk_py.Function.load(str(model), device)
 
         raise ValueError('Cannot load the model {} that is neither a file nor a byte buffer.'.format(model))
 


### PR DESCRIPTION
Python 3.5 introduced pathlib and python 3.6 add support for pathlib in os.path.
This fix add support for pathlib in load_model for python 3.6.

old exception msg:
```python
>>> cntk.load_model(Path('tmp'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/t-chboed/python/cntk/bindings/python/cntk/internal/swig_helper.py", line 74, in wrapper
    result = f(*args, **kwds)
  File "/home/t-chboed/python/cntk/bindings/python/cntk/ops/functions.py", line 1627, in load_model
    return Function.load(model, device)
  File "/home/t-chboed/python/cntk/bindings/python/cntk/internal/swig_helper.py", line 74, in wrapper
    result = f(*args, **kwds)
  File "/home/t-chboed/python/cntk/bindings/python/cntk/ops/functions.py", line 1541, in load
    return cntk_py.Function.load(model, device)
NotImplementedError: Wrong number or type of arguments for overloaded function 'Function_load'.
  Possible C/C++ prototypes are:
    CNTK::Function::Load(std::wstring const &,CNTK::DeviceDescriptor const &)
    CNTK::Function::Load(std::wstring const &)
    CNTK::Function::Load(std::istream &)
```
