### PR TITLE
Fix typos

### DIFF
--- a/Examples/Evaluation/CNTKLibraryCPPEvalCPUOnlyExamples/EvalMultithreads.cpp
+++ b/Examples/Evaluation/CNTKLibraryCPPEvalCPUOnlyExamples/EvalMultithreads.cpp
@@ -444,7 +444,7 @@ void RunEvaluationOneHidden(FunctionPtr evalFunc, const DeviceDescriptor& device
         for (size_t i = 0; i < numSamples; i++)
         {
             fprintf(stderr, "Iteration:%lu, Sample %lu:\n", (unsigned long)t, (unsigned long)i);
-            fprintf(stderr, "Ouput:");
+            fprintf(stderr, "Output:");
             for (size_t j = 0; j < outputDim; j++)
             {
                 fprintf(stderr, "%f ", outputData[dataIndex++]);

--- a/Source/ComputationNetworkLib/TrainingNodes.cpp
+++ b/Source/ComputationNetworkLib/TrainingNodes.cpp
@@ -31,7 +31,7 @@ template <class ElemType>
         UpdateRngOffset(GetRngOffset() + result.GetNumElements());
         break;
     default:
-        RuntimeError("RandomDistributionNode::ForwardProp: Unkown random distribution type code %d", m_type);
+        RuntimeError("RandomDistributionNode::ForwardProp: Unknown random distribution type code %d", m_type);
     }
 }
 

--- a/Tests/UnitTests/MathTests/GPUSparseMatrixTests.cpp
+++ b/Tests/UnitTests/MathTests/GPUSparseMatrixTests.cpp
@@ -376,9 +376,9 @@ BOOST_FIXTURE_TEST_CASE(GPUSparseTranspose, RandomSeedFixture)
     sparseMatrix.SetMatrixFromCSRFormat(c_i, c_j, c_v, c_size, c_rowCount, c_colCount);
 
     const GPUSparseMatrix<float> transposeMatrixA = sparseMatrix.Transpose();
-    GPUSparseMatrix<float> inplaceTranposeMatrix(sparseMatrix);
-    inplaceTranposeMatrix.InplaceTranspose();
-    BOOST_CHECK(inplaceTranposeMatrix.IsEqualTo(transposeMatrixA));
+    GPUSparseMatrix<float> inplaceTransposeMatrix(sparseMatrix);
+    inplaceTransposeMatrix.InplaceTranspose();
+    BOOST_CHECK(inplaceTransposeMatrix.IsEqualTo(transposeMatrixA));
 
     const GPUSparseMatrix<float> tranposeMatrixB = sparseMatrix.Transpose();
     GPUSparseMatrix<float> assignedTransposeMatrix(c_deviceIdZero);


### PR DESCRIPTION
This PR fixes some typos: `Ouput`, `Unkown`, and `Tranpose`.