### PR TITLE
Adding 'template' keyword (compiling with GCC)

### DIFF
--- a/Source/Math/ColumnQuantizer.h
+++ b/Source/Math/ColumnQuantizer.h
@@ -132,7 +132,8 @@ public:
                 // quantize
                 size_t ij = ColMIDX(i, colIdx, M);
                 ElemType val = inMat[ij] + inResidual[ij];
-                QWordVal qval = valQ.Quantize<ZeroThresholdFor1Bit>(val);
+                // 'template' keyword to compile with GCC
+                QWordVal qval = valQ.template Quantize<ZeroThresholdFor1Bit>(val);
 
                 // compute residual
                 ElemType uval = valQ.Unquantize(qval);


### PR DESCRIPTION
It is the 2nd instance in this file. The first instance was already fixed with the 'template' keyword.

Thanks.