### PR TITLE
Porting to OpenPOWER clusters

### DIFF
--- a/Source/Common/Include/ssefloat4.h
+++ b/Source/Common/Include/ssefloat4.h
@@ -11,7 +11,7 @@
 #include <intrin.h> // for intrinsics
 #endif
 #ifdef __unix__
-#if !defined(__aarch64__)
+#if !defined(__aarch64__) && !defined(__PPC64__)
 #include <x86intrin.h>
 #else
 #define _mm_free(p) free(p)
@@ -36,7 +36,7 @@ namespace msra { namespace math {
 // Since we don't have SSE on ARM64 (NEON has similar functionality but is not identical) we cannot
 // use the SSE implementation on ARM64.
 // TODO: In the future, we should provide a NEON based implementation instead.
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(__PPC64__)
 typedef struct __m128_t
 {
     float f[4];

--- a/Source/Math/BlockHandlerSSE.cpp
+++ b/Source/Math/BlockHandlerSSE.cpp
@@ -9,7 +9,7 @@
 // use the BlockHandlerSSE implementation no ARM64.
 // Therefore, exclude the implementation on ARM64 builds for now.
 // TODO: In the future, we should provide a NEON based implementation instead.
-#if !defined(__aarch64__)
+#if !defined(__aarch64__) && !defined(__PPC64__)
 
 #include <xmmintrin.h>
 #include <emmintrin.h>


### PR DESCRIPTION
I added __PPC64__ definitions to ignore SSE functions that is not available on POWER processors as similar to ARM processors.
(I think we have to add Altivec/VMX implementations, but currently I think these are not necessary if we have GPU)

I also found same problem while compiling Tests/UnitTests/MathTests/BlockMultiplierTests.cpp but I could not find the way to ignore SSE in this test program. I just commented out this test program compilation in the Makefile (But I did not commit this one)
