### PR TITLE
Fix typos

### DIFF
--- a/Source/ActionsLib/NetworkDescriptionLanguage.h
+++ b/Source/ActionsLib/NetworkDescriptionLanguage.h
@@ -57,7 +57,7 @@ class NDLScript;
 template <typename ElemType>
 class NDLNode;
 
-// NDLNodeEvaluator - Node evaluaton interface
+// NDLNodeEvaluator - Node evaluation interface
 // implemented by execution engines to convert script to approriate internal formats
 template <typename ElemType>
 class NDLNodeEvaluator

--- a/Source/CNTK/BrainScript/CNTKCoreLib/CNTK.core.bs
+++ b/Source/CNTK/BrainScript/CNTKCoreLib/CNTK.core.bs
@@ -1038,7 +1038,7 @@ RNNs =
     # Projection is enabled by passing different values for outputDim and cellDim.
     # This is the stateless version that takes the previous state as an input.
     # It returns a dictionary with three members: h and c, and dim=h.dim for convenience. prevState must have h and c.
-    # This function also takes an optional auxiliary input, e.g. for suporting attention models.
+    # This function also takes an optional auxiliary input, e.g. for supporting attention models.
     LSTMBlock (outputDim, cellShape=None, usePeepholes=false, init='glorotUniform', initValueScale=1, enableSelfStabilization=false) =
     {
         cellDim = if Constants.IsNone (cellShape) then outputDim else cellShape
@@ -1110,7 +1110,7 @@ RNNs =
     # Projection is enabled by passing different values for outputDim and cellDim.
     # This is the stateless version that takes the previous state as an input.
     # It returns a dictionary with three members: h and c, and dim=h.dim for convenience. prevState must have h and c.
-    # This function also takes an optional auxiliary input, e.g. for suporting attention models.
+    # This function also takes an optional auxiliary input, e.g. for supporting attention models.
     LSTMP (outputDim, cellDim=outputDim, x, aux=Constants.None, auxDim=aux.dim, prevState, enableSelfStabilization=false, inputDim=0) =
     [
         # TODO: Implement this in terms of the one above. Needs to be tested.
@@ -1254,7 +1254,7 @@ RNNs =
     # GRU -- GRU function with projection and self-stabilization
     # It returns a dictionary with three members: the hidden state h, the cell state c, and dim=h.dim.
     # While c isn't required, we return it for implementations like seq2seq that expect it so that this can be a proper drop-in replacement for LSTM
-    # Like the LSTM function, it also takes an optional auxiliary input, e.g. for suporting attention models.  
+    # Like the LSTM function, it also takes an optional auxiliary input, e.g. for supporting attention models.  
     GRU (outputDim, cellDim=outputDim, x, inputDim=x.dim, aux=Constants.None, auxDim=aux.dim, prevState, enableSelfStabilization=false) =
     [
         S(x) = Parameters.Stabilize (x, enabled=enableSelfStabilization)

--- a/Source/ComputationNetworkLib/TrainingNodes.h
+++ b/Source/ComputationNetworkLib/TrainingNodes.h
@@ -1781,7 +1781,7 @@ public:
 
         size_t nS = InputRef(0).GetNumParallelSequences();
         if (nS != 1)
-            LogicError("CRFNode: >1 parallel sequences are curently not implemented correctly.");
+            LogicError("CRFNode: >1 parallel sequences are currently not implemented correctly.");
         for (size_t i = 0; i < nS; i++) // process parallel sequences one by one  --BUGBUG: We should loop over individual sequences.
         {
             FrameRange sequenceRange = fr.Sequence(i); // FrameRange to select one sequence

--- a/Source/Math/CPUSparseMatrix.cpp
+++ b/Source/Math/CPUSparseMatrix.cpp
@@ -931,7 +931,7 @@ public:
         // Now do the actual multiplication.
         ElemType* valueBuffer = sparse.Buffer() + *sparse.SecondaryIndexLocation(); // Points to the value buffer of the current view (i.e. buffer containing values of non-zero elements).
         int* rowIndexBuffer = sparse.MajorIndexLocation();                          // Points to the index buffer of the current view (i.e. buffer containing indices of non-zero elements).
-        size_t iNonzero = 0;                                                           // Number of nonzero elements handled so far for curent slice view.
+        size_t iNonzero = 0;                                                           // Number of nonzero elements handled so far for current slice view.
         int numPreviosNonzero = sparse.SecondaryIndexLocation()[0];                 // Total number of nonzero values handled in previous slices.
 
         // Loop over columns of the sparse matrix

--- a/bindings/python/cntk/layers/layers.py
+++ b/bindings/python/cntk/layers/layers.py
@@ -413,7 +413,7 @@ def Convolution(filter_shape,     # shape of receptive field, e.g. (3,3)
     emulating_1D = False   # len(filter_shape) < 2 # TODO: 1D no longer needs emulation. Remove all related code once it passes Jenkins.
 
     actual_output_channels_shape = num_filters                if not emulating_output_depth else (1,)
-    actual_reduction_shape       = _INFERRED * reduction_rank if not emulating_input_depth  else _INFERRED  # TODO: C++ suport for 1D
+    actual_reduction_shape       = _INFERRED * reduction_rank if not emulating_input_depth  else _INFERRED  # TODO: C++ support for 1D
     actual_filter_shape          = (1,) * emulating_1D + filter_shape
 
     # add the dimension to the options as well


### PR DESCRIPTION
This PR fixes some typos: `evaluaton`, `suporting`, and `curent`.