### PR TITLE
BS.Constants.Range(dims) as 1D constant tensor

### DIFF
--- a/Source/CNTK/BrainScript/CNTKCoreLib/CNTK.core.bs
+++ b/Source/CNTK/BrainScript/CNTKCoreLib/CNTK.core.bs
@@ -775,6 +775,8 @@ Constants = [
     Zero = ConstantTensor (0, (1))
     One  = ConstantTensor (1, (1))
     OnesTensor (dims) = ConstantTensor (1, dims)
+    # A constant 1D tensor that contains an integer enumeration 0 .. (dims - 1).
+    Range (dim) = Splice( array [0..(dim-1)] ( i => Constant{i} ) )
     # BUGBUG: ZeroesLike() would recreate the full dimension of x. Well, no need if it considers broadcasting. But still wrong if we want to broadcast a vector of different tensor dim.
     #ZeroesLike (x) = CastAs (x, Zero) // read: Cast<x>(Zero)
     #OnesLike (x)   = CastAs (x, One)


### PR DESCRIPTION
The `Range(dims)` is intended to support the creation
of useful masks which are handy when dealing, for example,
with missing data.

The function `Range(dims)` generates a 1D constant tensor
that contains integers numbered from 0 .. (dims -1).

While the implementation is not complicated, it's a
non-trivial use of the primitives provided by BrainScript,
hence the justification for an inclusion in the core lib.

Microsoft/CNTK#2121