### PR TITLE
Remove unavalible link

### DIFF
--- a/Tutorials/CNTK_104_Finance_Timeseries_Basic_with_Pandas_Numpy.ipynb
+++ b/Tutorials/CNTK_104_Finance_Timeseries_Basic_with_Pandas_Numpy.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Tutorial 104: Time Series Basics with Pandas and Finance Data\n",
     "\n",
-    "Contributed by: Avi Thaker https://github.com/athaker/CNTK\n",
+    "Contributed by: Avi Thaker\n",
     "November 20, 2016\n",
     "\n",
     "This tutorial will introduce the use of the Cognitive Toolkit for time series data. We show how to prepare time series data for deep learning algorithms. We will cover training a neural network and evaluating the neural network model. We will also look at the predictive potential on classification of an Exchange-traded Funds ([ETF](https://en.wikipedia.org/wiki/Exchange-traded_fund)), and in this simplified setting how one could trade it. This tutorial serves **only** as an example of how to use neural networks for time series analysis. \n",


### PR DESCRIPTION
In tutorial 104, I find a link to contributors no longer available.