### PR TITLE
Fix HTKFeatureDeserializer to handle pathlib.Path

### DIFF
--- a/bindings/python/cntk/io/__init__.py
+++ b/bindings/python/cntk/io/__init__.py
@@ -738,7 +738,7 @@ def HTKFeatureDeserializer(streams):
         if 'scp' not in stream:
             raise ValueError("No scp files specified for HTKFeatureDeserializer")
         dimension = stream.dim
-        scp_file = stream['scp']
+        scp_file = str(stream['scp'])
         broadcast = stream['broadcast'] if 'broadcast' in stream else False
         defines_mb_size = stream.get('defines_mb_size', False)
         left_context, right_context = stream.context if 'context' in stream\


### PR DESCRIPTION
cntk.io.StreamDef currently does not support pathlib.Path.

Is the conversion to str also correct for python 2.7?