### PR TITLE
Put gradient into a contiguous buffer for faster aggregate

### DIFF
--- a/Source/Math/NcclComm.cpp
+++ b/Source/Math/NcclComm.cpp
@@ -22,12 +22,14 @@ static void operator||(cudaError_t rc, const char *msg)
 NcclComm::NcclComm(int deviceId, const MPIWrapperPtr& mpi)
     : m_ncclComm(nullptr), m_stream(nullptr)
 {
-    if (mpi->IsMultiHost())
-        return;
-
     size_t numRanks = mpi->NumNodesInUse();
     std::vector<int> allDevs(numRanks);
+    std::vector<std::array<char, MPI_MAX_PROCESSOR_NAME>> allHosts(numRanks);
+    std::array<char, MPI_MAX_PROCESSOR_NAME> procName {};
+    int nameLen;
+    MPI_Get_processor_name(procName.data(), &nameLen);
     mpi->Allgather(&deviceId, 1, MPI_INT, allDevs.data(), 1, MPI_INT);
+    mpi->Allgather(procName.data(), MPI_MAX_PROCESSOR_NAME, MPI_CHAR, allHosts[0].data(), MPI_MAX_PROCESSOR_NAME, MPI_CHAR);
 
     for (size_t r = 0; r<numRanks; r++)
     {
@@ -37,7 +39,7 @@ NcclComm::NcclComm(int deviceId, const MPIWrapperPtr& mpi)
             return;
         }
         for (size_t s = 0; s<r; s++)
-            if (allDevs[r] == allDevs[s])
+            if (allHosts[r] == allHosts[s] && allDevs[r] == allDevs[s])
             {
                 fprintf(stderr, "NcclComm: disabled, same device used by more than one rank\n");
                 return;
@@ -47,16 +49,19 @@ NcclComm::NcclComm(int deviceId, const MPIWrapperPtr& mpi)
     ncclUniqueId ncclId;
     ncclResult_t res;
 
-    res = ncclGetUniqueId(&ncclId);
-    if (res != ncclSuccess)
-        RuntimeError("NcclComm failed to obtain ncclUniqueId: %s", ncclGetErrorString(res));
+    if (mpi->IsMainNode())
+    {
+        res = ncclGetUniqueId(&ncclId);
+        if (res != ncclSuccess)
+            RuntimeError("NcclComm failed to obtain ncclUniqueId: %s", ncclGetErrorString(res));
+    }
 
     mpi->Bcast(&ncclId, NCCL_UNIQUE_ID_BYTES, MPI_CHAR, 0);
 
     PrepareDevice(deviceId);
     res = ncclCommInitRank(&m_ncclComm, numRanks, ncclId, mpi->CurrentNodeRank());
     if (res != ncclSuccess)
-      RuntimeError("NcclComm failed to initialize ncclComm_t: %s", ncclGetErrorString(res));
+        RuntimeError("NcclComm failed to initialize: %s", ncclGetErrorString(res));
 
     cudaStreamCreateWithFlags(&m_stream, cudaStreamDefault)
         || "cudaStreamCreateWithFlags failed";

--- a/Source/SGDLib/SGD.h
+++ b/Source/SGDLib/SGD.h
@@ -362,7 +362,8 @@ public:
           m_prevChosenMinibatchSize(0),
           m_lastFinishedEpochTrainLoss(0.0),
           m_distGradAgg(nullptr),
-          m_gradHeader(nullptr)
+          m_gradHeader(nullptr),
+          m_gradAlloc(nullptr), m_useMergedGrads(false)
     {
         msra::files::make_intermediate_dirs(m_modelPath);
     }
@@ -592,6 +593,8 @@ protected:
 
     std::shared_ptr<IDistGradAggregator<ElemType>> m_distGradAgg;
     std::shared_ptr<struct DistGradHeader> m_gradHeader;
+    std::shared_ptr<Matrix<ElemType>> m_gradAlloc;
+    bool m_useMergedGrads;
 
     shared_ptr<IMASGD<ElemType>> m_pMASGDHelper;
 


### PR DESCRIPTION
This approach switches the underlying matrix of each gradient tensor with a slice of a contiguous buffer. So there won't be extra memcpy and all matrix should be put together.

This is done after the memory sharing is decided.
In best case, where these matrix are not shared with other matrices, the memory usage remain same.
In worst case, the memory consumption will be increased by some fraction of total size of gradient.

In cases there is not enough memory for contiguous buffer, it will fall back to not using it. So nothing will fail because of turning on this.
  
