### PR TITLE
Adding Dockerfile for CNTK on Arch Linux

### DIFF
--- a/Tools/docker/CNTK-CPUOnly-Image_ArchLinux/Dockerfile
+++ b/Tools/docker/CNTK-CPUOnly-Image_ArchLinux/Dockerfile
@@ -1,0 +1,89 @@
+# CNTK Dockerfile
+#   CPU only
+#   No 1-bit SGD
+FROM imriss/archlinux
+RUN echo 'CNTK CPUOnly on Arch Linux'
+MAINTAINER Reza Farrahi <imriss@ieee.org>
+LABEL description="CNTK CPUOnly / Arch Linux"
+
+RUN  pacman -Syyu --noconfirm && \
+  pacman -S findutils nano vi --noconfirm && \
+  pacman-db-upgrade && \
+  export editor=nano && \
+  pacman -S --noconfirm systemd python python-yaml wget python-pip openssh git curl jq yajl perl expac \
+  gcc gcc-libs clang && \
+  pip install --upgrade pip && \
+  pip install simplejson
+
+# DDADD https://raw.githubusercontent.com/imriss/scylla/master/aur.sh /usr/sbin/aur.sh
+# DDADD https://raw.githubusercontent.com/imriss/scylla/master/add-aur.sh /usr/sbin/add-aur
+ADD ./aur.sh /usr/sbin/aur.sh
+ADD ./add-aur.sh /usr/sbin/add-aur
+RUN chmod u+x /usr/sbin/aur.sh
+RUN chmod u+x /usr/sbin/add-aur
+RUN export "PATH=/usr/bin/core_perl:$PATH" && \
+  add-aur docker
+
+RUN su docker -c 'pacaur -S --noprogressbar --noedit --noconfirm base-devel expect cmake gcc-fortran \
+    ffmpeg jasper libjpeg-turbo libpng lapacke libtiff protobuf python-protobuf unzip automake libtool autoconf \
+    subversion apr apr-util serf m4 jdk7-openjdk openmpi python2-mpi4py libzip opencv blas boost boost-libs swig \
+    anaconda '
+
+# ENV PATH /usr/local/mpi/bin:$PATH
+ENV LD_LIBRARY_PATH /usr/lib/openmpi/:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH /usr/local/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH /usr/lib:$LD_LIBRARY_PATH
+
+# Install CNTK custom MKL
+RUN CNTK_CUSTOM_MKL_VERSION=3 && \
+    mkdir /usr/local/CNTKCustomMKL && \
+    wget --no-verbose -O - https://www.cntk.ai/mkl/CNTKCustomMKL-Linux-$CNTK_CUSTOM_MKL_VERSION.tgz | \
+    tar -xzf - -C /usr/local/CNTKCustomMKL
+
+WORKDIR /cntk
+
+# Build CNTK
+RUN git clone --depth=1 -b master https://github.com/Microsoft/CNTK.git . && \
+    cp /cntk/Scripts/install/linux/conda-linux-cntk-py36-environment.yml /tmp/ && \
+    /opt/anaconda/bin/conda env create -p /opt/anaconda/envs/cntk-py36/ --file /tmp/conda-linux-cntk-py36-environment.yml 
+ENV PATH /opt/anaconda/envs/cntk-py36/bin:$PATH
+ADD activate-cntk ./activate-cntk
+RUN CONFIGURE_OPTS="" && \
+    git submodule update --init Source/Multiverso && \
+    git submodule sync --recursive && \
+    git submodule update --init --recursive && \
+    git submodule sync --recursive && \
+    git submodule update --init --recursive && \
+    sed -i "s,libprotobuf.a,libprotobuf.so,g" Makefile && \ 
+    sed -i "s,libprotobuf.a,libprotobuf.so,g" configure && \
+    sed -i "s,QWordVal qval = valQ.Quantize,QWordVal qval = valQ.template Quantize,g" Source/Math/ColumnQuantizer.h && \ 
+    # sed -i "s,    template CNTK_API const float\* NDArrayView::DataBuffer,    "\
+# "template CNTK_API const TensorView<float>* NDArrayView::GetTensorView<float>() "\
+# "const;"$"\n    template CNTK_API const TensorView<double>* NDArrayView::GetTensorView<double>() "\
+# "const;"$"\n\n    template CNTK_API const float\* NDArrayView::DataBuffer,g" Source/CNTKv2LibraryDll/NDArrayView.cpp && \ 
+    mkdir -p build-mkl/cpu/release && \
+    cd build-mkl/cpu/release && \
+    ../../../configure $CONFIGURE_OPTS --with-mkl=/usr/local/CNTKCustomMKL && \
+    make -j"$(nproc)" all # && \
+    # cd ../../.. && \    
+    # mkdir -p build/cpu/release && \
+    # cd build/cpu/release && \
+    # ../../../configure $CONFIGURE_OPTS --with-openblas=/usr/pkgs/openblas-0.2.19-2 && \
+    # make -j"$(nproc)" all 
+
+# RUN cd Examples/Image/DataSets/CIFAR-10 && \
+    # python install_cifar10.py && \
+    # cd ../../../..
+
+# RUN cd Examples/Image/DataSets/MNIST && \
+    # python install_mnist.py && \
+    # cd ../../../..
+
+RUN pacman -Scc --noconfirm && \
+  rm /var/cache/pacman/pkg/* && \
+  paccache -rf && \
+  rm -rd /home/docker/sandground && \
+  echo `du /usr/lib -hd 1`
+
+ENV PATH=/cntk/build-mkl/cpu/release/bin:$PATH PYTHONPATH=/cntk/bindings/python LD_LIBRARY_PATH=/cntk/bindings/python/cntk/libs:$LD_LIBRARY_PATH
+CMD ["source", "/cntk/activate-cntk"]

--- a/Tools/docker/CNTK-CPUOnly-Image_ArchLinux/activate-cntk
+++ b/Tools/docker/CNTK-CPUOnly-Image_ArchLinux/activate-cntk
@@ -1,0 +1,26 @@
+if [ -z "$BASH_VERSION" ]; then
+  echo Error: only Bash is supported.
+elif [ "$(basename "$0" 2> /dev/null)" == "activate-cntk" ]; then
+  echo Error: this script is meant to be sourced. Run 'source activate-cntk'
+else
+  export PATH="/cntk/cntk/bin:$PATH"
+  export LD_LIBRARY_PATH="/cntk/cntk/lib:/cntk/cntk/dependencies/lib:/usr/lib/openmpi:$LD_LIBRARY_PATH"
+  source "/opt/anaconda/bin/activate" "/opt/anaconda/envs/cntk-py36"
+
+  cat <<MESSAGE
+
+************************************************************
+CNTK is activated.
+
+Please checkout tutorials and examples here:
+  /cntk/Tutorials
+  /cntk/Examples
+
+To deactivate the environment run
+
+  source /opt/anaconda/bin/deactivate
+
+************************************************************
+MESSAGE
+
+fi

--- a/Tools/docker/CNTK-CPUOnly-Image_ArchLinux/add-aur.sh
+++ b/Tools/docker/CNTK-CPUOnly-Image_ArchLinux/add-aur.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# this script sets up unattended aur access via pacaur for a user given as the first argument
+set -o pipefail -e
+
+[[ -z "$1" ]] && echo "You must specify a user name" && exit 1
+AUR_USER=$1
+
+# create the user
+useradd -m $AUR_USER
+
+# set the user's password to blank
+echo "${AUR_USER}:" | chpasswd -e
+
+# install devel packages
+pacman -S --needed --noprogressbar --noconfirm base-devel
+
+# give the aur user passwordless sudo powers
+echo "$AUR_USER      ALL = NOPASSWD: ALL" >> /etc/sudoers
+
+# use all possible cores for subsequent package builds
+sed -i 's,#MAKEFLAGS="-j2",MAKEFLAGS="-j$(nproc)",g' /etc/makepkg.conf
+
+# don't compress the packages built here
+sed -i "s,PKGEXT='.pkg.tar.xz',PKGEXT='.pkg.tar',g" /etc/makepkg.conf
+
+# install pacaur
+su $AUR_USER -c 'mkdir /home/docker/sandground'
+su $AUR_USER -c 'cd /home/docker/sandground; bash /usr/sbin/aur.sh -si --noconfirm --needed cower-git pacaur'
+echo "step 1"
+export editor=vi
+export visual=vi
+echo "$editor"
+echo "$visual"
+/usr/sbin/find / -name mysqld.sock
+# su $AUR_USER -c 'cd; rm -rf cower pacaur'
+
+# do a pacaur system update
+su $AUR_USER -c 'pacaur -Syyua --noprogressbar --noedit --noconfirm'
+
+echo "Packages from the AUR can now be installed like this:"
+echo "su $AUR_USER -c 'pacaur -S --needed --noprogressbar --noedit --noconfirm PACKAGE'"

--- a/Tools/docker/CNTK-CPUOnly-Image_ArchLinux/aur.sh
+++ b/Tools/docker/CNTK-CPUOnly-Image_ArchLinux/aur.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+d=${BUILDDIR:-$PWD}
+echo "${BUILDDIR:-$PWD}"
+for p in ${@##-*}
+do
+cd "$d"
+echo "https://aur.archlinux.org/cgit/aur.git/snapshot/$p.tar.gz" 
+curl "https://aur.archlinux.org/cgit/aur.git/snapshot/$p.tar.gz" |tar xz
+cd "$p"
+sed -i -e 's=git://github.com/falconindy/cower=git+https://github.com/falconindy/cower.git=g' PKGBUILD
+echo "makepkg --skippgpcheck ${@##[^\-]*}"
+git config --global url."https://".insteadOf git://
+makepkg --skippgpcheck ${@##[^\-]*}
+echo "$d"
+# /usr/sbin/find / -name "$p.*" 
+# ls -laR "$d"
+# su root -c 'pacman -U $p.tar.xz'
+done

--- a/Tools/docker/CNTK-CPUOnly-Image_ArchLinux/build
+++ b/Tools/docker/CNTK-CPUOnly-Image_ArchLinux/build
@@ -1,0 +1,1 @@
+docker build --tag cntk_cpu_archlinux:v2 .


### PR DESCRIPTION
It builds a container based on Arch Linux distro for CNTK-CPUOnly (v2)

Linux Kernel: 4.11.9
GCC: 7.1.1 (20170621) 
Python: 3.6.0 (Anaconda 4.4.0)
Boost: 1.64.0
OpenMPI: 2.1.1
Protobuf: 3.3.2
