### PR TITLE
Fixing hardwired Libmpi.so version (outdated on Arch Linux)

### DIFF
--- a/bindings/python/cntk/train/distributed.py
+++ b/bindings/python/cntk/train/distributed.py
@@ -7,13 +7,13 @@ from .. import cntk_py
 from ..train import trainer
 from cntk.internal import typemap
 
-# Preload libmpi.so.12 for non-Windows platform to work around MPI_Init failure bug
+# Preload libmpi.so for non-Windows platform to work around MPI_Init failure bug
 # https://xrunhprof.wordpress.com/2014/11/04/an-openmpi-python-and-dlopen-issue/
 # If other OS has similar OpenMPI MPI_Init failure, add dll load to global here
 import platform
 import ctypes
 if platform.system() == 'Linux':
-    ctypes.CDLL("libmpi.so.12", mode=ctypes.RTLD_GLOBAL)
+    ctypes.CDLL("libmpi.so", mode=ctypes.RTLD_GLOBAL)
 
 __doc__= '''\
 Distributed learners manage learners in distributed environment.


### PR DESCRIPTION
The libmpi.so version is 20 (libmpi.so.20) at the moment (and it will change in the future). It is better to use the symbolic link libmpi.so instead which is agnostic to the actual version.