### PR TITLE
install multiverso and install to CMAKE_INSTALL_PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1026,7 +1026,8 @@ $(MULTIVERSO_LIB):
 	@mkdir -p $(LIBDIR)
 	@mkdir -p $(BINDIR)
 	@mkdir -p $(SOURCEDIR)/Multiverso/build/$(BUILDTYPE)
-	@cmake -DCMAKE_VERBOSE_MAKEFILE=TRUE \
+	@cmake -DCMAKE_INSTALL_PREFIX=$(LIBDIR) \
+		-DCMAKE_VERBOSE_MAKEFILE=TRUE \
 		-DCMAKE_CXX_COMPILER=$(CXX) \
 		-DOpenMP_CXX_FLAGS="" \
 		-DOpenMP_C_FLAGS="" \
@@ -1039,6 +1040,7 @@ $(MULTIVERSO_LIB):
 		-DCMAKE_BUILD_TYPE=$(MULTIVERSO_CMAKE_BUILDTYPE) \
 		-B./Source/Multiverso/build/$(BUILDTYPE) -H./Source/Multiverso
 	@make VERBOSE=1 -C ./Source/Multiverso/build/$(BUILDTYPE) -j multiverso
+	@make VERBOSE=1 -C ./Source/Multiverso/build/$(BUILDTYPE) install
 
 UNITTEST_MULTIVERSO_SRC = \
 	$(SOURCEDIR)/Multiverso/Test/unittests/test_array.cpp \


### PR DESCRIPTION
As mentioned in [https://github.com/Microsoft/Multiverso](url)
The make steps for multiverso have `make install`

Also, in `Makefile`, line 1013, `MULTIVERSO_LIB:=$(LIBDIR)/libmultiverso.so`
Therefore, `DCMAKE_INSTALL_PREFIX` is added to install to `$(LIBDIR)`