### PR TITLE
Fix typos

### DIFF
--- a/Manual/Manual_How_to_write_a_custom_deserializer.ipynb
+++ b/Manual/Manual_How_to_write_a_custom_deserializer.ipynb
@@ -141,7 +141,7 @@
    "source": [
     "As can be seen above the main work is done in the constructor, where given the data we infer the information about the exposed streams. The implementation of __get_chunk__ and __num_chunk__ is degenerate for this case because we have a single chunk only. \n",
     "\n",
-    "The chunk is a dictonary that as keys contains the names of the streams and as values either a list of sequences or a NumPy array/CSR matrix (in sample mode when all sequences are of length 1).\n",
+    "The chunk is a dictionary that as keys contains the names of the streams and as values either a list of sequences or a NumPy array/CSR matrix (in sample mode when all sequences are of length 1).\n",
     "\n",
     "Now given the defined above deserializer we can simply create a minibatch source with or without randomization:"
    ]

--- a/Source/CNTK/BrainScript/BrainScriptParser.cpp
+++ b/Source/CNTK/BrainScript/BrainScriptParser.cpp
@@ -976,7 +976,7 @@ public:
         if (GotToken().kind != eof)
             Fail(L"junk at end of source", GetCursor());
     }
-    // top-level parse function parses dictonary members without enclosing [ ... ] and returns it as a dictionary
+    // top-level parse function parses dictionary members without enclosing [ ... ] and returns it as a dictionary
     ExpressionPtr ParseRecordMembersToDict()
     {
         let topMembers = ParseRecordMembers();

--- a/Source/Common/Include/ScriptableObjects.h
+++ b/Source/Common/Include/ScriptableObjects.h
@@ -427,7 +427,7 @@ public:
 
     const ConfigValuePtr &ResolveValue() const // (this is const but mutates the value if it resolves)
     {
-        // call this when a a member might be as-of-yet unresolved, to evaluate it on-demand
+        // call this when a member might be as-of-yet unresolved, to evaluate it on-demand
         // get() is a pointer to a Thunk in that case, that is, a function object that yields the value
         const auto thunkp = GetThunk(); // is it a Thunk?
         if (thunkp)                     // value is a Thunk: we need to resolve

--- a/Tests/UnitTests/ReaderTests/ImageReaderTests.cpp
+++ b/Tests/UnitTests/ReaderTests/ImageReaderTests.cpp
@@ -565,7 +565,7 @@ namespace
     BOOST_AUTO_TEST_CASE(ImageReader3DotsSyntaxInMapFile)
     {
         auto testDir = testDataPath();
-        std::wstring mapFileLocaton = std::wstring(testDir.begin(), testDir.end()) + L"/Data/ImageReader3Dots_map.txt";
+        std::wstring mapFileLocation = std::wstring(testDir.begin(), testDir.end()) + L"/Data/ImageReader3Dots_map.txt";
         HelperRunReaderTest<float>(
             testDataPath() + "/Config/ImageDeserializers.cntk",
             testDataPath() + "/Control/ImageReader3DotsSyntaxInMapFile_Control.txt",
@@ -582,7 +582,7 @@ namespace
             false,
             true,
             true,
-            { L"MapFile=\"" + mapFileLocaton + L"\"" });
+            { L"MapFile=\"" + mapFileLocation + L"\"" });
     }
 
     BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR fixes some typos: `dictonary`, `a a`, and `Locaton`.