### PR TITLE
Fix Typos, bugs and added retrain option in FastRCNN

### DIFF
--- a/Examples/Image/Detection/FastRCNN/A2_RunWithPyModel.py
+++ b/Examples/Image/Detection/FastRCNN/A2_RunWithPyModel.py
@@ -1,10 +1,11 @@
-﻿# Copyright (c) Microsoft. All rights reserved.
+# Copyright (c) Microsoft. All rights reserved.
 
 # Licensed under the MIT license. See LICENSE.md file in the project root
 # for full license information.
 # ==============================================================================
 
 from __future__ import print_function
+from builtins import input as builtin_input
 import cntk as C
 from cntk import *
 from cntk.initializer import glorot_uniform
@@ -204,10 +205,17 @@ if __name__ == '__main__':
     os.chdir(base_path)
     model_path = os.path.join(abs_path, "Output", "frcn_py.model")
 
-    # Train only is no model exists yet
+    # Asks to retrain model if it exists
     if os.path.exists(model_path):
-        print("Loading existing model from %s" % model_path)
-        trained_model = load_model(model_path)
+        print("Model exists in %s" % model_path)
+        retrain_choice = builtin_input('--> INPUT: Press "y" to retrain model, this will delete the previous model:')
+        if retrain_choice.lower() in ['y', 'yes']:
+            trained_model = train_fast_rcnn()
+            trained_model.save(model_path)
+            print("Stored trained model at %s" % model_path)
+        else:
+            print("Loading existing model from %s" % model_path)
+            trained_model = load_model(model_path)
     else:
         trained_model = train_fast_rcnn()
         trained_model.save(model_path)

--- a/Examples/Image/Detection/FastRCNN/PARAMETERS.py
+++ b/Examples/Image/Detection/FastRCNN/PARAMETERS.py
@@ -128,7 +128,7 @@ def get_parameters_for_dataset(datasetName=dataset):
         parameters = GroceryParameters(datasetName)
     elif datasetName.startswith("pascalVoc"):
         parameters = PascalParameters(datasetName)
-    elif dataset.Name == "CustomDataset":
+    elif datasetName == "CustomDataset":
         parameters = CustomDataset(datasetName)
     else:
         ERROR

--- a/Examples/Image/Detection/FastRCNN/README.md
+++ b/Examples/Image/Detection/FastRCNN/README.md
@@ -23,7 +23,7 @@ In this example, we use [AlexNet](../../Classification/AlexNet) as a pre-trained
 
 ### Getting the data and AlexNet model
 
-we use a toy dataset of images captured from a refrigerator to demonstrate Fast-R-CNN. Both the dataset and the pre-trained AlexNet model can be downloaded by running the following Python command:
+We use a toy dataset of images captured from a refrigerator to demonstrate Fast-R-CNN. Both the dataset and the pre-trained AlexNet model can be downloaded by running the following Python command:
 
 `python install_fastrcnn.py`
 
@@ -106,7 +106,7 @@ If you carefully examine the [fastrcnn.cntk](./fastrcnn.cntk) file, you would no
 
 ### Evaluate trained model
 
-One the model has been trained for detection, you may run:
+Once the model has been trained for detection, you may run:
 
 `python A3_ParseAndEvaluateOutput.py`
 


### PR DESCRIPTION
1. Some minor typo fixes in FastRCNN README
2. Corrected wrong variable name when using CustomDataset
3. Added an option to retrain frcn_py.model , this is to address the issue when switching datasets, and also to address the issues described in #1870 and #1909 