### PR TITLE
optimize AggregateGradientsImpl (async pipeline) for non-GDR & GPU sc…

### DIFF
--- a/Source/SGDLib/SimpleDistGradAggregator.h
+++ b/Source/SGDLib/SimpleDistGradAggregator.h
@@ -339,7 +339,7 @@ private:
                 cudaMemcpy(m_intermediateCPUBuffers[gpuToCpuIndex].get(), gpuCopyBuffer->Data(), gpuCopyBuffer->GetNumElements() * sizeof(ElemType), cudaMemcpyDeviceToHost);
                 gpuToCpuIndex++;
 
-                for (i = 1; i <= numGradientIndex; i ++)
+                for (size_t i = 1; i <= numGradientIndex; i ++)
                 {
                     // Get next gradient
                     if (i < numGradientIndex)

--- a/Source/SGDLib/SimpleDistGradAggregator.h
+++ b/Source/SGDLib/SimpleDistGradAggregator.h
@@ -363,7 +363,7 @@ private:
                 currentGradientIndex = i;
             }
             // If currentGradientIndex == -2, it means no gradient index from m_gradientIndexToAggregate
-            if (currentGradientIndex == -2)
+            if (currentGradientIndex != -2)
             {
                 //for last copy
                 if (allReduceIndex != 0)
@@ -390,7 +390,7 @@ private:
                 allReduceRequests.push_back(MPI_Request());
                 reductionBuffer = (i == -1)? m_aggregationBuffer->Data() : gradients[i]->Data();
                 // CPU
-                if (m_mpi->UseGpuGdr() ==0)
+                if (m_mpi->UseGpuGdr() == 0)
                 {
                     m_mpi->Iallreduce(MPI_IN_PLACE, reductionBuffer, (i == -1) ? m_aggregationBuffer->GetNumElements() : gradients[i]->GetNumElements(),
                         MPIWrapper::GetDataType(reductionBuffer), MPI_SUM, &allReduceRequests.back()) || MpiFail("MPI_Iallreduce");


### PR DESCRIPTION
This patch optimizes AggregateGradientsImpl for non-GDR & GPU mode. In our experiment, this can cut almost 50% of aggregation time when training a model with 60 million parameters (using DataParallelSGD, gradientBits=32, MPI=openMPI).

For non-GDR + GPU scenario, the original aggregator uses async GPU/CPU copy and nonblocking (async) allreduce. However, the original pipeline is not efficient with those batched async operations. Because nonblocking MPI calls may not work until MPI Wait() is called. 
![original-pipeline](https://user-images.githubusercontent.com/6314092/28897965-1bf322c6-7798-11e7-9f6b-c4b1907aecba.png)

We changed the pipeline using async GPU/CPU copy and blocking allreduce for overlapping data copy and transmission. 
Our new pipeline for aggregator is:
![new-pipeline](https://user-images.githubusercontent.com/6314092/28896702-5d065c20-7792-11e7-9a33-7b56025f5e29.png)

This commit has been tested under non-GDR + GPU.  
We may also need a CopyGPUToCPUSync() in GPUDataTransferer.

Thank you,
Juncheng