### PR TITLE
Tweaks for cuda9 build support

### DIFF
--- a/Source/Math/CuDnnRNN.h
+++ b/Source/Math/CuDnnRNN.h
@@ -79,14 +79,18 @@ public:
         m_dataType(CuDnnTensor::GetDataType<ElemType>())
     {
         CUDNN_CALL(cudnnCreateRNNDescriptor(&m_rnnDesc));
+#if CUDNN_VERSION >= 7000
+        CUDNN_CALL(cudnnSetRNNDescriptor_v5(m_rnnDesc,
+#else
         CUDNN_CALL(cudnnSetRNNDescriptor(m_rnnDesc,
-            (int)m_rnnAttributes.m_hiddenSize,
-            (int)m_rnnAttributes.m_numLayers,
-            m_dropout,
-            CUDNN_LINEAR_INPUT, // We can also skip the input matrix transformation
-            m_rnnAttributes.m_bidirectional ? CUDNN_BIDIRECTIONAL : CUDNN_UNIDIRECTIONAL,
-            GetMode(),
-            m_dataType));
+#endif
+                                         (int)m_rnnAttributes.m_hiddenSize,
+                                         (int)m_rnnAttributes.m_numLayers,
+                                         m_dropout,
+                                         CUDNN_LINEAR_INPUT, // We can also skip the input matrix transformation
+                                         m_rnnAttributes.m_bidirectional ? CUDNN_BIDIRECTIONAL : CUDNN_UNIDIRECTIONAL,
+                                         GetMode(),
+                                         m_dataType));
     }
 
     ~CuDnnRNN()

--- a/Source/Math/MatrixQuantizer_kernel.cu
+++ b/Source/Math/MatrixQuantizer_kernel.cu
@@ -89,30 +89,35 @@ __device__ void allreduce(T& var)
     {
         var = var + vBuf[threadIdx.x + 32];
         vBuf[threadIdx.x] = var;
+        __syncwarp(0xffffffff);
     }
 
     if ((BLOCKSIZE >= 32) && (threadIdx.x < 16))
     {
         var = var + vBuf[threadIdx.x + 16];
         vBuf[threadIdx.x] = var;
+        __syncwarp(0xffff);
     }
 
     if ((BLOCKSIZE >= 16) && (threadIdx.x < 8))
     {
         var = var + vBuf[threadIdx.x + 8];
         vBuf[threadIdx.x] = var;
+        __syncwarp(0xff);
     }
 
     if ((BLOCKSIZE >= 8) && (threadIdx.x < 4))
     {
         var = var + vBuf[threadIdx.x + 4];
         vBuf[threadIdx.x] = var;
-    }
+        __syncwarp(0xf);
+   }
 
     if ((BLOCKSIZE >= 4) && (threadIdx.x < 2))
     {
         var = var + vBuf[threadIdx.x + 2];
         vBuf[threadIdx.x] = var;
+        __syncwarp(0x3);
     }
 
     if ((BLOCKSIZE >= 2) && (threadIdx.x == 0))


### PR DESCRIPTION
Contains following changes:
- build support for cub1.7, note that build with 1.4 will break
  cuda 9 introduced new threading model, which will break older cub. updating to 1.7 allow build with both cuda 9 and earlier.
- support for multi-node initialization in NCCL2
- check for cudnn version to allow build with both 6&7 because of API deprecation