### PR TITLE
Fix typos

### DIFF
--- a/Source/ComputationNetworkLib/EvaluationNodes.h
+++ b/Source/ComputationNetworkLib/EvaluationNodes.h
@@ -902,7 +902,7 @@ private:
     Matrix<ElemType> mBacktrace;
 
     int mStartLab; // the starting output label
-    int mEndLab;   // the ending output label, if avaliable
+    int mEndLab;   // the ending output label, if available
     ElemType m_default_activity;
 
 public:

--- a/Source/ComputationNetworkLib/ReshapingNodes.cpp
+++ b/Source/ComputationNetworkLib/ReshapingNodes.cpp
@@ -87,7 +87,7 @@ template <class ElemType>
 /*virtual*/ void ReduceElementsNode<ElemType>::ForwardProp(const FrameRange& fr) /*override*/
 {
     // We are mixing two kinds of operations here; elementwise and whole-batch or sequence reduction (ReduceAllAxes()).
-    // In the latter case, we must mimic the behaviour of ComputationNodeNonLooping.
+    // In the latter case, we must mimic the behavior of ComputationNodeNonLooping.
     if ((ReduceAllAxes() || ReduceSequenceAxis() || ReduceBatchAxis()) && !fr.IsAllFrames())
         LogicError("%ls: %s node should never be in a loop when reducing over all static and dynamic axes or just the sequence axis.", Base::NodeDescription().c_str(), typeid(*this).name());
 

--- a/Source/Math/ConvolutionEngine.cpp
+++ b/Source/Math/ConvolutionEngine.cpp
@@ -898,7 +898,7 @@ std::unique_ptr<ConvolutionEngine<ElemType>> ConvolutionEngine<ElemType>::Create
     }
 
     if (!isEnabled(ConvolutionEngineKind::Reference))
-        RuntimeError("Reference convolution is disabled and no other engine supports such configuratin (or disabled).");
+        RuntimeError("Reference convolution is disabled and no other engine supports such configuration (or disabled).");
 
     if (GetMathLibTraceLevel() > 0)
         fprintf(stderr, "%lsusing reference convolution engine for geometry, could be VERY SLOW: %s.\n", logPrefix.c_str(), engStr.c_str());

--- a/Source/SGDLib/SGD.cpp
+++ b/Source/SGDLib/SGD.cpp
@@ -1067,7 +1067,7 @@ size_t SGD<ElemType>::TrainOneEpoch(ComputationNetworkPtr net,
         smbDispatcher.Init(net, learnableNodes, criterionNodes, evaluationNodes);
 
     // The following is a special feature only supported by the Kaldi2Reader for more efficient sequence training.
-    // This attemps to compute the error signal for the whole utterance, which will
+    // This attempts to compute the error signal for the whole utterance, which will
     // be fed to the neural network as features. Currently it is a workaround
     // for the two-forward-pass sequence and ctc training, which allows
     // processing more utterances at the same time.

--- a/bindings/python/cntk/layers/sequence.py
+++ b/bindings/python/cntk/layers/sequence.py
@@ -565,7 +565,7 @@ def UnfoldFrom(generator_function, until_predicate=None, length_increase=1, name
       a tuple of N+1 outputs, where the first output is the value to emit, while the others are the state.
      until_predicate (:class:`~cntk.ops.functions.Function` or equivalent Python function):
       A function that denotes when the last element of the unfold has been emitted.
-      It takes the same number of argments as the generator, and returns a scalar that must be 1
+      It takes the same number of arguments as the generator, and returns a scalar that must be 1
       for the last element of the sequence, and 0 otherwise.
       This is subject to the maximum length as determined by the input sequence and ``length_increase``.
       If this parameter is not provided, the output length will be equal to the specified maximum length.


### PR DESCRIPTION
This PR fixes some typos: `avaliable`, `behaviour`, `configuratin`, `attemps`, and `argments`.