### PR TITLE
Fix typos

### DIFF
--- a/Examples/Text/LightRNN/DLL/DLL/pyreallocate.cpp
+++ b/Examples/Text/LightRNN/DLL/DLL/pyreallocate.cpp
@@ -43,7 +43,7 @@ struct InsertNode {
     /*
     * The Word Node,
     * It include the sorted loss vector of row and col,
-    * and the next great postion row or col for the curr word.
+    * and the next great position row or col for the curr word.
     * */
     DIVector prob_row;
     DIVector prob_col;

--- a/Examples/Text/LightRNN/LightRNN/reallocate.py
+++ b/Examples/Text/LightRNN/LightRNN/reallocate.py
@@ -30,7 +30,7 @@ class InsertNode:
     '''
     The Word Node,
     It include the sorted loss vector of row and col,
-    and the next great postion row or col for the curr word.
+    and the next great position row or col for the curr word.
     '''
     def __init__(self, prob_row, prob_col, word_id):
         self.prob_row = prob_row

--- a/Source/ActionsLib/NDLNetworkBuilder.h
+++ b/Source/ActionsLib/NDLNetworkBuilder.h
@@ -220,7 +220,7 @@ public:
     }
 
     // EvaluateParameters - Evaluate the parameters of a call
-    // node - NDLNode we are evaluating paramters for
+    // node - NDLNode we are evaluating parameters for
     // baseName - baseName for the current node
     // nodeParamStart - starting parameter that contains a node
     // nodeParamCount - ending parameter that contains a node
@@ -237,7 +237,7 @@ public:
             return inputs;
         }
         if (nodeParamStart + nodeParamCount > parameter.size())
-            LogicError("EvaluateParmeters: nodeParamters specified that do not exist");
+            LogicError("EvaluateParmeters: nodeParameters specified that do not exist");
         size_t numChildren = nodeParamCount;
         for (size_t i = 0; i < numChildren; ++i)
         {

--- a/Source/ActionsLib/NetworkDescriptionLanguage.h
+++ b/Source/ActionsLib/NetworkDescriptionLanguage.h
@@ -75,7 +75,7 @@ public:
     virtual NDLNode<ElemType>* EvaluateParameter(NDLNode<ElemType>* node, NDLNode<ElemType>* nodeParam, const std::wstring& baseName, const NDLPass pass) = 0;
 
     // EvaluateParameters - Evaluate the parameters of a call
-    // node - NDLNode we are evaluating paramters for
+    // node - NDLNode we are evaluating parameters for
     // baseName - baseName for the current node
     // nodeParamStart - starting parameter that contains a node
     // nodeParamCount - ending parameter that contains a node

--- a/Source/ActionsLib/SynchronousExecutionEngine.h
+++ b/Source/ActionsLib/SynchronousExecutionEngine.h
@@ -211,7 +211,7 @@ public:
     }
 
     // EvaluateParameters - Evaluate the parameters of a call
-    // node - NDLNode we are evaluating paramters for
+    // node - NDLNode we are evaluating parameters for
     // baseName - baseName for the current node
     // nodeParamStart - starting parameter that contains a node
     // nodeParamCount - ending parameter that contains a node
@@ -228,7 +228,7 @@ public:
             return inputs;
         }
         if (nodeParamStart + nodeParamCount > parameter.size())
-            LogicError("EvaluateParmeters: nodeParamters specified that do not exist");
+            LogicError("EvaluateParmeters: nodeParameters specified that do not exist");
         size_t numChildren = nodeParamCount;
         for (size_t i = 0; i < numChildren; ++i)
         {

--- a/Source/Common/Include/Config.h
+++ b/Source/Common/Include/Config.h
@@ -438,7 +438,7 @@ public:
     //  - (NDLScript)
     //  - more to be added
     // stringParse - string to parse
-    // pos - postion to start parsing at
+    // pos - position to start parsing at
     // m_separator - extra separator character between tokens, typically ';' (in addition to comma and newline)
     void Parse(const std::string& stringParse, std::string::size_type pos = 0)
     {

--- a/Source/Math/NcclComm.h
+++ b/Source/Math/NcclComm.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #pragma warning( push )
-#pragma warning ( disable : 4100 ) // Disable warning 4100 (unrefrenced paramter)
+#pragma warning ( disable : 4100 ) // Disable warning 4100 (unrefrenced parameter)
 
 #include "Matrix.h"
 #include "MPIWrapper.h"

--- a/Source/Readers/BinaryReader/BinaryFile.cpp
+++ b/Source/Readers/BinaryReader/BinaryFile.cpp
@@ -759,7 +759,7 @@ SectionHeader* Section::GetSectionHeader(size_t filePosition, MappingType& mappi
     }
     case mappingFile:
         if (filePosition != 0)
-            RuntimeError("invalid fileposition, file mapping sections must start at filePostion zero");
+            RuntimeError("invalid fileposition, file mapping sections must start at filePosition zero");
     // intentional fall-through - same case, just at beginning of file
     case mappingSectionAll:
         sectionHeader = m_file->GetSection(filePosition, size);

--- a/Tutorials/CNTK_104_Finance_Timeseries_Basic_with_Pandas_Numpy.ipynb
+++ b/Tutorials/CNTK_104_Finance_Timeseries_Basic_with_Pandas_Numpy.ipynb
@@ -163,7 +163,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Building the training paramaters\n",
+    "## Building the training parameters\n",
     "\n",
     "The stock market behavior exhibits substantial [autocorrelation](https://en.wikipedia.org/wiki/Autocorrelation) ([reference](http://epchan.blogspot.com/2016/04/mean-reversion-momentum-and-volatility.html)). We use [ETF](http://www.investopedia.com/terms/e/etf.asp) `SPY` index representing the \"market\" of stock. This is the ETF that encompasses around top 500 companies in America by market capitalization. We will trade under the assumption that there is some short term autocorrelation that have predictive power in the market. \n",
     "\n",


### PR DESCRIPTION
This PR fixes some typos: `postion`, `Postion`, `paramters`, `Paramters`, and `paramater`.