### PR TITLE
Fix typos

### DIFF
--- a/Documentation/CNTK-TechReport/lyx/CNTKBook_CNTK_Chapter.lyx
+++ b/Documentation/CNTK-TechReport/lyx/CNTKBook_CNTK_Chapter.lyx
@@ -1795,7 +1795,7 @@ autoAdjustMinibatch
  Default value is false.
  Adaptive minibatch sizing will begin on epochs starting after user minibatch
  sizes explicitly specified are complete.
-  For example if the userspecifed minibatchSize=256:1024, then 256 and 1024are
+  For example if the userspecified minibatchSize=256:1024, then 256 and 1024are
  used in the first 2 Epochs and adaptive minibatchsizing is used afterwards
  
 \end_layout

--- a/Examples/Speech/Miscellaneous/AMI/scripts/train_nnet.sh
+++ b/Examples/Speech/Miscellaneous/AMI/scripts/train_nnet.sh
@@ -137,7 +137,7 @@ cn_command="$cn_command $cntk_train_opts DeviceNumber=$device"
 cn_command="$cn_command command=TrainModel"
 $cmd $parallel_opts JOB=1:1 $dir/log/cntk.train.JOB.log $cn_command || exit 1;
 
-echo "$0 successfuly finished.. $dir"
+echo "$0 successfully finished.. $dir"
 
 sleep 3
 exit 0

--- a/Examples/Speech/Miscellaneous/AMI/train_cntk2.sh
+++ b/Examples/Speech/Miscellaneous/AMI/train_cntk2.sh
@@ -70,7 +70,7 @@ EOF
 ## training command ##
 $cn_gpu configFile=${expdir}/Base.config configFile=${expdir}/CNTK2.cntk DeviceNumber=0 action=TrainDNN ndlfile=$ndlfile
 
-echo "$0 successfuly finished.. $dir"
+echo "$0 successfully finished.. $dir"
 
 fi
 

--- a/Source/ComputationNetworkLib/ComputationNetwork.cpp
+++ b/Source/ComputationNetworkLib/ComputationNetwork.cpp
@@ -812,7 +812,7 @@ void ComputationNetwork::DescribeNetworkUsingDot(list<ComputationArc>& arcs,
     fstream << FormSpecialNodes(dotcfg.m_featuresStyle, m_featureNodes);
     // labels
     fstream << FormSpecialNodes(dotcfg.m_labelsStyle, m_labelNodes);
-    // critera
+    // criteria
     fstream << FormSpecialNodes(dotcfg.m_CriteriaStyle, m_criterionNodes);
     // pre-compute nodes
     fstream << FormSpecialNodes(dotcfg.m_PrecomputingNodeStyle, preComputedNodes);

--- a/Source/ComputationNetworkLib/ComputationNetwork.h
+++ b/Source/ComputationNetworkLib/ComputationNetwork.h
@@ -795,7 +795,7 @@ public:
         // determine nodes to evaluate
         std::vector<ComputationNodeBasePtr> evalNodes;
 
-        set<ComputationNodeBasePtr> criteriaLogged; // (keeps track ot duplicates to avoid we don't double-log critera)
+        set<ComputationNodeBasePtr> criteriaLogged; // (keeps track ot duplicates to avoid we don't double-log criteria)
         if (evalNodeNames.size() == 0)
         {
             fprintf(stderr, "evalNodeNames are not specified, using all the default evalnodes and training criterion nodes.\n");

--- a/Source/ComputationNetworkLib/SpecialPurposeNodes.h
+++ b/Source/ComputationNetworkLib/SpecialPurposeNodes.h
@@ -458,7 +458,7 @@ public:
     {
     }
 
-    // compute gradients to input observations, the weights to the observations, and the class log posterior probabilites
+    // compute gradients to input observations, the weights to the observations, and the class log posterior probabilities
     virtual void BackpropToNonLooping(size_t inputIndex) override
     {
         // auto t_start_time = Timer::MilliSecondElapsed();
@@ -795,7 +795,7 @@ public:
         AttachInputsFromConfig(configp, this->GetExpectedNumInputs());
     }
 
-    // Compute gradients to input observations, the weights to the observations, and the class log posterior probabilites
+    // Compute gradients to input observations, the weights to the observations, and the class log posterior probabilities
     virtual void BackpropToNonLooping(size_t inputIndex) override
     {
         // Left node must be a scalar

--- a/Source/ComputationNetworkLib/TrainingNodes.h
+++ b/Source/ComputationNetworkLib/TrainingNodes.h
@@ -1524,7 +1524,7 @@ private:
         return sz;
     }
 
-    // compute gradients to input observations, the weights to the observations, and the class log posterior probabilites
+    // compute gradients to input observations, the weights to the observations, and the class log posterior probabilities
     virtual void BackpropToNonLooping(size_t inputIndex) override
     {
         // this should never be called for input[0], which is controlled through learningRateMultiplier == 0

--- a/Source/Math/GPUTensor.cu
+++ b/Source/Math/GPUTensor.cu
@@ -264,7 +264,7 @@ struct TensorOps
 };
 
 // ----------------------------------------------------------------------------
-// Function to update an aggregate value for the specifed reduction operation
+// Function to update an aggregate value for the specified reduction operation
 // ----------------------------------------------------------------------------
 
 template <typename ElemType> __device__ ElemType AggregateNeutralValue(ElementWiseOperator op)

--- a/Source/Readers/ReaderLib/IndexBuilder.cpp
+++ b/Source/Readers/ReaderLib/IndexBuilder.cpp
@@ -164,7 +164,7 @@ TextInputIndexBuilder::TextInputIndexBuilder(const FileWrapper& input)
 
 /*virtual*/ wstring TextInputIndexBuilder::GetCacheFilename() /*override*/
 {
-    // What follows are all the options that affect the outcome of indexing (i.e., specifing a 'main' stream 
+    // What follows are all the options that affect the outcome of indexing (i.e., specifying a 'main' stream 
     // using the definesMBsize flag will affect the sequence length in terms of number of samples). 
     // We could compute a (SHA1) hash of all these options and add it instead to the filename (+ embed the
     // values themselves into the cache header), but given that there're only a few of them, encoding them

--- a/Tests/EndToEndTests/TestDriver.py
+++ b/Tests/EndToEndTests/TestDriver.py
@@ -696,7 +696,7 @@ def runCommand(args):
     pyPaths['py35'] = convertPythonPath(args.py35_paths)
   if args.py36_paths:
     pyPaths['py36'] = convertPythonPath(args.py36_paths)
-  # If no Python was explicitly specifed, go against current.
+  # If no Python was explicitly specified, go against current.
   if not pyPaths:
     pyPaths['py'] = ''
 

--- a/bindings/python/cntk/ops/__init__.py
+++ b/bindings/python/cntk/ops/__init__.py
@@ -2751,7 +2751,7 @@ def random_sample_inclusion_frequency(
     seed = SentinelValueForAutoSelectRandomSeed,
     name=''):
     '''
-    For weighted sampling with the specifed sample size (`num_samples`)
+    For weighted sampling with the specified sample size (`num_samples`)
     this operation computes the expected number of occurrences of each class
     in the sampled set. In case of sampling without replacement
     the result is only an estimate which might be quite rough in the


### PR DESCRIPTION
This PR fixes some typos: `specifed`, `successfuly`, `critera`, `probabilites`, and `specifing`.