### PR TITLE
numeric_limits::min returns positive value for floats - breaks argmax

### DIFF
--- a/Source/Math/CPUMatrixImpl.h
+++ b/Source/Math/CPUMatrixImpl.h
@@ -7332,12 +7332,12 @@ template <class ElemType>
 int CPUMatrix<ElemType>::Argmax() const
 {
     int maxArg = -1;
-    ElemType maxValue = std::numeric_limits<ElemType>::min();
+    ElemType maxValue = std::numeric_limits<ElemType>::lowest();
 
 #pragma omp parallel 
     {
         int localMaxArg = -1;
-        ElemType localMaxValue = std::numeric_limits<ElemType>::min();
+        ElemType localMaxValue = std::numeric_limits<ElemType>::lowest();
 
 #pragma omp for
         for (int index = 0; index < (int)GetNumElements(); ++index)


### PR DESCRIPTION
This fixes a bug with the CPU implementation of argmax.
To reproduce original bug (in Python):

```
import cntk
data = [-4,-5,-6]
cntk.argmax(data).eval()
```
expected: 0
actual: -1
