### PR TITLE
Fixed typo in CNTK_101_LogisticRegression.ipynb

### DIFF
--- a/Tutorials/CNTK_101_LogisticRegression.ipynb
+++ b/Tutorials/CNTK_101_LogisticRegression.ipynb
@@ -843,13 +843,13 @@
      "output_type": "stream",
      "text": [
       "Label    : [1, 0, 0, 1, 1, 1, 0, 1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1]\n",
-      "Predicted: [0, 0]\n"
+      "Predicted: [1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1]\n"
      ]
     }
    ],
    "source": [
     "print(\"Label    :\", [np.argmax(label) for label in labels])\n",
-    "print(\"Predicted:\", [np.argmax(x) for x in result[0]])"
+    "print(\"Predicted:\", [np.argmax(x) for x in result])"
    ]
   },
   {


### PR DESCRIPTION
Fixed typo regarding the output of the predicted labels.