### PR TITLE
Fixes "'exp' was not declared"

### DIFF
--- a/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
+++ b/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <future>
 #include <cstddef>
+#include <cmath>
 
 #ifdef SWIG
 #define final


### PR DESCRIPTION
This fixes the error: "error: ‘exp’ was not declared in this scope return momTC == 0.0 ? 0 : exp(-1.0 / momTC);",when compiling CNTK with GCC. 

Reference: https://github.com/Microsoft/CNTK/issues/2341