### PR TITLE
Fixes error: ‘openblas_set_num_threads’ was not declared in this scope

### DIFF
--- a/Source/Math/CPUMatrixImpl.h
+++ b/Source/Math/CPUMatrixImpl.h
@@ -56,6 +56,11 @@
 #endif
 #include <cblas.h>
 #include <lapacke.h>
+
+#if defined(USE_OPENBLAS)
+extern "C" void openblas_set_num_threads(int num_threads);
+#endif
+
 #endif
 
 #define SWAP(a, b)  \


### PR DESCRIPTION
Hi, there.
I compiled CNTK with openblas (CPU version) on Arch Linux. The compiling configurations were below:

Operating System: Arch Linux
Compiler: g++ 7.2.0

Here are my building steps.
```C
mkdir build
cd build
../configure --with-openblas
make -j9
```

When compiling the file `Source/Math/CPUMatrixImpl.h`, the compiler shows the error: ‘openblas_set_num_threads’ was not declared in this scope.

```c++
In file included from Source/Math/CPUMatrixFloat.cpp:6:0:
Source/Math/CPUMatrixImpl.h: In static member function ‘static int Microsoft::MSR::CNTK::CPUMatrix<ElemType>::SetNumThreads(int)’:
Source/Math/CPUMatrixImpl.h:6785:9: error: there are no arguments to ‘openblas_set_num_threads’ that depend on a template parameter, so a declaration of ‘openblas_set_num_threads’ must be available [-Werror=permissive]
         openblas_set_num_threads(numThreads);
         ^~~~~~~~~~~~~~~~~~~~~~~~
Source/Math/CPUMatrixImpl.h: In instantiation of ‘static int Microsoft::MSR::CNTK::CPUMatrix<ElemType>::SetNumThreads(int) [with ElemType = float]’:
Source/Math/CPUMatrixFloat.cpp:23:29:   required from here
Source/Math/CPUMatrixImpl.h:6785:33: error: ‘openblas_set_num_threads’ was not declared in this scope
         openblas_set_num_threads(numThreads);
         ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
Source/Math/CPUMatrixImpl.h:6785:33: note: suggested alternative: ‘omp_set_num_threads’
         openblas_set_num_threads(numThreads);
         ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
         omp_set_num_threads
In file included from Source/Math/CPUMatrixDouble.cpp:6:0:
Source/Math/CPUMatrixImpl.h: In static member function ‘static int Microsoft::MSR::CNTK::CPUMatrix<ElemType>::SetNumThreads(int)’:
Source/Math/CPUMatrixImpl.h:6785:9: error: there are no arguments to ‘openblas_set_num_threads’ that depend on a template parameter, so a declaration of ‘openblas_set_num_threads’ must be available [-Werror=permissive]
         openblas_set_num_threads(numThreads);
         ^~~~~~~~~~~~~~~~~~~~~~~~
Source/Math/CPUMatrixImpl.h: In instantiation of ‘static int Microsoft::MSR::CNTK::CPUMatrix<ElemType>::SetNumThreads(int) [with ElemType = double]’:
Source/Math/CPUMatrixDouble.cpp:11:29:   required from here
Source/Math/CPUMatrixImpl.h:6785:33: error: ‘openblas_set_num_threads’ was not declared in this scope
         openblas_set_num_threads(numThreads);
         ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
Source/Math/CPUMatrixImpl.h:6785:33: note: suggested alternative: ‘omp_set_num_threads’
         openblas_set_num_threads(numThreads);
         ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
         omp_set_num_threads
```

I add `extern "C" void openblas_set_num_threads(int num_threads);` at the beginning of `Source/Math/CPUMatrixImpl.h` to address the problem.