### PR TITLE
Fix typos

### DIFF
--- a/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
+++ b/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
@@ -388,7 +388,7 @@ namespace CNTK
             (left.m_sampleLayout == right.m_sampleLayout));
     }
 
-    // Some projects require only some generic data types/interfaces from this file, and do not want to link explicitely to CNTKv2Library.
+    // Some projects require only some generic data types/interfaces from this file, and do not want to link explicitly to CNTKv2Library.
     // In this case they have to define CNTK_HEADERONLY_DEFINITIONS before including CNTKLibrary.h
 #ifndef CNTK_HEADERONLY_DEFINITIONS
     ///

--- a/Source/CNTKv2LibraryDll/API/CNTKLibraryInternals.h
+++ b/Source/CNTKv2LibraryDll/API/CNTKLibraryInternals.h
@@ -83,7 +83,7 @@ namespace CNTK
 #define __declspec_noreturn __attribute__((noreturn))
 #endif
 
-// Some projects require only some generic data types/interfaces from this file, and do not want to link explicitely to CNTKv2Library.
+// Some projects require only some generic data types/interfaces from this file, and do not want to link explicitly to CNTKv2Library.
 // In this case they have to define CNTK_HEADERONLY_DEFINITIONS before including CNTKLibrary.h
 #ifndef CNTK_HEADERONLY_DEFINITIONS
 

--- a/Source/CNTKv2LibraryDll/CompositeFunction.cpp
+++ b/Source/CNTKv2LibraryDll/CompositeFunction.cpp
@@ -365,7 +365,7 @@ namespace CNTK
             return;
         }
 
-        // build a map of souce funtion to the destination (this) function UIDs.
+        // build a map of souce function to the destination (this) function UIDs.
         map<wstring, wstring> uidMap;
         for (auto i = 0; i < theirUIDs.size(); i++)
             uidMap[theirUIDs[i]] = ourUIDs[i];

--- a/Source/Math/CPUSparseMatrix.h
+++ b/Source/Math/CPUSparseMatrix.h
@@ -175,7 +175,7 @@ public:
     void RequireSizeAndAllocate(const size_t numRows, const size_t numCols, const size_t numNZElemToReserve, const MatrixFormat matrixFormat, const bool growOnly = true, bool keepExistingValues = true); // matrix format will affect the size to allocate
     // Otherwise we will just use the current MatrixFormat.
     void RequireSizeAndAllocate(const size_t numRows, const size_t numCols, const size_t numNZElemToReserve = 10000, const bool growOnly = true, bool keepExistingValues = false);
-    // Sparse matrix RequireSize is similar to dense matrix RequireSize in that it will only allocate the minimum amount of storage requried to successfully create the matrix.
+    // Sparse matrix RequireSize is similar to dense matrix RequireSize in that it will only allocate the minimum amount of storage required to successfully create the matrix.
     // This is required because some formats (e.g., SparseCSC) require the SecondaryIndexLocation to have valid data in order to compute m_nz. Otherwise this method would not
     // update the storage at all.
     void RequireSize(const size_t numRows, const size_t numCols, const size_t numNZElemToReserve, const MatrixFormat format, const bool growOnly = true);

--- a/Source/Math/CommonMatrix.h
+++ b/Source/Math/CommonMatrix.h
@@ -401,7 +401,7 @@ protected:
 
 protected:
     // **************************
-    // Variables requried by all matrices
+    // Variables required by all matrices
     // **************************
     MatrixFormat m_format;
     mutable DEVICEID_TYPE m_computeDevice; // current GPU device Id or CPUDEVICE

--- a/Source/Readers/HTKDeserializers/HTKDeserializer.h
+++ b/Source/Readers/HTKDeserializers/HTKDeserializer.h
@@ -79,7 +79,7 @@ private:
     size_t m_ioFeatureDimension = 0;
     std::string m_featureKind;
 
-    // A flag that indicates whether the utterance should be extended to match the lenght of the utterance from the primary deserializer.
+    // A flag that indicates whether the utterance should be extended to match the length of the utterance from the primary deserializer.
     // TODO: This should be moved to the packers when deserializers work in sequence mode only.
     bool m_expandToPrimary;
 };

--- a/Source/SGDLib/DataReaderHelpers.h
+++ b/Source/SGDLib/DataReaderHelpers.h
@@ -116,7 +116,7 @@ namespace Microsoft { namespace MSR { namespace CNTK {
 
         // get MB size and tell Network to update its nodes' buffers based on what's in the input matrices
         // Note: Decimation may have reduced this to 0 frames. We still must return 'true'.
-        // BUGBUG: This has a definitional problem once we support multiple feature streams with different lenghts.
+        // BUGBUG: This has a definitional problem once we support multiple feature streams with different lengths.
         // BUGBUG: We should discount gaps.
         actualMBSize = net->DetermineActualMBSizeFromFeatures();
 

--- a/Source/SGDLib/SGD.cpp
+++ b/Source/SGDLib/SGD.cpp
@@ -620,7 +620,7 @@ void SGD<ElemType>::TrainOrAdaptModel(int startEpoch, ComputationNetworkPtr net,
         }
 
         // For legacy readers, in BPTT mode the minibatch size was not the real minibatch size but truncation.
-        // Because of that we have to fix up the real minibatch size multiplying the number of parallel sequences by the truncation lenght.
+        // Because of that we have to fix up the real minibatch size multiplying the number of parallel sequences by the truncation length.
         // This is not require any more for the new readers.
         if (trainSetDataReader->IsLegacyReader())
             actualMinibatchSize = FixUpEffectiveMBSize(chosenMinibatchSize /*BUGBUG workaround:*/, trainSetDataReader->GetNumParallelSequencesForFixingBPTTMode());
@@ -2227,7 +2227,7 @@ void SGD<ElemType>::TrainOneMiniEpochAndReloadModel(ComputationNetworkPtr net,
                        /*out*/ dummyMinibatchSize);
 }
 
-// Attemps to compute the error signal for the whole utterance, which will
+// Attempts to compute the error signal for the whole utterance, which will
 // be fed to the neural network as features. Currently it is a workaround
 // for the two-forward-pass sequence and ctc training, which allows
 // processing more utterances at the same time. Only used in Kaldi2Reader.

--- a/Source/SGDLib/SGD.h
+++ b/Source/SGDLib/SGD.h
@@ -480,7 +480,7 @@ protected:
                                       std::list<Matrix<ElemType>>& smoothedGradients, std::vector<double> smoothedCounts,
                                       const size_t minMinibatchSize, const size_t maxMinibatchSize);
 
-    // Attemps to compute the error signal for the whole utterance, which will
+    // Attempts to compute the error signal for the whole utterance, which will
     // be fed to the neural network as features. Currently it is a workaround
     // for the two-forward-pass sequence and ctc training, which allows
     // processing more utterances at the same time. Only used in Kaldi2Reader.

--- a/Tutorials/CNTK_103B_MNIST_LogisticRegression.ipynb
+++ b/Tutorials/CNTK_103B_MNIST_LogisticRegression.ipynb
@@ -281,7 +281,7 @@
     "\n",
     "$$\\vec{z} = \\textbf{W} \\bf \\vec{x}^T + \\vec{b}$$ \n",
     "\n",
-    "where $\\bf{W}$ is the weight matrix of dimension 10 x 784 and $\\vec{b}$ is known as the *bias* vector with lenght 10, one for each digit. \n",
+    "where $\\bf{W}$ is the weight matrix of dimension 10 x 784 and $\\vec{b}$ is known as the *bias* vector with length 10, one for each digit. \n",
     "\n",
     "The evidence ($\\vec{z}$) is not squashed (hence no activation). Instead the output is normalized using a [softmax](https://en.wikipedia.org/wiki/Softmax_function) function such that all the outputs add up to a value of 1, thus lending a probabilistic iterpretation to the prediction. In CNTK, we use the softmax operation that is combined with the cross entropy error function."
    ]

--- a/bindings/python/cntk/contrib/deeprl/agent/agent.py
+++ b/bindings/python/cntk/contrib/deeprl/agent/agent.py
@@ -50,7 +50,7 @@ class AgentBaseClass(object):
         # _discrete_observation_space: True for cases 1 and 2, False otherwise.
         #   State is represented by a scalar.
         # _space_discretizer: Not none for case 2 to indicate a conversion on
-        #   state is requried. None otherwise.
+        #   state is required. None otherwise.
         # _shape_of_inputs: (n, ) for cases 1 and 2 to indicate it is a vector
         #   of length n. For case 3, it is the shape of array that represents
         #   the state. For example, an image input will have shape denoted as


### PR DESCRIPTION
This PR fixes some typos: `explicitely`, `funtion`, `requried`, `lenght`, and `Attemps`.