### PR TITLE
Fix typos

### DIFF
--- a/Examples/Speech/Miscellaneous/AMI/run_ihm.sh
+++ b/Examples/Speech/Miscellaneous/AMI/run_ihm.sh
@@ -8,7 +8,7 @@
 # 1) SRILM 
 # 2) 
 
-#1) some setings
+#1) some settings
 #do not change this, it's for ctr-c ctr-v of training commands between ihm, sdm and mdm
 mic=ihm
 #path where AMI whould be downloaded or where is locally available

--- a/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
+++ b/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
@@ -2744,7 +2744,7 @@ namespace CNTK
         virtual void Erase();
 
         ///
-        /// Unpacks sequences in 'this' Value as a vector of NDArrayView objects, each represeting a sequence in the
+        /// Unpacks sequences in 'this' Value as a vector of NDArrayView objects, each representing a sequence in the
         /// batch of sequences that 'this' Value object contains data for.
         /// Besides the NDArrayView objects (that represent contents of each sequence), this method also returns
         /// the sequence start information for each sequence, which indicates whether that sequence is the start of
@@ -2788,7 +2788,7 @@ namespace CNTK
         }
 
         ///
-        /// Unpacks sequences in 'this' Value as a vector of NDArrayView objects, each represeting a sequence in the
+        /// Unpacks sequences in 'this' Value as a vector of NDArrayView objects, each representing a sequence in the
         /// batch of sequences that 'this' Value object contains data for.
         /// Besides the NDArrayView objects (that represent contents of each sequence), this method also returns
         /// the sequence start information for each sequence, which indicates whether that sequence is the start of
@@ -5925,7 +5925,7 @@ namespace CNTK
         /// Disallow copy and move construction and assignment
         TrainingSession(const TrainingSession&) = delete; TrainingSession& operator=(const TrainingSession&) = delete; TrainingSession& operator=(TrainingSession&&) = delete; TrainingSession(TrainingSession&&) = delete;
 
-        // Auxilary functions.
+        // Auxiliary functions.
         void GetNextMinibatch(const MinibatchSourcePtr& source,
             std::unordered_map<Variable, ValuePtr>& minibatch,
             const std::unordered_map<Variable, StreamInformation>& inputVarToStream,

--- a/Source/CNTKv2LibraryDll/proto/onnx/core/graph.cpp
+++ b/Source/CNTKv2LibraryDll/proto/onnx/core/graph.cpp
@@ -1296,7 +1296,7 @@ namespace ONNXIR
                     // A op_type refers to nothing.
                     Status status(false,
                         "Error: the operator or function (" + op_type
-                        + ") refered by node (" + nodeName
+                        + ") referred by node (" + nodeName
                         + ") does not exist.");
                     return status;
                 }

--- a/Source/CNTKv2LibraryDll/proto/onnx/core/graph.h
+++ b/Source/CNTKv2LibraryDll/proto/onnx/core/graph.h
@@ -546,7 +546,7 @@ namespace ONNXIR
             const std::unordered_map<std::string, Node::EdgeEnd>& p_outputArgs);
 
         // Clean function definition map.
-        // Remove function definitions not refered by any node.
+        // Remove function definitions not referred by any node.
         void CleanFunctionDefMap(const std::set<std::string>& p_funcDefNames);
 
         // Add source/sink nodes to <*this> graph.

--- a/Source/Math/Matrix.cpp
+++ b/Source/Math/Matrix.cpp
@@ -4027,7 +4027,7 @@ MatrixFormat Matrix<ElemType>::GetFormat() const
 // BUGBUG: This performs a copy operation even for the output matrix that gets overwritten right away.
 //         We should (1) define which is the output and (2) whether it will be completely overwritten (so we won't actually copy it).
 // bring two matrices onto the same device
-// If different and prefered devices are the same, move to preferred device.
+// If different and preferred devices are the same, move to preferred device.
 // Otherwise GPU takes precedence over CPU, and if both are GPU move to a's device.
 // The inputs are only distinguished in that a's GPU takes precedence over b's in case they differ.
 // TODO: This is called somewhat inconsistently, sometimes with a=*this, sometimes with b=*this.

--- a/bindings/python/cntk/learners/tests/learner_test.py
+++ b/bindings/python/cntk/learners/tests/learner_test.py
@@ -211,7 +211,7 @@ def test_learner_init():
 
     #test new API: learning_parameter_schedule
 
-    #explictly specify reference minibatch size and learning rate is in number:
+    #explicitly specify reference minibatch size and learning rate is in number:
     learner = sgd(res.parameters, lr=0.1, minibatch_size = 25)
     assert learner.is_compatible_mode() == False
     assert learner.minibatch_size == 25 #the learner's reference minibatch
@@ -219,7 +219,7 @@ def test_learner_init():
     assert learner._learning_rate_schedule.minibatch_size == 25
     assert learner.learning_rate() == 0.1
 
-    #no explictly specification of reference minibatch size and learning rate is in number:
+    #no explicitly specification of reference minibatch size and learning rate is in number:
     learner = sgd(res.parameters, lr=learning_parameter_schedule(0.1))
     assert learner.is_compatible_mode() == False
     assert learner.minibatch_size == C.learners.IGNORE #the learner's reference minibatch
@@ -242,7 +242,7 @@ def test_learner_init():
     assert learner._learning_rate_schedule.minibatch_size == 20
     assert learner.learning_rate() == 0.1
 
-    #no explictly specification of reference minibatch size and learning rate is in number:
+    #no explicitly specification of reference minibatch size and learning rate is in number:
     learner = sgd(res.parameters, lr=learning_parameter_schedule(0.1))
     assert learner.is_compatible_mode() == False
     assert learner.minibatch_size == C.learners.IGNORE #the learner's reference minibatch
@@ -251,7 +251,7 @@ def test_learner_init():
     assert learner.learning_rate() == 0.1
 
 
-    #no explictly specification of reference minibatch size and learning rate is in number:
+    #no explicitly specification of reference minibatch size and learning rate is in number:
     learner = sgd(res.parameters, lr=learning_parameter_schedule(0.1), minibatch_size=C.learners.IGNORE)
     assert learner.is_compatible_mode() == True
     assert learner.minibatch_size == C.learners.IGNORE #the learner's reference minibatch
@@ -267,7 +267,7 @@ def test_learner_init():
     assert learner._learning_rate_schedule.minibatch_size == 20
     assert learner.learning_rate() == 0.1
 
-    #no explictly specification of reference minibatch size and learning rate is in number:
+    #no explicitly specification of reference minibatch size and learning rate is in number:
     learner = sgd(res.parameters, lr=learning_parameter_schedule(0.1), minibatch_size=C.learners.IGNORE)
     assert learner.is_compatible_mode() == True
     assert learner.minibatch_size == C.learners.IGNORE #the learner's reference minibatch


### PR DESCRIPTION
This PR fixes some typos: `setings`, `represeting`, `Auxilary`, `refered`, and `explictly`.