### PR TITLE
Modified ScaleTransForm

### DIFF
--- a/Source/Readers/ImageReader/ImageTransformers.h
+++ b/Source/Readers/ImageReader/ImageTransformers.h
@@ -1,4 +1,3 @@
-//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.md file in the project root for full license information.
 //
@@ -146,7 +145,10 @@ private:
     {
         Fill = 0,
         Crop = 1,
-        Pad  = 2
+	Pad  = 2,
+	ResizeMin = 3,
+	ResizeMax = 4
+	  
     };
     void Apply(uint8_t copyId, cv::Mat &mat) override;
 

--- a/bindings/python/cntk/io/transforms.py
+++ b/bindings/python/cntk/io/transforms.py
@@ -81,6 +81,8 @@ def scale(width, height, channels, interpolations='linear', scale_mode="fill", p
           'fill' - warp the image to the given target size.
           'crop' - resize the image's shorter side to the given target size and crop the overlap.
           'pad'  - resize the image's larger side to the given target size, center it and pad the rest
+          'resizemin' - resize the image's shorter side to the given target size while maintaining the aspect ratio.
+          'resizemax' - resize the image's longer size to the given target size while maintaining the aspect ratio.
         pad_value (int, default -1): -1 or int value. The pad value used for the 'pad' mode.
          If set to -1 then the border will be replicated.
 


### PR DESCRIPTION
Added Options "ResizeMin" and "ResizeMax" to ScaleTransform.

ResizeMin  sets the smaller dimension of the image to a fixed size while keeping the same aspect ratio.
ResizeMax sets the larger dimension of the image to a fixed size while keeping the same aspect ratio.

This allows us to use a greater diversity during data augmentation.

This method has been used in the [OverFeat Paper](https://arxiv.org/abs/1312.6229)