### PR TITLE
Disable UCF11 test

### DIFF
--- a/Tests/EndToEndTests/CNTKv2Python/Examples/ucf11_conv3d_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Examples/ucf11_conv3d_test.py
@@ -21,8 +21,9 @@ from prepare_test_data import prepare_UCF11_data
 
 TOLERANCE_ABSOLUTE = 2E-1
 
-@pytest.mark.skipif(sys.platform != 'win32',
-                    reason="does currently run only on Windows")
+#@pytest.mark.skipif(sys.platform != 'win32',
+#                    reason="does currently run only on Windows")
+@pytest.mark.skip(reason="Issue with imageio.plugins.ffmpeg.Reader. Error: Couldn't load meta information.")
 def test_ucf11_conv3d_error(device_id):
     if cntk_device(device_id).type() != DeviceKind_GPU:
         pytest.skip('test only runs on GPU')


### PR DESCRIPTION
UCF11 test fails due to ffmpeg issue https://github.com/imageio/imageio/issues/273
Disabling the test for now to let the nightly builds succeed.