### PR TITLE
always need to update data size

### DIFF
--- a/Source/ComputationNetworkLib/ComputationNode.cpp
+++ b/Source/ComputationNetworkLib/ComputationNode.cpp
@@ -48,11 +48,7 @@ void ComputationNode<ElemType>::LazyZeroGradient(const ComputationNodeBase* grad
         gradientInitializedBy->ImplementsGradientOptimization(this) != ParentGradientOptimization::None &&
         1 == std::count_if(inputs.begin(), inputs.end(), [this](ComputationNodeBasePtr p) { return &*p == this; }))
     {
-        // don't need update size as parent already set it to the right size when reusing
-        if (!ParentGradientReused())
-        {
-            UpdateDataSize(Gradient());
-        }
+        UpdateDataSize(Gradient());
         m_gradientInitializedBy = gradientInitializedBy;
     }
     else


### PR DESCRIPTION
```
import cntk as C
import numpy as np

batch_size = 8
w = C.parameter(shape=(3, 2), name='w1')
x = C.input_variable(shape=[3], name='x')
y = C.softmax(C.times(x, w))
y = C.unpack_batch(y)
y = C.reshape(y, [batch_size * 2])
loss = C.reduce_mean(-C.log(y))

learning_rate = 0.01
lr_schedule = C.learning_rate_schedule(learning_rate, C.UnitType.minibatch)
learner = C.sgd(y.parameters, lr_schedule, gradient_clipping_threshold_per_sample=1.0)
trainer = C.Trainer(y, (loss), [learner])

for i in range(0, 10):
    features = np.random.randn(batch_size, 3)
    trainer.train_minibatch({x: features})
```

The example will fail due to dimension mismatch in the original implementation. 