### PR TITLE
fix readonly bug in Value::Create(); adapt and add tests

### DIFF
--- a/Source/CNTKv2LibraryDll/Value.cpp
+++ b/Source/CNTKv2LibraryDll/Value.cpp
@@ -193,9 +193,21 @@ namespace CNTK
         if (numSequences == 1)
         {
             if (createNewCopy)
-                valueData = sequences[0]->DeepClone();
+                valueData = sequences[0]->DeepClone(readOnly);
             else
-                valueData = sequences[0];
+            {
+                if (sequences[0]->IsReadOnly() != readOnly)
+                {
+                    if (readOnly)
+                        // Alias() without data copy is sufficient if the sequences[0] is not readOnly, and the created Value should be readonly
+                        valueData = sequences[0]->Alias(readOnly);
+                    else
+                        // DeepClone() is required if the sequence[0] is readonly, but the created Value is not readonly.
+                        valueData = sequences[0]->DeepClone(readOnly);
+                }
+                else
+                    valueData = sequences[0];
+            }
 
             // We can use the original buffer directly but need to reshape to the valueDataShape
             valueData = valueData->AsShape(valueDataShape);
@@ -279,8 +291,13 @@ namespace CNTK
         NDArrayViewPtr deviceValueData;
         if (device == valueData->Device())
         {
-            if (readOnly)
-                deviceValueData = valueData->Alias(readOnly);
+            if (readOnly != valueData->IsReadOnly())
+            {
+                if (readOnly)
+                    deviceValueData = valueData->Alias(readOnly);
+                else
+                    RuntimeError("Cannot create a non-read-only value object from a read-only view.");
+            }
             else
                 deviceValueData = valueData;
         }


### PR DESCRIPTION
Bug description: When creating a Value from the provided vector of NDArrayView while readonly is set to false, the returned Value object does not have the expected readonly property. Instead of a non-readonly as the parameter requires, the returned Value object is always read-only.
This PR fixes the bug and also adds new tests for checking the readonly property.
I have tested it release/2.2. 
This PR is based on the current master, but I have not built and tested it since I do not have that latest build environment locally on my machine. Please build and test it before merging. 