### PR TITLE
Changes required to build on Ubuntu 16.04/gcc 5.4, plus javadoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ SOURCEDIR:= Source
 INCLUDEPATH:= $(addprefix $(SOURCEDIR)/, Common/Include CNTKv2LibraryDll CNTKv2LibraryDll/API CNTKv2LibraryDll/proto ../Examples/Extensibility/CPP Math CNTK ActionsLib ComputationNetworkLib SGDLib SequenceTrainingLib CNTK/BrainScript Readers/ReaderLib PerformanceProfilerDll)
 INCLUDEPATH+=$(PROTOBUF_PATH)/include
 # COMMON_FLAGS include settings that are passed both to NVCC and C++ compilers.
-COMMON_FLAGS:= -DHAS_MPI=$(HAS_MPI) -D_POSIX_SOURCE -D_XOPEN_SOURCE=600 -D__USE_XOPEN2K -std=c++11
+COMMON_FLAGS:= -DHAS_MPI=$(HAS_MPI) -D_POSIX_SOURCE -D_XOPEN_SOURCE=600 -D__USE_XOPEN2K 
 CPPFLAGS:= 
-CXXFLAGS:= $(SSE_FLAGS) -std=c++0x -fopenmp -fpermissive -fPIC -Werror -fcheck-new
+CXXFLAGS:= $(SSE_FLAGS) -fopenmp -fpermissive -fPIC -Werror -fcheck-new -std=c++14
 LIBPATH:=
 LIBS_LIST:=
 LDFLAGS:=
@@ -115,7 +115,7 @@ SRC:=
 all : buildall
 
 # Set up basic nvcc options and add CUDA targets from above
-CUFLAGS = -m 64
+CUFLAGS = -m 64 -std=c++11
 
 ifdef CUDA_PATH
   ifndef GDK_INCLUDE_PATH
@@ -1485,6 +1485,7 @@ ifdef CUDA_PATH
 endif
 	cp -p $(JAVA_SWIG_DIR)/CNTKNativeUtils.java $(JAVA_SWIG_DIR)/com/microsoft/CNTK/CNTKNativeUtils.java
 	$(JDK_BIN_PATH)/javac $(GENERATED_JAVA_DIR)/*.java
+	cd $(JAVA_SWIG_DIR) && mkdir -p doc && $(JDK_BIN_PATH)/javadoc com/microsoft/CNTK/*.java -d doc
 	mkdir -p $(LIBDIR)/java
 	cd $(JAVA_SWIG_DIR) && $(JDK_BIN_PATH)/jar -cvf cntk.jar com
 	cp $(JAVA_SWIG_DIR)/cntk.jar $(LIBDIR)/java

--- a/Source/CNTKv2LibraryDll/Trainer.cpp
+++ b/Source/CNTKv2LibraryDll/Trainer.cpp
@@ -541,7 +541,7 @@ namespace CNTK
             return m_parameterLearners->ParameterLearners().front()->TotalNumberOfSamplesSeen();
         default:
             //should not be here; whenever a new data unit is defined, there should be a new case in this function.
-            LogicError("Unsupported data unit: %d", unit);
+            LogicError("Unsupported data unit: %d", (int ) unit);
         }
     }
 


### PR DESCRIPTION
These are a few small changes required to build the current CNTK system on Ubuntu 16.04/gcc 5.4.

Trainer.cpp required one cast to satisfy the 5.4 compiler.

With gcc the current code fails with c++11 with this error: lambda capture initializers only available with -std=c++14.
Also, cuda 8 does not support c++14. To make it work I had to use c++14 for gcc and c++11 for nvcc.

I also added a line to the Makefile to generate javadoc documentation for the Java wrapper.