### PR TITLE
Bug fixes: fp16 default behavior

### DIFF
--- a/Source/Math/CuDnnBatchNormalization.cu
+++ b/Source/Math/CuDnnBatchNormalization.cu
@@ -54,7 +54,8 @@ protected:
             InvalidArgument("cuDNN batch normalization engine currently supports blendTimeConstant of 0 or 1 only.");
 
         m_inOutCuDnnT.UpdateBatchSize(in.GetNumCols());
-        cudnnBatchNormMode_t mode = m_spatial ? CUDNN_BATCHNORM_SPATIAL : CUDNN_BATCHNORM_PER_ACTIVATION;
+        cudnnBatchNormMode_t mode = m_spatial ? CUDNN_BATCHNORM_SPATIAL_PERSISTENT : CUDNN_BATCHNORM_PER_ACTIVATION;
+        if (inferenceOnly) mode = m_spatial ? CUDNN_BATCHNORM_SPATIAL : CUDNN_BATCHNORM_PER_ACTIVATION;
         // cuDNN will fail with BAD_PARAM if epsilon < CUDNN_BN_MIN_EPSILON.
         m_cudnnEpsilon = max(epsilon, CUDNN_BN_MIN_EPSILON);
         if (inferenceOnly)
@@ -81,7 +82,7 @@ protected:
     {
         UNUSED(blendFactor);  // BUGBUG: It should be used.
         m_inOutCuDnnT.UpdateBatchSize(srcGrad.GetNumCols());
-        cudnnBatchNormMode_t mode = m_spatial ? CUDNN_BATCHNORM_SPATIAL : CUDNN_BATCHNORM_PER_ACTIVATION;
+        cudnnBatchNormMode_t mode = m_spatial ? CUDNN_BATCHNORM_SPATIAL_PERSISTENT : CUDNN_BATCHNORM_PER_ACTIVATION;
         // REVIEW alexeyk: change betaParamDiff to 1 and update CNTK BN engine.
         CUDNN_CALL(cudnnBatchNormalizationBackward(*m_cudnn, mode, &C::One, accumulateDataGrad ? &C::One : &C::Zero, &C::One, &C::Zero, m_inOutCuDnnT, ptr(in), m_inOutCuDnnT, ptr(srcGrad), m_inOutCuDnnT, ptr(grad),
                                                    m_scaleBiasCuDnnT, ptr(scale), ptr(scaleGrad), ptr(biasGrad), m_cudnnEpsilon, ptr(savedMean), ptr(savedInvStdDev)));

--- a/Source/Math/fpgeneric.h
+++ b/Source/Math/fpgeneric.h
@@ -151,6 +151,7 @@ inline cublasStatus_t cublasgemmHelper(cublasHandle_t handle, cublasOperation_t 
     // This does pseudo FP16 computation (input/output in fp16, computation in fp32)
     float h_a = *alpha;
     float h_b = *beta;
+    cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH);
     return cublasGemmEx(handle, transa, transb, m, n, k, &h_a, A, CUDA_R_16F, lda, B, CUDA_R_16F, ldb, &h_b, C, CUDA_R_16F, ldc, CUDA_R_32F, CUBLAS_GEMM_DFALT);
 }
 


### PR DESCRIPTION
This line of commit message is not completely accurate:
set convolution mathType to tensor core only for fp16, and normal math for fp32

The change is actually trying to address this problem:
cudnn find will give you the fastest algo by number and its math type, but before find, we need to set allow tensor core math in order to include algo using tensor core in our searching.
After find, say algo1 without tensor core math is the fastest, we need to record it correctly and set mathtype to disable tensor core, otherwise we will be running algo1 with tensor core.

There might be bug in those batchsize changing cases that cntk allow, but all these are within if(half), so fp32/64 should not be affected.

