### PR TITLE
Add explicit weight decay

### DIFF
--- a/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
+++ b/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
@@ -4742,6 +4742,7 @@ namespace CNTK
     };
 
     typedef TrainingParameterSchedule<double> LearningRateSchedule;
+	typedef TrainingParameterSchedule<double> WeightDecaySchedule;
     typedef TrainingParameterSchedule<double> MomentumSchedule;
     typedef TrainingParameterSchedule<size_t> MinibatchSizeSchedule;
     
@@ -4791,6 +4792,7 @@ namespace CNTK
     {
         double l1RegularizationWeight = 0.0;
         double l2RegularizationWeight = 0.0;
+		WeightDecaySchedule weightDecay = 0.0;
         TrainingParameterSchedule<double> gaussianNoiseInjectionStdDev = 0.0;
         double gradientClippingThresholdPerSample = std::numeric_limits<double>::infinity();
         bool gradientClippingWithTruncation = true;

--- a/bindings/python/cntk/cntk_py.i
+++ b/bindings/python/cntk/cntk_py.i
@@ -117,6 +117,7 @@
 
 %rename(l1_regularization_weight) CNTK::AdditionalLearningOptions::l1RegularizationWeight;
 %rename(l2_regularization_weight) CNTK::AdditionalLearningOptions::l2RegularizationWeight;
+%rename(weight_decay) CNTK::AdditionalLearningOptions::weightDecay;
 %rename(ignored_minibatch_size) CNTK::TrainingParameterSchedule<double>::IgnoredMinibatchSize;
 %rename(ignored_minibatch_size) CNTK::TrainingParameterSchedule<std::size_t>::IgnoredMinibatchSize;
 %rename(_MINIBATCH_SIZE) CNTK::Learner::MinibatchSizeKey; // L"MinibatchSize"

--- a/bindings/python/cntk/learners/tests/learner_test.py
+++ b/bindings/python/cntk/learners/tests/learner_test.py
@@ -456,6 +456,13 @@ def test_learner_update():
     assert learner.learning_rate() == 0.3
     x = learner.update({w: np.asarray([[2.]], dtype=np.float32)}, 100)
     assert learner.learning_rate() == 0.4
+    
+    # Test weight decay
+    w = parameter(shape=(1,), init=w_init)
+    res = i * w
+    learner = sgd(res.parameters, lr=C.learning_parameter_schedule(0.1, minibatch_size = 1, epoch_size=1), weight_decay=0.1)
+    x = learner.update({w: np.asarray([[0.]], dtype=np.float32)}, 100)
+    assert w.value < w_init  # Weight should decay despite gradient being 0
 
 
 def test_noise_injection_with_checkpointing():


### PR DESCRIPTION
Adds explicit support for weight decay as per request in #2784.
This enables better optimization behavior for adaptive gradient methods (e.g., adagrad, adam) and easier hyperparameter tuning all techniques outside of vanilla SGD due to improved separation between learning rate and regularization terms. In order to enable weight decay schemes discussed in the [paper](https://arxiv.org/abs/1711.05101) which highlights this issue, the user is able to specify the weight decay using a schedule.