### PR TITLE
Fix ResNet18

### DIFF
--- a/Examples/Image/Classification/ResNet/BrainScript/ResNet20_ImageNet1K.cntk
+++ b/Examples/Image/Classification/ResNet/BrainScript/ResNet20_ImageNet1K.cntk
@@ -42,7 +42,7 @@ TrainNetwork = {
             ResNetBasic {cMap[2], bnTimeConst} :
 
             ResNetBasicInc {cMap[3], (2:2), bnTimeConst} :
-            ResNetBasic {cMap[3], bnTimeConst} :
+            ResNetBasicStack {2, cMap[3], bnTimeConst} :
 
             # avg pooling
             AveragePoolingLayer {(7: 7), stride = 1} :

--- a/Examples/Image/Classification/ResNet/BrainScript/ResNet20_ImageNet1K.cntk
+++ b/Examples/Image/Classification/ResNet/BrainScript/ResNet20_ImageNet1K.cntk
@@ -1,4 +1,5 @@
-# Node: ResNet-18 with ImageNet -- 18 layers plain ResNet for image classification
+# Node: ResNet-20 with ImageNet -- 20 layers plain ResNet for image classification
+# This network is similar to a ResNet-18 with an extra residual block at the last stage
 # Reference: "Deep Residual Learning for Image Recognition" https://arxiv.org/abs/1512.03385
 
 command = TrainNetwork:Eval
@@ -12,8 +13,8 @@ OutputDir = "$RootDir$/Output"
 ModelDir = "$OutputDir$/Models"
 MeanDir = "$DataDir$"
 
-modelPath = "$ModelDir$/ResNet_18"
-stderr = "$OutputDir$/ResNet_18_BS_out"
+modelPath = "$ModelDir$/ResNet_20"
+stderr = "$OutputDir$/ResNet_20_BS_out"
 
 parallelTrain = true
 

--- a/Examples/Image/Classification/ResNet/Python/TrainResNet_ImageNet_Distributed.py
+++ b/Examples/Image/Classification/ResNet/Python/TrainResNet_ImageNet_Distributed.py
@@ -82,6 +82,8 @@ def create_resnet_network(network_name, fp16):
 
         # create model, and configure learning parameters
         if network_name == 'resnet18':
+            z = create_imagenet_model_basic(graph_input, [2, 1, 1, 1], num_classes)
+        elif network_name == 'resnet20':
             z = create_imagenet_model_basic(graph_input, [2, 1, 1, 2], num_classes)
         elif network_name == 'resnet34':
             z = create_imagenet_model_basic(graph_input, [3, 3, 5, 2], num_classes)

--- a/PretrainedModels/download_model.py
+++ b/PretrainedModels/download_model.py
@@ -17,7 +17,7 @@ models = (('Image Classification', 'AlexNet_ImageNet_CNTK', 'https://www.cntk.ai
           ('Image Classification', 'AlexNet_ImageNet_Caffe', 'https://www.cntk.ai/Models/Caffe_Converted/AlexNet_ImageNet_Caffe.model'),
           ('Image Classification', 'InceptionV3_ImageNet_CNTK', 'https://www.cntk.ai/Models/CNTK_Pretrained/InceptionV3_ImageNet_CNTK.model'),
           ('Image Classification', 'BNInception_ImageNet_Caffe', 'https://www.cntk.ai/Models/Caffe_Converted/BNInception_ImageNet_Caffe.model'),
-          ('Image Classification', 'ResNet18_ImageNet_CNTK', 'https://www.cntk.ai/Models/CNTK_Pretrained/ResNet18_ImageNet_CNTK.model'),
+          ('Image Classification', 'ResNet20_ImageNet_CNTK', 'https://www.cntk.ai/Models/CNTK_Pretrained/ResNet18_ImageNet_CNTK.model'),
           ('Image Classification', 'ResNet34_ImageNet_CNTK', 'https://www.cntk.ai/Models/CNTK_Pretrained/ResNet34_ImageNet_CNTK.model'),
           ('Image Classification', 'ResNet50_ImageNet_CNTK', 'https://www.cntk.ai/Models/CNTK_Pretrained/ResNet50_ImageNet_CNTK.model'),
           ('Image Classification', 'ResNet20_CIFAR10_CNTK', 'https://www.cntk.ai/Models/CNTK_Pretrained/ResNet20_CIFAR10_CNTK.model'),


### PR DESCRIPTION
Fixes #2873 
The current link to download ResNet-18 was changed to ResNet-20. The file itself is still named ResNet-18 and the new Resnet-18 would need to be trained.