### PR TITLE
Do not allow BlockRandomizer to cross sweeps

### DIFF
--- a/Source/Readers/ReaderLib/BlockRandomizer.cpp
+++ b/Source/Readers/ReaderLib/BlockRandomizer.cpp
@@ -147,7 +147,7 @@ Sequences BlockRandomizer::GetNextSequences(size_t globalSampleCount, size_t loc
         numGlobalSamplesLoaded += numGlobalSamples;
         numLocalSamplesLoaded += numLocalSamples;
 
-    } while (m_config.m_allowMinibatchesToCrossSweepBoundaries && 
+    } while ( false && //m_config.m_allowMinibatchesToCrossSweepBoundaries &&  Currently UNSUPPORTED
              !result.m_endOfEpoch &&
              result.m_endOfSweep &&
              globalSampleCount > numGlobalSamplesLoaded &&


### PR DESCRIPTION
Do not generate minibatches that cross sweep boundaries.
This causes problems because SequenceRandomizer clears data at
the start of each sweep which causes the packer to read from
uninitialized memory.

Workaround for issue #2905 