### PR TITLE
Fix typo in C# examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,7 +332,8 @@ Manual/.ipynb_checkpoints
 Examples/Text/LightRNN/LightRNN/*.so
 
 # other
-/packages
+packages/
 /CNTK.VC.db
 /CNTK.VC.VC.opendb
 /Local
+.vs/

--- a/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKLibraryCSEvalExamples.cs
+++ b/Examples/Evaluation/CNTKLibraryCSEvalCPUOnlyExamples/CNTKLibraryCSEvalExamples.cs
@@ -140,7 +140,7 @@ namespace CNTKLibraryCSEvalExamples
                     bmp = new Bitmap(Bitmap.FromFile(imageList[sampleIndex]));
                     resized = bmp.Resize(imageWidth, imageHeight, true);
                     resizedCHW = resized.ParallelExtractCHW();
-                    // Aadd this sample to the data buffer.
+                    // Add this sample to the data buffer.
                     seqData.AddRange(resizedCHW);
                 }
 
@@ -301,14 +301,14 @@ namespace CNTKLibraryCSEvalExamples
             {
                 Console.WriteLine("\n===== Load model from memory buffer =====");
 
-                // For demo purpose, we first read the the model into memory
+                // For demo purpose, we first read the model into memory
                 // The model resnet20.dnn is trained by <CNTK>/Examples/Image/Classification/ResNet/Python/TrainResNet_CIFAR10.py
                 // Please see README.md in <CNTK>/Examples/Image/Classification/ResNet about how to train the model.
                 string modelFilePath = "resnet20.dnn";
                 ThrowIfFileNotExist(modelFilePath, string.Format("Error: The model '{0}' does not exist. Please follow instructions in README.md in <CNTK>/Examples/Image/Classification/ResNet to create the model.", modelFilePath));
                 var modelBuffer = File.ReadAllBytes(modelFilePath);
 
-                // Load model from memroy buffer
+                // Load model from memory buffer
                 Function modelFunc = Function.Load(modelBuffer, device);
                 
                 // Get shape data for the input variable
@@ -358,7 +358,7 @@ namespace CNTKLibraryCSEvalExamples
         /// <summary>
         /// The example shows
         /// - how to evaluate model using asynchronous task. This is useful when offloading is needed to achieve better responsiveness.
-        /// The asynchronous evaluation is implemented as an extension method in CNTKExtensions.cs, which provides an asynchrounous facade for the synchronous Evaluation().
+        /// The asynchronous evaluation is implemented as an extension method in CNTKExtensions.cs, which provides an asynchronous facade for the synchronous Evaluation().
         /// </summary>
         /// <param name="device">Specify on which device to run the evaluation.</param>
         public static async Task EvaluationSingleImageAsync(DeviceDescriptor device)
@@ -421,7 +421,7 @@ namespace CNTKLibraryCSEvalExamples
         }
 
         /// <summary>
-        /// Print out the evalaution results.
+        /// Print out the evaluation results.
         /// </summary>
         /// <typeparam name="T">The data value type</typeparam>
         /// <param name="sampleSize">The size of each sample.</param>

--- a/Examples/Evaluation/ImageExtension/CNTKImageProcessing.cs
+++ b/Examples/Evaluation/ImageExtension/CNTKImageProcessing.cs
@@ -75,7 +75,7 @@ namespace CNTKImageProcessing
         /// </summary>
         /// <param name="image">The image to resize</param>
         /// <param name="width">New width in pixels</param>
-        /// <param name="height">New height in pixesl</param>
+        /// <param name="height">New height in pixels</param>
         /// <param name="useHighQuality">Resize quality</param>
         /// <returns>The resized image</returns>
         public static Bitmap Resize(this Bitmap image, int width, int height, bool useHighQuality)

--- a/Examples/Evaluation/LegacyEvalDll/CSEvalClient/ModelEvaluator.cs
+++ b/Examples/Evaluation/LegacyEvalDll/CSEvalClient/ModelEvaluator.cs
@@ -54,7 +54,7 @@ namespace Microsoft.MSR.CNTK.Extensibility.Managed.CSEvalClient
         private Dictionary<string, List<float>> m_inputs;
 
         /// <summary>
-        /// Indicates if the object is diposed
+        /// Indicates if the object is disposed
         /// </summary>
         private static bool Disposed
         {

--- a/Examples/Evaluation/LegacyEvalDll/CSEvalClient/Program.cs
+++ b/Examples/Evaluation/LegacyEvalDll/CSEvalClient/Program.cs
@@ -575,7 +575,7 @@ namespace Microsoft.MSR.CNTK.Extensibility.Managed.CSEvalClient
         }
 
         /// <summary>
-        /// Creats a list of random numbers
+        /// Creates a list of random numbers
         /// </summary>
         /// <param name="size">The size of the list</param>
         /// <param name="maxValue">The maximum value for the generated values</param>

--- a/Examples/TrainingCSharp/Common/CifarResNetClassifier.cs
+++ b/Examples/TrainingCSharp/Common/CifarResNetClassifier.cs
@@ -19,7 +19,7 @@ namespace CNTK.CSTrainingExamples
         public static string CifarDataFolder = "../../Examples/Image/DataSets/CIFAR-10";
 
         /// <summary>
-        /// number of epoches for training. 
+        /// number of epochs for training. 
         /// </summary>
         public static uint MaxEpochs = 1;
 
@@ -187,7 +187,7 @@ namespace CNTK.CSTrainingExamples
         /// https://arxiv.org/abs/1512.03385
         /// </summary>
         /// <param name="input">input variable for image data</param>
-        /// <param name="numOutputClasses">number of outout classes</param>
+        /// <param name="numOutputClasses">number of output classes</param>
         /// <param name="device">CPU or GPU device to run</param>
         /// <param name="outputName">name of the classifier</param>
         /// <returns></returns>

--- a/Examples/TrainingCSharp/Common/TestHelper.cs
+++ b/Examples/TrainingCSharp/Common/TestHelper.cs
@@ -86,7 +86,7 @@ namespace CNTK.CSTrainingExamples
                     break;
                 totalCount += (int)minibatchData[featureStreamInfo].numberOfSamples;
 
-                // expected lables are in the minibatch data.
+                // expected labels are in the minibatch data.
                 var labelData = minibatchData[labelStreamInfo].data.GetDenseData<float>(labelOutput);
                 var expectedLabels = labelData.Select(l => l.IndexOf(l.Max())).ToList();
 

--- a/Examples/TrainingCSharp/Common/TransferLearning.cs
+++ b/Examples/TrainingCSharp/Common/TransferLearning.cs
@@ -10,7 +10,7 @@ namespace CNTK.CSTrainingExamples
     /// <summary>
     /// This class demonstrates transfer learning use a pretrained ResNet model. 
     /// Refer to https://github.com/Microsoft/CNTK/blob/master/Tutorials/CNTK_301_Image_Recognition_with_Deep_Transfer_Learning.ipynb
-    /// for tranfer learning in general, and ResNet model, data used for training. 
+    /// for transfer learning in general, and ResNet model, data used for training. 
     /// </summary>
     public class TransferLearning
     {
@@ -30,7 +30,7 @@ namespace CNTK.CSTrainingExamples
 
         /// <summary>
         /// TrainAndEvaluateWithFlowerData shows how to do transfer learning with a MinibatchSource. MinibatchSource is constructed with 
-        /// a map file that contains image file paths and labels. Data loading, image preprocessing, and batch ramdomization are handled 
+        /// a map file that contains image file paths and labels. Data loading, image preprocessing, and batch randomization are handled 
         /// by MinibatchSource.
         /// </summary>
         /// <param name="device">CPU or GPU device to run</param>
@@ -373,7 +373,7 @@ namespace CNTK.CSTrainingExamples
                 if (totalCount > maxCount)
                     break;
 
-                // expected lables are in the minibatch data.
+                // expected labels are in the minibatch data.
                 var labelData = minibatchData[labelStreamInfo].data.GetDenseData<float>(labelOutput);
                 var expectedLabels = labelData.Select(l => l.IndexOf(l.Max())).ToList();
 


### PR DESCRIPTION
Fix typos in C# examples and change gitignore for Visual Studio.