### PR TITLE
Remove unnecessary sys/io.h

### DIFF
--- a/Source/CNTKv2LibraryDll/proto/onnx/core/model.cpp
+++ b/Source/CNTKv2LibraryDll/proto/onnx/core/model.cpp
@@ -11,7 +11,6 @@
 #ifdef _WIN32
 #include <io.h>
 #else
-#include <sys/io.h>
 #include <unistd.h>
 #endif
 #include "model.h"

--- a/Source/CNTKv2LibraryDll/proto/onnx/core/utils.h
+++ b/Source/CNTKv2LibraryDll/proto/onnx/core/utils.h
@@ -6,7 +6,6 @@
 #ifdef _WIN32
 #include <io.h>
 #else
-#include <sys/io.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Machines with aarch64 architecture such as NVIDIA Jetson TX1 does
not have sys/io.h. Without this commit, building
libCntk.Core-2.5.so fails on a aarch64 machine.

It should be safe to completely remove the inclusion of sys/io.h,
since it seems that functions in the header are not used by CNTK.

Following quote is from [here](https://bugzilla.redhat.com/show_bug.cgi?id=1116162#c1):
> The sys/ headers are architecture and OS dependent. They do not exist across all targets and io.h in particular is intended for very lowl-level non-portable uses often in coordination with the kernel. The only targets that provide sys/io.h are x86*, Alpha, IA64, and 32-bit ARM. No other systems provide it.