### PR TITLE
Allow to add some extra cxxflags via env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,9 @@ SOURCEDIR:= Source
 INCLUDEPATH:= $(addprefix $(SOURCEDIR)/, Common/Include CNTKv2LibraryDll CNTKv2LibraryDll/API CNTKv2LibraryDll/proto ../Examples/Extensibility/CPP Math CNTK ActionsLib ComputationNetworkLib SGDLib SequenceTrainingLib CNTK/BrainScript Readers/ReaderLib PerformanceProfilerDll)
 INCLUDEPATH+=$(PROTOBUF_PATH)/include
 # COMMON_FLAGS include settings that are passed both to NVCC and C++ compilers.
-COMMON_FLAGS:= -DHAS_MPI=$(HAS_MPI) -D_POSIX_SOURCE -D_XOPEN_SOURCE=600 -D__USE_XOPEN2K -std=c++11 -DCUDA_NO_HALF -D__CUDA_NO_HALF_OPERATORS__
+COMMON_FLAGS:= $(COMMON_FLAGS) -DHAS_MPI=$(HAS_MPI) -D_POSIX_SOURCE -D_XOPEN_SOURCE=600 -D__USE_XOPEN2K -std=c++11 -DCUDA_NO_HALF -D__CUDA_NO_HALF_OPERATORS__
 CPPFLAGS:=
-CXXFLAGS:= $(SSE_FLAGS) -std=c++0x -fopenmp -fpermissive -fPIC -Werror -fcheck-new
+CXXFLAGS:= $(SSE_FLAGS) $(CXXFLAGS) -std=c++0x -fopenmp -fpermissive -fPIC -Werror -fcheck-new
 LIBPATH:=
 LIBS_LIST:=
 LDFLAGS:=


### PR DESCRIPTION
Allow to add some extra cxxflags via system env. 

Use cases:
1) https://github.com/Microsoft/CNTK/issues/3155
export CXXFLAGS="-Wno-unused-variable -Wno-sign-compare" 
configure && make

2) Our libc/libstdc has been built with gcc-4.9. So we fail to build cntk in current state with gcc-5 in compatibility mode.
https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html

After patching cntk we have successful build:
COMMON_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 -Wno-unused-variable -Wno-sign-compare" configure && make
(nvcc don't recongnise -W flags)
