### PR TITLE
Handle intermediate directory creation properly

### DIFF
--- a/Tutorials/CNTK_303_Deep_Structured_Semantic_Modeling_with_LSTM_Networks.ipynb
+++ b/Tutorials/CNTK_303_Deep_Structured_Semantic_Modeling_with_LSTM_Networks.ipynb
@@ -109,7 +109,7 @@
     "            handle.write(data)\n",
     "\n",
     "if not os.path.exists(location):\n",
-    "    os.mkdir(location)\n",
+    "    os.mkdirs(location)\n",
     "     \n",
     "for item in data.values():\n",
     "    path = os.path.normpath(os.path.join(location, item['file']))\n",


### PR DESCRIPTION
This simple change allows python to create intermediate directions if they do not exist.