### PR TITLE
fix break for cub 1.8 API change

### DIFF
--- a/Source/Math/CntkBatchNormalization.cuh
+++ b/Source/Math/CntkBatchNormalization.cuh
@@ -117,7 +117,7 @@ __device__ __forceinline__ T Shuffle(T input, int srcLane, unsigned int mask)
     // shfl is supported only on Kepler+
     static_assert(__CUDA_ARCH__ >= 300, "CNTK only supports only Kepler GPU architecture or newer.");
 #if CUDA_VERSION >= 9000
-    return cub::ShuffleIndex(input, srcLane, CUB_PTX_WARP_THREADS, mask); // Need cub > 1.7.0
+    return cub::ShuffleIndex<CUB_PTX_WARP_THREADS>(input, srcLane, mask); // Need cub >= 1.8.0
 #else
     return cub::ShuffleIndex(input, srcLane);
 #endif


### PR DESCRIPTION
Note that we don't support multiple cub version. This code keep this behavior and only support cub version >= 1.8.0