### PR TITLE
Add sequence error builtin function

### DIFF
--- a/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
+++ b/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
@@ -4348,6 +4348,11 @@ namespace CNTK
     CNTK_API FunctionPtr EditDistanceError(const Variable& prediction, const Variable& labels, float substitutionPenalty, float deletionPenalty, float insertionPenalty, bool squashInputs, 
         const std::vector<size_t>& tokensToIgnore, const std::wstring& name = L"");
 
+	///
+	/// Create an instance of the CNTK built-in operation for computing the transcription error for specified operands.
+	///
+	CNTK_API FunctionPtr TranscriptionError(const Variable& prediction, const Variable& labels, bool squashInputs, const std::vector<size_t>& tokensToIgnore, const std::wstring& name = L"");
+
     ///
     /// Create an instance of the CNTK built-in operation for sequence with lattice training (typically for speech).
     ///

--- a/Source/CNTKv2LibraryDll/BackCompat.cpp
+++ b/Source/CNTKv2LibraryDll/BackCompat.cpp
@@ -498,6 +498,13 @@ namespace CNTK
 
                     opType = PrimitiveOpType::EditDistanceError;
                 }
+				else if (node->OperationName() == OperationNameOf(TranscriptionErrorNode)) {
+					auto edNode = node->As<TranscriptionErrorNode<ElementType>>();
+					primitiveFunctionConfigParameters[PrimitiveFunction::AttributeNameSquashInputs] = edNode->SquashInputs();
+					primitiveFunctionConfigParameters[PrimitiveFunction::AttributeNameTokensToIgnore] = AsDictionaryValueVector(edNode->TokensToIgnore());
+
+					opType = PrimitiveOpType::TranscriptionError;
+				}
                 else if (node->OperationName() == OperationNameOf(StopGradientNode))
                 {
                     opType = PrimitiveOpType::StopGradient;

--- a/Source/CNTKv2LibraryDll/BackCompat.cpp
+++ b/Source/CNTKv2LibraryDll/BackCompat.cpp
@@ -498,13 +498,14 @@ namespace CNTK
 
                     opType = PrimitiveOpType::EditDistanceError;
                 }
-				else if (node->OperationName() == OperationNameOf(TranscriptionErrorNode)) {
-					auto edNode = node->As<TranscriptionErrorNode<ElementType>>();
-					primitiveFunctionConfigParameters[PrimitiveFunction::AttributeNameSquashInputs] = edNode->SquashInputs();
-					primitiveFunctionConfigParameters[PrimitiveFunction::AttributeNameTokensToIgnore] = AsDictionaryValueVector(edNode->TokensToIgnore());
+                else if (node->OperationName() == OperationNameOf(TranscriptionErrorNode))
+                {
+                    auto edNode = node->As<TranscriptionErrorNode<ElementType>>();
+                    primitiveFunctionConfigParameters[PrimitiveFunction::AttributeNameSquashInputs] = edNode->SquashInputs();
+                    primitiveFunctionConfigParameters[PrimitiveFunction::AttributeNameTokensToIgnore] = AsDictionaryValueVector(edNode->TokensToIgnore());
 
-					opType = PrimitiveOpType::TranscriptionError;
-				}
+                    opType = PrimitiveOpType::TranscriptionError;
+                }
                 else if (node->OperationName() == OperationNameOf(StopGradientNode))
                 {
                     opType = PrimitiveOpType::StopGradient;

--- a/Source/CNTKv2LibraryDll/CompositeFunction.cpp
+++ b/Source/CNTKv2LibraryDll/CompositeFunction.cpp
@@ -1127,6 +1127,13 @@ namespace CNTK
                     ASSIGN_NEW_NODE(EditDistanceErrorNode, network->GetDeviceId(), internalNodeName, subPen, delPen, insPen, squashInputs, tokensToIgnore);
                     break;
                 }
+				case PrimitiveOpType::TranscriptionError:
+				{
+					auto squashInputs = functionConfig[PrimitiveFunction::AttributeNameSquashInputs].Value<bool>();
+					auto tokensToIgnore = AsVector<size_t>(functionConfig[PrimitiveFunction::AttributeNameTokensToIgnore].Value<std::vector<DictionaryValue>>());
+					ASSIGN_NEW_NODE(TranscriptionErrorNode, network->GetDeviceId(), internalNodeName, squashInputs, tokensToIgnore);
+					break;
+				}
                 case PrimitiveOpType::LatticeSequenceWithSoftmax:
                 {
                     auto symListPath = functionConfig[PrimitiveFunction::AttributeNameSymListPath].Value<wstring>();

--- a/Source/CNTKv2LibraryDll/CompositeFunction.cpp
+++ b/Source/CNTKv2LibraryDll/CompositeFunction.cpp
@@ -1127,13 +1127,13 @@ namespace CNTK
                     ASSIGN_NEW_NODE(EditDistanceErrorNode, network->GetDeviceId(), internalNodeName, subPen, delPen, insPen, squashInputs, tokensToIgnore);
                     break;
                 }
-				case PrimitiveOpType::TranscriptionError:
-				{
-					auto squashInputs = functionConfig[PrimitiveFunction::AttributeNameSquashInputs].Value<bool>();
-					auto tokensToIgnore = AsVector<size_t>(functionConfig[PrimitiveFunction::AttributeNameTokensToIgnore].Value<std::vector<DictionaryValue>>());
-					ASSIGN_NEW_NODE(TranscriptionErrorNode, network->GetDeviceId(), internalNodeName, squashInputs, tokensToIgnore);
-					break;
-				}
+                case PrimitiveOpType::TranscriptionError:
+                {
+                    auto squashInputs = functionConfig[PrimitiveFunction::AttributeNameSquashInputs].Value<bool>();
+                    auto tokensToIgnore = AsVector<size_t>(functionConfig[PrimitiveFunction::AttributeNameTokensToIgnore].Value<std::vector<DictionaryValue>>());
+                    ASSIGN_NEW_NODE(TranscriptionErrorNode, network->GetDeviceId(), internalNodeName, squashInputs, tokensToIgnore);
+                    break;
+                }
                 case PrimitiveOpType::LatticeSequenceWithSoftmax:
                 {
                     auto symListPath = functionConfig[PrimitiveFunction::AttributeNameSymListPath].Value<wstring>();

--- a/Source/CNTKv2LibraryDll/Function.cpp
+++ b/Source/CNTKv2LibraryDll/Function.cpp
@@ -2154,15 +2154,15 @@ namespace CNTK
 
         return BinaryOp(PrimitiveOpType::EditDistanceError, prediction, labels, std::move(additionalProperties), name);
     }
-	
-	FunctionPtr TranscriptionError(const Variable& prediction, const Variable& labels, bool squashInputs, const vector<size_t>& tokensToIgnore, const std::wstring& name)
-	{
-		auto additionalProperties = Dictionary();
-		additionalProperties[PrimitiveFunction::AttributeNameSquashInputs] = squashInputs;
-		additionalProperties[PrimitiveFunction::AttributeNameTokensToIgnore] = AsDictionaryValueVector(tokensToIgnore);
 
-		return BinaryOp(PrimitiveOpType::TranscriptionError, prediction, labels, std::move(additionalProperties), name);
-	}
+    FunctionPtr TranscriptionError(const Variable& prediction, const Variable& labels, bool squashInputs, const vector<size_t>& tokensToIgnore, const std::wstring& name)
+    {
+        auto additionalProperties = Dictionary();
+        additionalProperties[PrimitiveFunction::AttributeNameSquashInputs] = squashInputs;
+        additionalProperties[PrimitiveFunction::AttributeNameTokensToIgnore] = AsDictionaryValueVector(tokensToIgnore);
+
+        return BinaryOp(PrimitiveOpType::TranscriptionError, prediction, labels, std::move(additionalProperties), name);
+    }
 
     FunctionPtr LatticeSequenceWithSoftmax(const Variable& labels, const Variable& prediction, const Variable& scaledLogLikelihood, const Variable& lattice, const std::wstring& symListPath, const std::wstring& phonePath, const std::wstring& stateListPath, const std::wstring& transProbPath, const std::wstring& latticeConfigPath, float hSmoothingWeight, float frameDropThresh, bool doReferenceAlign, bool seqGammarUsesMBR, float seqGammarAMF, float seqGammarLMF, float seqGammarBMMIFactor, float seqGammarWordPen, const std::wstring& name)
     {

--- a/Source/CNTKv2LibraryDll/Function.cpp
+++ b/Source/CNTKv2LibraryDll/Function.cpp
@@ -2154,6 +2154,15 @@ namespace CNTK
 
         return BinaryOp(PrimitiveOpType::EditDistanceError, prediction, labels, std::move(additionalProperties), name);
     }
+	
+	FunctionPtr TranscriptionError(const Variable& prediction, const Variable& labels, bool squashInputs, const vector<size_t>& tokensToIgnore, const std::wstring& name)
+	{
+		auto additionalProperties = Dictionary();
+		additionalProperties[PrimitiveFunction::AttributeNameSquashInputs] = squashInputs;
+		additionalProperties[PrimitiveFunction::AttributeNameTokensToIgnore] = AsDictionaryValueVector(tokensToIgnore);
+
+		return BinaryOp(PrimitiveOpType::TranscriptionError, prediction, labels, std::move(additionalProperties), name);
+	}
 
     FunctionPtr LatticeSequenceWithSoftmax(const Variable& labels, const Variable& prediction, const Variable& scaledLogLikelihood, const Variable& lattice, const std::wstring& symListPath, const std::wstring& phonePath, const std::wstring& stateListPath, const std::wstring& transProbPath, const std::wstring& latticeConfigPath, float hSmoothingWeight, float frameDropThresh, bool doReferenceAlign, bool seqGammarUsesMBR, float seqGammarAMF, float seqGammarLMF, float seqGammarBMMIFactor, float seqGammarWordPen, const std::wstring& name)
     {

--- a/Source/CNTKv2LibraryDll/PrimitiveFunction.cpp
+++ b/Source/CNTKv2LibraryDll/PrimitiveFunction.cpp
@@ -129,6 +129,7 @@ namespace CNTK
             (op == PrimitiveOpType::CrossEntropyWithSoftmax) ||
             (op == PrimitiveOpType::LatticeSequenceWithSoftmax) ||
             (op == PrimitiveOpType::EditDistanceError) ||
+			(op == PrimitiveOpType::TranscriptionError) ||
             (op == PrimitiveOpType::ClassificationError) ||
             (op == PrimitiveOpType::ForwardBackward) ||
             (op == PrimitiveOpType::Logistic) ||
@@ -874,6 +875,7 @@ namespace CNTK
                         case PrimitiveOpType::CosDistance:
                         case PrimitiveOpType::SquaredError:
                         case PrimitiveOpType::EditDistanceError:
+						case PrimitiveOpType::TranscriptionError:
                         case PrimitiveOpType::LatticeSequenceWithSoftmax:
                         case PrimitiveOpType::ClassificationError:
                         case PrimitiveOpType::NDCG:

--- a/Source/CNTKv2LibraryDll/PrimitiveFunction.cpp
+++ b/Source/CNTKv2LibraryDll/PrimitiveFunction.cpp
@@ -129,7 +129,7 @@ namespace CNTK
             (op == PrimitiveOpType::CrossEntropyWithSoftmax) ||
             (op == PrimitiveOpType::LatticeSequenceWithSoftmax) ||
             (op == PrimitiveOpType::EditDistanceError) ||
-			(op == PrimitiveOpType::TranscriptionError) ||
+            (op == PrimitiveOpType::TranscriptionError) ||
             (op == PrimitiveOpType::ClassificationError) ||
             (op == PrimitiveOpType::ForwardBackward) ||
             (op == PrimitiveOpType::Logistic) ||

--- a/Source/CNTKv2LibraryDll/PrimitiveFunction.h
+++ b/Source/CNTKv2LibraryDll/PrimitiveFunction.h
@@ -839,7 +839,8 @@ namespace CNTK
         // Version 19: Add TopK
         // Version 20: Add squeeze, expand dims, zeros like, ones like
         // Version 21: Add EyeLikeOp
-        static const size_t s_serializationVersion = 21;
+        // Version 22: Add TranscriptionError
+        static const size_t s_serializationVersion = 22;
     };
 
     std::vector<DictionaryValue> GetInputUids(const Function& f);

--- a/Source/CNTKv2LibraryDll/PrimitiveFunction.h
+++ b/Source/CNTKv2LibraryDll/PrimitiveFunction.h
@@ -66,6 +66,7 @@ namespace CNTK
         {PrimitiveOpType::LatticeSequenceWithSoftmax, L"LatticeSequenceWithSoftmax" },
         {PrimitiveOpType::ClassificationError, L"ClassificationError"},
         {PrimitiveOpType::EditDistanceError, L"EditDistanceError" },
+		{PrimitiveOpType::TranscriptionError, L"TranscriptionError"},
         {PrimitiveOpType::ForwardBackward, L"ForwardBackward" },
         {PrimitiveOpType::LabelsToGraph, L"LabelsToGraph" },
         {PrimitiveOpType::PastValue, L"PastValue"},

--- a/Source/CNTKv2LibraryDll/PrimitiveOpType.h
+++ b/Source/CNTKv2LibraryDll/PrimitiveOpType.h
@@ -103,7 +103,7 @@ namespace CNTK
         Cast = 91,
         EyeLikeOp = 92,
         CustomProxyOp = 93,
-
+        TranscriptionError = 94,
         // New op types should only be appended to the end of this list 
         UnknownOP
         // and UnknownOP should always be last.

--- a/Source/ComputationNetworkLib/ComputationNetworkBuilder.cpp
+++ b/Source/ComputationNetworkLib/ComputationNetworkBuilder.cpp
@@ -446,6 +446,12 @@ shared_ptr<ComputationNode<ElemType>> ComputationNetworkBuilder<ElemType>::EditD
 }
 
 template <class ElemType>
+shared_ptr<ComputationNode<ElemType>> ComputationNetworkBuilder<ElemType>::TranscriptionError(const ComputationNodePtr a, const ComputationNodePtr b, bool squashInputs, vector<size_t> tokensToIgnore, const std::wstring nodeName)
+{
+	return net.AddNodeToNetAndAttachInputs(New<TranscriptionErrorNode<ElemType>>(net.GetDeviceId(), nodeName, squashInputs, tokensToIgnore), { a, b });
+}
+
+template <class ElemType>
 shared_ptr<ComputationNode<ElemType>> ComputationNetworkBuilder<ElemType>::StopGradient(const ComputationNodePtr a, const std::wstring nodeName)
 {
     return net.AddNodeToNetAndAttachInputs(New<StopGradientNode<ElemType>>(net.GetDeviceId(), nodeName), { a });

--- a/Source/ComputationNetworkLib/ComputationNetworkBuilder.h
+++ b/Source/ComputationNetworkLib/ComputationNetworkBuilder.h
@@ -144,8 +144,8 @@ public:
     ComputationNodePtr Dropout(const ComputationNodePtr a, const std::wstring nodeName = L"");
     ComputationNodePtr DummyCriterion(const ComputationNodePtr objectives, const ComputationNodePtr derivatives, const ComputationNodePtr prediction, const std::wstring nodeName = L"");
     ComputationNodePtr EditDistanceError(const ComputationNodePtr a, const ComputationNodePtr b, float subPen, float delPen, float insPen, bool squashInputs, vector<size_t> tokensToIgnore, const std::wstring nodeName = L"");
-	ComputationNodePtr TranscriptionError(const ComputationNodePtr a, const ComputationNodePtr b, bool squashInputs, vector<size_t> tokensToIgnore, const std::wstring nodeName = L"");
-	ComputationNodePtr StopGradient(const ComputationNodePtr a, const std::wstring nodeName = L"");
+    ComputationNodePtr TranscriptionError(const ComputationNodePtr a, const ComputationNodePtr b, bool squashInputs, vector<size_t> tokensToIgnore, const std::wstring nodeName = L"");
+    ComputationNodePtr StopGradient(const ComputationNodePtr a, const std::wstring nodeName = L"");
     ComputationNodePtr ElementTimes(const ComputationNodePtr a, const ComputationNodePtr b, const std::wstring nodeName = L"");
     ComputationNodePtr DynamicAxis(const ComputationNodePtr a, const std::wstring& nodeName = L"");
     ComputationNodePtr ClassificationError(const ComputationNodePtr a, const ComputationNodePtr b, const std::wstring nodeName = L"");

--- a/Source/ComputationNetworkLib/ComputationNetworkBuilder.h
+++ b/Source/ComputationNetworkLib/ComputationNetworkBuilder.h
@@ -144,7 +144,8 @@ public:
     ComputationNodePtr Dropout(const ComputationNodePtr a, const std::wstring nodeName = L"");
     ComputationNodePtr DummyCriterion(const ComputationNodePtr objectives, const ComputationNodePtr derivatives, const ComputationNodePtr prediction, const std::wstring nodeName = L"");
     ComputationNodePtr EditDistanceError(const ComputationNodePtr a, const ComputationNodePtr b, float subPen, float delPen, float insPen, bool squashInputs, vector<size_t> tokensToIgnore, const std::wstring nodeName = L"");
-    ComputationNodePtr StopGradient(const ComputationNodePtr a, const std::wstring nodeName = L"");
+	ComputationNodePtr TranscriptionError(const ComputationNodePtr a, const ComputationNodePtr b, bool squashInputs, vector<size_t> tokensToIgnore, const std::wstring nodeName = L"");
+	ComputationNodePtr StopGradient(const ComputationNodePtr a, const std::wstring nodeName = L"");
     ComputationNodePtr ElementTimes(const ComputationNodePtr a, const ComputationNodePtr b, const std::wstring nodeName = L"");
     ComputationNodePtr DynamicAxis(const ComputationNodePtr a, const std::wstring& nodeName = L"");
     ComputationNodePtr ClassificationError(const ComputationNodePtr a, const ComputationNodePtr b, const std::wstring nodeName = L"");

--- a/Source/ComputationNetworkLib/EvaluationNodes.h
+++ b/Source/ComputationNetworkLib/EvaluationNodes.h
@@ -458,196 +458,207 @@ protected:
 template class NDCG1EvalNode<float>;
 template class NDCG1EvalNode<double>;
 
-template<class ElemType>
+template <class ElemType>
 class TextTranscriptionErrorNodeBase : public ComputationNodeNonLooping<ElemType>, public NumInputs<2>
 {
-	using Base = ComputationNodeNonLooping<ElemType>;
+    using Base = ComputationNodeNonLooping<ElemType>;
+
 public:
-	TextTranscriptionErrorNodeBase(DEVICEID_TYPE deviceId, const wstring & name, bool squashInputs = false, vector<size_t> tokensToIgnore = {})
-		: Base(deviceId, name), m_squashInputs(squashInputs), m_tokensToIgnore(tokensToIgnore)
-	{
-	}
+    TextTranscriptionErrorNodeBase(DEVICEID_TYPE deviceId, const wstring& name, bool squashInputs = false, vector<size_t> tokensToIgnore = {})
+        : Base(deviceId, name), m_squashInputs(squashInputs), m_tokensToIgnore(tokensToIgnore)
+    {
+    }
 
-	virtual void BackpropToNonLooping(size_t /*inputIndex*/) override
-	{
-		LogicError("%ls operation is used for evaluation only.", OperationName().c_str());
-	}
+    virtual void BackpropToNonLooping(size_t /*inputIndex*/) override
+    {
+        LogicError("%ls operation is used for evaluation only.", OperationName().c_str());
+    }
 
-	virtual void ComputeTextError() = 0;
+    virtual void ComputeTextError() = 0;
 
-	virtual void ForwardPropNonLooping() override
-	{
-		bool isInput0Sparse = Input(0)->template Is<SparseInputValue<ElemType>>();
-		bool isInput1Sparse = Input(1)->template Is<SparseInputValue<ElemType>>();
-		if (isInput0Sparse || isInput1Sparse)
-			LogicError("EditDistanceError node was not tested for sparse inputs.");
+    virtual void ForwardPropNonLooping() override
+    {
+        bool isInput0Sparse = Input(0)->template Is<SparseInputValue<ElemType>>();
+        bool isInput1Sparse = Input(1)->template Is<SparseInputValue<ElemType>>();
+        if (isInput0Sparse || isInput1Sparse)
+            LogicError("EditDistanceError node was not tested for sparse inputs.");
 
-		FrameRange frameRange(Input(0)->GetMBLayout());
-		Input(0)->ValueFor(frameRange).VectorMax(*m_maxIndexes0, *m_maxValues, true);
-		Input(1)->ValueFor(frameRange).VectorMax(*m_maxIndexes1, *m_maxValues, true);
+        FrameRange frameRange(Input(0)->GetMBLayout());
+        Input(0)->ValueFor(frameRange).VectorMax(*m_maxIndexes0, *m_maxValues, true);
+        Input(1)->ValueFor(frameRange).VectorMax(*m_maxIndexes1, *m_maxValues, true);
 
-		MaskMissingColumnsToZero(*m_maxIndexes0, Input(0)->GetMBLayout(), frameRange);
-		MaskMissingColumnsToZero(*m_maxIndexes1, Input(1)->GetMBLayout(), frameRange);
+        MaskMissingColumnsToZero(*m_maxIndexes0, Input(0)->GetMBLayout(), frameRange);
+        MaskMissingColumnsToZero(*m_maxIndexes1, Input(1)->GetMBLayout(), frameRange);
 
-		ComputeTextError();
-	}
+        ComputeTextError();
+    }
 
-	virtual void Validate(bool isFinalValidationPass) override
-	{
-		ValidateBinaryReduce(isFinalValidationPass);
-	}
+    virtual void Validate(bool isFinalValidationPass) override
+    {
+        ValidateBinaryReduce(isFinalValidationPass);
+    }
 
-	virtual void UpdateFunctionMBSize() override
-	{
-		Base::UpdateFunctionMBSize();
+    virtual void UpdateFunctionMBSize() override
+    {
+        Base::UpdateFunctionMBSize();
 
-		// resize the temporaries to their proper size
-		size_t cols = Input(0)->Value().GetNumCols();
-		m_maxIndexes0->Resize(1, cols);
-		m_maxIndexes1->Resize(1, cols);
-		m_maxValues->Resize(1, cols);
-	}
+        // resize the temporaries to their proper size
+        size_t cols = Input(0)->Value().GetNumCols();
+        m_maxIndexes0->Resize(1, cols);
+        m_maxIndexes1->Resize(1, cols);
+        m_maxValues->Resize(1, cols);
+    }
 
-	virtual void CopyTo(ComputationNodeBasePtr  nodeP, const std::wstring& newName, const CopyNodeFlags flags) const override
-	{
-		Base::CopyTo(nodeP, newName, flags);
+    virtual void CopyTo(ComputationNodeBasePtr nodeP, const std::wstring& newName, const CopyNodeFlags flags) const override
+    {
+        Base::CopyTo(nodeP, newName, flags);
 
-		if (flags & CopyNodeFlags::copyNodeValue)
-		{
-			auto node = dynamic_pointer_cast<EditDistanceErrorNode<ElemType>>(nodeP);
-			node->m_maxIndexes0 = m_maxIndexes0;
-			node->m_maxIndexes1 = m_maxIndexes1;
-			node->m_maxValues = m_maxValues;
-			node->m_squashInputs = m_squashInputs;
-			node->m_tokensToIgnore = m_tokensToIgnore;
-		}
-	}
+        if (flags & CopyNodeFlags::copyNodeValue)
+        {
+            auto node = dynamic_pointer_cast<EditDistanceErrorNode<ElemType>>(nodeP);
+            node->m_maxIndexes0 = m_maxIndexes0;
+            node->m_maxIndexes1 = m_maxIndexes1;
+            node->m_maxValues = m_maxValues;
+            node->m_squashInputs = m_squashInputs;
+            node->m_tokensToIgnore = m_tokensToIgnore;
+        }
+    }
 
-	//request matrices needed to do node function value evaluation
-	virtual void RequestMatricesBeforeForwardProp(MatrixPool& matrixPool)
-	{
-		Base::RequestMatricesBeforeForwardProp(matrixPool);
-		RequestMatrixFromPool(m_maxIndexes0, matrixPool);
-		RequestMatrixFromPool(m_maxIndexes1, matrixPool);
-		RequestMatrixFromPool(m_maxValues, matrixPool);
-	}
+    //request matrices needed to do node function value evaluation
+    virtual void RequestMatricesBeforeForwardProp(MatrixPool& matrixPool)
+    {
+        Base::RequestMatricesBeforeForwardProp(matrixPool);
+        RequestMatrixFromPool(m_maxIndexes0, matrixPool);
+        RequestMatrixFromPool(m_maxIndexes1, matrixPool);
+        RequestMatrixFromPool(m_maxValues, matrixPool);
+    }
 
-	//release temp matrices that are only used by forward computation
-	//don't release matrices that need to be used in the gradient computation
-	virtual void ReleaseMatricesAfterForwardProp(MatrixPool& matrixPool)
-	{
-		Base::ReleaseMatricesAfterForwardProp(matrixPool);
-		ReleaseMatrixToPool(m_maxIndexes0, matrixPool);
-		ReleaseMatrixToPool(m_maxIndexes1, matrixPool);
-		ReleaseMatrixToPool(m_maxValues, matrixPool);
-	}
+    //release temp matrices that are only used by forward computation
+    //don't release matrices that need to be used in the gradient computation
+    virtual void ReleaseMatricesAfterForwardProp(MatrixPool& matrixPool)
+    {
+        Base::ReleaseMatricesAfterForwardProp(matrixPool);
+        ReleaseMatrixToPool(m_maxIndexes0, matrixPool);
+        ReleaseMatrixToPool(m_maxIndexes1, matrixPool);
+        ReleaseMatrixToPool(m_maxValues, matrixPool);
+    }
 
-	virtual void Save(File& fstream) const override
-	{
-		Base::Save(fstream);
-		fstream << m_squashInputs;
-		fstream << m_tokensToIgnore;
-	}
+    virtual void Save(File& fstream) const override
+    {
+        Base::Save(fstream);
+        fstream << m_squashInputs;
+        fstream << m_tokensToIgnore;
+    }
 
-	virtual void Load(File& fstream, size_t modelVersion) override
-	{
-		Base::Load(fstream, modelVersion);
-		fstream >> m_squashInputs;
-		fstream >> m_tokensToIgnore;
-	}
+    virtual void Load(File& fstream, size_t modelVersion) override
+    {
+        Base::Load(fstream, modelVersion);
+        fstream >> m_squashInputs;
+        fstream >> m_tokensToIgnore;
+    }
 
-	bool SquashInputs() const { return m_squashInputs; }
-	std::vector<size_t> TokensToIgnore() const { return m_tokensToIgnore; }
+    bool SquashInputs() const
+    {
+        return m_squashInputs;
+    }
+    std::vector<size_t> TokensToIgnore() const
+    {
+        return m_tokensToIgnore;
+    }
 
 protected:
-	shared_ptr<Matrix<ElemType>> m_maxIndexes0, m_maxIndexes1;
-	shared_ptr<Matrix<ElemType>> m_maxValues;
-	bool m_squashInputs;
-	std::vector<size_t> m_tokensToIgnore;
+    shared_ptr<Matrix<ElemType>> m_maxIndexes0, m_maxIndexes1;
+    shared_ptr<Matrix<ElemType>> m_maxValues;
+    bool m_squashInputs;
+    std::vector<size_t> m_tokensToIgnore;
 
-	// Clear out_SampleSeqVec and extract a vector of samples from the matrix into out_SampleSeqVec.
-	static void ExtractSampleSequence(const Matrix<ElemType>& firstSeq, vector<size_t>& columnIndices, bool squashInputs, const vector<size_t>& tokensToIgnore, std::vector<int>& out_SampleSeqVec)
-	{
-		out_SampleSeqVec.clear();
+    // Clear out_SampleSeqVec and extract a vector of samples from the matrix into out_SampleSeqVec.
+    static void ExtractSampleSequence(const Matrix<ElemType>& firstSeq, vector<size_t>& columnIndices, bool squashInputs, const vector<size_t>& tokensToIgnore, std::vector<int>& out_SampleSeqVec)
+    {
+        out_SampleSeqVec.clear();
 
-		// Get the first element in the sequence
-		size_t lastId = (int)firstSeq(0, columnIndices[0]);
-		if (std::find(tokensToIgnore.begin(), tokensToIgnore.end(), lastId) == tokensToIgnore.end())
-			out_SampleSeqVec.push_back(lastId);
+        // Get the first element in the sequence
+        size_t lastId = (int) firstSeq(0, columnIndices[0]);
+        if (std::find(tokensToIgnore.begin(), tokensToIgnore.end(), lastId) == tokensToIgnore.end())
+            out_SampleSeqVec.push_back(lastId);
 
-		// Remaining elements
-		if (squashInputs)
-		{
-			//squash sequences of identical samples
-			for (size_t i = 1; i < columnIndices.size(); i++)
-			{
-				size_t refId = (int)firstSeq(0, columnIndices[i]);
-				if (lastId != refId)
-				{
-					lastId = refId;
-					if (std::find(tokensToIgnore.begin(), tokensToIgnore.end(), refId) == tokensToIgnore.end())
-						out_SampleSeqVec.push_back(refId);
-				}
-			}
-		}
-		else
-		{
-			for (size_t i = 1; i < columnIndices.size(); i++)
-			{
-				auto refId = (int)firstSeq(0, columnIndices[i]);
-				if (std::find(tokensToIgnore.begin(), tokensToIgnore.end(), refId) == tokensToIgnore.end())
-					out_SampleSeqVec.push_back(refId);
-			}
-		}
-	}
+        // Remaining elements
+        if (squashInputs)
+        {
+            //squash sequences of identical samples
+            for (size_t i = 1; i < columnIndices.size(); i++)
+            {
+                size_t refId = (int) firstSeq(0, columnIndices[i]);
+                if (lastId != refId)
+                {
+                    lastId = refId;
+                    if (std::find(tokensToIgnore.begin(), tokensToIgnore.end(), refId) == tokensToIgnore.end())
+                        out_SampleSeqVec.push_back(refId);
+                }
+            }
+        }
+        else
+        {
+            for (size_t i = 1; i < columnIndices.size(); i++)
+            {
+                auto refId = (int) firstSeq(0, columnIndices[i]);
+                if (std::find(tokensToIgnore.begin(), tokensToIgnore.end(), refId) == tokensToIgnore.end())
+                    out_SampleSeqVec.push_back(refId);
+            }
+        }
+    }
 };
 
-template<class ElemType>
+template <class ElemType>
 class TranscriptionErrorNode : public TextTranscriptionErrorNodeBase<ElemType>
 {
-	using Base = TextTranscriptionErrorNodeBase<ElemType>;
+    using Base = TextTranscriptionErrorNodeBase<ElemType>;
     UsingComputationNodeMembersBoilerplate;
-	static const std::wstring TypeName() { return L"TranscriptionError"; }
+    static const std::wstring TypeName()
+    {
+        return L"TranscriptionError";
+    }
 
 public:
-	TranscriptionErrorNode(DEVICEID_TYPE deviceId, const wstring & name, bool squashInputs = false, vector<size_t> tokensToIgnore = {})
-		: TextTranscriptionErrorNodeBase<ElemType>(deviceId, name, squashInputs, tokensToIgnore)
-	{
-	}
+    TranscriptionErrorNode(DEVICEID_TYPE deviceId, const wstring& name, bool squashInputs = false, vector<size_t> tokensToIgnore = {})
+        : TextTranscriptionErrorNodeBase<ElemType>(deviceId, name, squashInputs, tokensToIgnore)
+    {
+    }
 
-	TranscriptionErrorNode(const ScriptableObjects::IConfigRecordPtr configp)
-		: TranscriptionErrorNode(configp->Get(L"deviceId"), L"<placeholder>", configp->Get(L"squashInputs"), {})
-	{
-		AttachInputsFromConfig(configp, this->GetExpectedNumInputs());
-		m_tokensToIgnore = ScriptableObjects::ConfigArray::FlattenedVectorFrom<size_t>(configp->Get(L"tokensToIgnore"));
-	}
+    TranscriptionErrorNode(const ScriptableObjects::IConfigRecordPtr configp)
+        : TranscriptionErrorNode(configp->Get(L"deviceId"), L"<placeholder>", configp->Get(L"squashInputs"), {})
+    {
+        AttachInputsFromConfig(configp, this->GetExpectedNumInputs());
+        m_tokensToIgnore = ScriptableObjects::ConfigArray::FlattenedVectorFrom<size_t>(configp->Get(L"tokensToIgnore"));
+    }
 
-	virtual void ComputeTextError() override {
-		vector<int> firstSeqVec;
-		vector<int> secondSeqVec;
-		ElemType numIncorrectSeqs = 0;
-		MBLayoutPtr pMBLayout = Input(0)->GetMBLayout();
-		for (const auto& sequence : pMBLayout->GetAllSequences())
-		{
-			if (sequence.seqId == GAP_SEQUENCE_ID)
-				continue;
+    virtual void ComputeTextError() override
+    {
+        vector<int> firstSeqVec;
+        vector<int> secondSeqVec;
+        ElemType numIncorrectSeqs = 0;
+        MBLayoutPtr pMBLayout = Input(0)->GetMBLayout();
+        for (const auto& sequence : pMBLayout->GetAllSequences())
+        {
+            if (sequence.seqId == GAP_SEQUENCE_ID)
+                continue;
 
-			auto numFrames = pMBLayout->GetNumSequenceFramesInCurrentMB(sequence);
+            auto numFrames = pMBLayout->GetNumSequenceFramesInCurrentMB(sequence);
 
-			if (numFrames > 0)
-			{
-				auto columnIndices = pMBLayout->GetColumnIndices(sequence);
-				ExtractSampleSequence(*m_maxIndexes0, columnIndices, m_squashInputs, m_tokensToIgnore, firstSeqVec);
-				ExtractSampleSequence(*m_maxIndexes1, columnIndices, m_squashInputs, m_tokensToIgnore, secondSeqVec);
-				if (firstSeqVec != secondSeqVec) 
-				{
-					++numIncorrectSeqs;
-				}
-			}
-		}
-		Value()(0, 0) = numIncorrectSeqs;
-		Value().TransferToDeviceIfNotThere(Input(0)->GetDeviceId());
-	}
+            if (numFrames > 0)
+            {
+                auto columnIndices = pMBLayout->GetColumnIndices(sequence);
+                ExtractSampleSequence(*m_maxIndexes0, columnIndices, m_squashInputs, m_tokensToIgnore, firstSeqVec);
+                ExtractSampleSequence(*m_maxIndexes1, columnIndices, m_squashInputs, m_tokensToIgnore, secondSeqVec);
+                if (firstSeqVec != secondSeqVec)
+                {
+                    ++numIncorrectSeqs;
+                }
+            }
+        }
+        Value()(0, 0) = numIncorrectSeqs;
+        Value().TransferToDeviceIfNotThere(Input(0)->GetDeviceId());
+    }
 };
 
 template class TranscriptionErrorNode<float>;
@@ -668,8 +679,8 @@ template class TranscriptionErrorNode<double>;
 template<class ElemType>
 class EditDistanceErrorNode : public TextTranscriptionErrorNodeBase<ElemType>
 {
-	using Base = TextTranscriptionErrorNodeBase<ElemType>;
-	UsingComputationNodeMembersBoilerplate;
+    using Base = TextTranscriptionErrorNodeBase<ElemType>;
+    UsingComputationNodeMembersBoilerplate;
     static const std::wstring TypeName() { return L"EditDistanceError"; }
 
 public:
@@ -690,14 +701,15 @@ public:
         m_tokensToIgnore = ScriptableObjects::ConfigArray::FlattenedVectorFrom<size_t>(configp->Get(L"tokensToIgnore"));
     }
 
-	virtual void ComputeTextError() override {
-		Value()(0, 0) = ComputeEditDistanceError(*m_maxIndexes0, *m_maxIndexes1, Input(0)->GetMBLayout(), m_subPen, m_delPen, m_insPen, m_squashInputs, m_tokensToIgnore);
-		Value().TransferToDeviceIfNotThere(Input(0)->GetDeviceId());
-	}
+    virtual void ComputeTextError() override
+    {
+        Value()(0, 0) = ComputeEditDistanceError(*m_maxIndexes0, *m_maxIndexes1, Input(0)->GetMBLayout(), m_subPen, m_delPen, m_insPen, m_squashInputs, m_tokensToIgnore);
+        Value().TransferToDeviceIfNotThere(Input(0)->GetDeviceId());
+    }
 
     virtual void CopyTo(ComputationNodeBasePtr  nodeP, const std::wstring& newName, const CopyNodeFlags flags) const override
     {
-		TextTranscriptionErrorNodeBase<ElemType>::CopyTo(nodeP, newName, flags);
+        TextTranscriptionErrorNodeBase<ElemType>::CopyTo(nodeP, newName, flags);
         if (flags & CopyNodeFlags::copyNodeValue)
         {
             auto node = dynamic_pointer_cast<EditDistanceErrorNode<ElemType>>(nodeP);
@@ -832,7 +844,7 @@ public:
 
     virtual void Save(File& fstream) const override
     {
-		TextTranscriptionErrorNodeBase<ElemType>::Save(fstream);
+        TextTranscriptionErrorNodeBase<ElemType>::Save(fstream);
         fstream << m_subPen;
         fstream << m_delPen;
         fstream << m_insPen;
@@ -840,15 +852,24 @@ public:
 
     virtual void Load(File& fstream, size_t modelVersion) override
     {
-		TextTranscriptionErrorNodeBase<ElemType>::Load(fstream, modelVersion);
+        TextTranscriptionErrorNodeBase<ElemType>::Load(fstream, modelVersion);
         fstream >> m_subPen;
         fstream >> m_delPen;
         fstream >> m_insPen;
     }
 
-	float SubstitutionPenalty() const { return m_subPen; }
-	float DeletionPenalty() const { return m_delPen; }
-	float InsertionPenalty() const { return m_insPen; }
+    float SubstitutionPenalty() const
+    {
+        return m_subPen;
+    }
+    float DeletionPenalty() const
+    {
+        return m_delPen;
+    }
+    float InsertionPenalty() const
+    {
+        return m_insPen;
+    }
 
 private:
     float m_subPen;

--- a/Tests/UnitTests/V2LibraryTests/SerializationTests.cpp
+++ b/Tests/UnitTests/V2LibraryTests/SerializationTests.cpp
@@ -352,7 +352,8 @@ void CheckEnumValuesNotModified() {
                   static_cast<size_t>(PrimitiveOpType::Squeeze) == 88 &&
                   static_cast<size_t>(PrimitiveOpType::ConstantOp) == 89 &&
                   static_cast<size_t>(PrimitiveOpType::LatticeSequenceWithSoftmax) == 90 &&
-                  static_cast<size_t>(PrimitiveOpType::Cast) == 91,
+                  static_cast<size_t>(PrimitiveOpType::Cast) == 91 &&
+                  static_cast<size_t>(PrimitiveOpType::TranscriptionError) == 94,
                   "PrimitiveOpType enum value was modified.");
 }
 


### PR DESCRIPTION
When trying to quantify the accuracy of a scene text recognition system or something similar, a useful metric is the number of incorrectly transcribed sequences. This error function reuses some logic in EditDistanceErrorNode to provide this metric.