### PR TITLE
Fix overlapping memcpy reported by valgrind in SmallVector

### DIFF
--- a/Source/Common/Include/TensorShape.h
+++ b/Source/Common/Include/TensorShape.h
@@ -160,6 +160,8 @@ public:
     }
     void operator=(const SmallVector& other)
     {
+        if (m_data == other.m_data)
+            return;
         m_size = other.m_size;
         memcpy(m_data, other.m_data, other.m_size * sizeof(T));
     }


### PR DESCRIPTION
Valgrind sometimes reports "Source and destination overlap in memcpy" on
the overloaded `=` operator of `SmallVector` class. Whenever it is reported,
the src address and the dest address of `memcpy` is actually identical.

The solution in this commit is to check the src and dest address first,
and do `memcpy` only if they are not identical. This should be enough to
handle the issue, since the only case they overlap is when they are
identical, provided that `m_data` is a member of a class.

```
==4694== Source and destination overlap in memcpy(0xffeffe2d0, 0xffeffe2d0, 24)
==4694==    at 0x4C32513: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4694==    by 0x9928366: Microsoft::MSR::CNTK::SmallVector<unsigned long>::operator=(Microsoft::MSR::CNTK::SmallVector<unsigned long> const&) (TensorShape.h:164)
==4694==    by 0x98ECF44: Microsoft::MSR::CNTK::TensorShape::operator=(Microsoft::MSR::CNTK::TensorShape const&) (TensorShape.h:342)
==4694==    by 0x9FD9113: Microsoft::MSR::CNTK::ComputationNode<float>::Unpack(Microsoft::MSR::CNTK::TensorShape const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<float> > const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<float> > const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<char> > const&, bool, float const*) (ComputationNode.cpp:151)
==4694==    by 0x9DBED8D: Microsoft::MSR::CNTK::ComputationNode<float>::Unpack(Microsoft::MSR::CNTK::TensorShape const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, bool, float const*) (ComputationNode.h:1550)
==4694==    by 0x9DB2722: std::shared_ptr<CNTK::Value> CNTK::Utils::GetValueObjectFromCNTKImplMatrixAndMBLayout<float>(CNTK::NDShape const&, std::vector<CNTK::Axis, std::allocator<CNTK::Axis> > const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, bool) (Utils.cpp:902)
==4694==    by 0x9DD4A98: CNTK::PackedValue::Unpack() const (Value.cpp:670)
==4694==    by 0x998DCDE: CNTK::PackedValue::Data() const (Value.h:80)
...
==4694== Source and destination overlap in memcpy(0xffeffe338, 0xffeffe338, 24)
==4694==    at 0x4C32513: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4694==    by 0x99283AC: Microsoft::MSR::CNTK::SmallVector<long>::operator=(Microsoft::MSR::CNTK::SmallVector<long> const&) (TensorShape.h:164)
==4694==    by 0x98ECF5F: Microsoft::MSR::CNTK::TensorShape::operator=(Microsoft::MSR::CNTK::TensorShape const&) (TensorShape.h:342)
==4694==    by 0x9FD9113: Microsoft::MSR::CNTK::ComputationNode<float>::Unpack(Microsoft::MSR::CNTK::TensorShape const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<float> > const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<float> > const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<char> > const&, bool, float const*) (ComputationNode.cpp:151)
==4694==    by 0x9DBED8D: Microsoft::MSR::CNTK::ComputationNode<float>::Unpack(Microsoft::MSR::CNTK::TensorShape const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, bool, float const*) (ComputationNode.h:1550)
==4694==    by 0x9DB2722: std::shared_ptr<CNTK::Value> CNTK::Utils::GetValueObjectFromCNTKImplMatrixAndMBLayout<float>(CNTK::NDShape const&, std::vector<CNTK::Axis, std::allocator<CNTK::Axis> > const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, bool) (Utils.cpp:902)
==4694==    by 0x9DD4A98: CNTK::PackedValue::Unpack() const (Value.cpp:670)
==4694==    by 0x998DCDE: CNTK::PackedValue::Data() const (Value.h:80)
...
==4694== Source and destination overlap in memcpy(0xffeffe2d0, 0xffeffe2d0, 32)
==4694==    at 0x4C32513: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4694==    by 0x9928366: Microsoft::MSR::CNTK::SmallVector<unsigned long>::operator=(Microsoft::MSR::CNTK::SmallVector<unsigned long> const&) (TensorShape.h:164)
==4694==    by 0x98ECF44: Microsoft::MSR::CNTK::TensorShape::operator=(Microsoft::MSR::CNTK::TensorShape const&) (TensorShape.h:342)
==4694==    by 0x9FD9165: Microsoft::MSR::CNTK::ComputationNode<float>::Unpack(Microsoft::MSR::CNTK::TensorShape const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<float> > const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<float> > const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<char> > const&, bool, float const*) (ComputationNode.cpp:152)
==4694==    by 0x9DBED8D: Microsoft::MSR::CNTK::ComputationNode<float>::Unpack(Microsoft::MSR::CNTK::TensorShape const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, bool, float const*) (ComputationNode.h:1550)
==4694==    by 0x9DB2722: std::shared_ptr<CNTK::Value> CNTK::Utils::GetValueObjectFromCNTKImplMatrixAndMBLayout<float>(CNTK::NDShape const&, std::vector<CNTK::Axis, std::allocator<CNTK::Axis> > const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, bool) (Utils.cpp:902)
==4694==    by 0x9DD4A98: CNTK::PackedValue::Unpack() const (Value.cpp:670)
==4694==    by 0x998DCDE: CNTK::PackedValue::Data() const (Value.h:80)
...
==4694== Source and destination overlap in memcpy(0xffeffe338, 0xffeffe338, 32)
==4694==    at 0x4C32513: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4694==    by 0x99283AC: Microsoft::MSR::CNTK::SmallVector<long>::operator=(Microsoft::MSR::CNTK::SmallVector<long> const&) (TensorShape.h:164)
==4694==    by 0x98ECF5F: Microsoft::MSR::CNTK::TensorShape::operator=(Microsoft::MSR::CNTK::TensorShape const&) (TensorShape.h:342)
==4694==    by 0x9FD9165: Microsoft::MSR::CNTK::ComputationNode<float>::Unpack(Microsoft::MSR::CNTK::TensorShape const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<float> > const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<float> > const&, std::shared_ptr<Microsoft::MSR::CNTK::Matrix<char> > const&, bool, float const*) (ComputationNode.cpp:152)
==4694==    by 0x9DBED8D: Microsoft::MSR::CNTK::ComputationNode<float>::Unpack(Microsoft::MSR::CNTK::TensorShape const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, bool, float const*) (ComputationNode.h:1550)
==4694==    by 0x9DB2722: std::shared_ptr<CNTK::Value> CNTK::Utils::GetValueObjectFromCNTKImplMatrixAndMBLayout<float>(CNTK::NDShape const&, std::vector<CNTK::Axis, std::allocator<CNTK::Axis> > const&, Microsoft::MSR::CNTK::Matrix<float> const&, std::shared_ptr<Microsoft::MSR::CNTK::MBLayout> const&, bool) (Utils.cpp:902)
==4694==    by 0x9DD4A98: CNTK::PackedValue::Unpack() const (Value.cpp:670)
==4694==    by 0x998DCDE: CNTK::PackedValue::Data() const (Value.h:80)
```