### PR TITLE
Expose gradients in c# bindings

### DIFF
--- a/bindings/common/CNTKManagedCommon.i
+++ b/bindings/common/CNTKManagedCommon.i
@@ -200,7 +200,6 @@ IGNORE_FUNCTION CNTK::Function::Serialize;
 IGNORE_FUNCTION CNTK::Function::Deserialize;
 IGNORE_FUNCTION CNTK::Function::Function;
 IGNORE_FUNCTION CNTK::Function::RestoreFromCheckpoint;
-IGNORE_FUNCTION CNTK::Function::Gradients;
 IGNORE_FUNCTION CNTK::Function::RegisterNativeUserFunction;
 IGNORE_FUNCTION CNTK::Function::NativeUserFunction;
 IGNORE_FUNCTION CNTK::Function::SetAttribute;
@@ -213,7 +212,9 @@ IGNORE_FUNCTION CNTK::NCELoss;
 
 #ifndef SWIGCSHARP
 IGNORE_CLASS CNTK::TrainingParameterSchedule;
+IGNORE_FUNCTION CNTK::Function::Gradients;
 #else
+RENAME_AND_MAKE_PRIVATE(CNTK::Function, Gradients);
 %ignore CNTK::TrainingParameterSchedule::TrainingParameterSchedule(TrainingParameterSchedule<T>&&); 
 %ignore CNTK::TrainingParameterSchedule::operator=;
 %ignore CNTK::TrainingParameterSchedule::Transform;

--- a/bindings/csharp/CNTKLibraryManagedDll/ShimApiClasses/FunctionShim.cs
+++ b/bindings/csharp/CNTKLibraryManagedDll/ShimApiClasses/FunctionShim.cs
@@ -214,6 +214,69 @@ namespace CNTK
         }
 
         /// <summary>
+        /// Evaluate the gradients.
+        /// </summary>
+        /// <param name="inputs">Dictionary specifying the inputs to the function.</param>
+        /// <param name="gradients">Dictionary specifying the variables to calculate the
+        /// gradients with respect to.</param>
+        /// <param name="computeDevice"></param>
+        public void Gradients(
+                IDictionary<Variable, Value> inputs,
+                IDictionary<Variable, Value> gradients,
+                DeviceDescriptor computeDevice
+                )
+        {
+            var outputsToEvaluate = new Dictionary<Variable, Value>();
+            Gradients(inputs, gradients, outputsToEvaluate, computeDevice);
+        }
+
+        /// <summary>
+        /// Evaluate the gradients and preserve some output values from the
+        /// forward pass.
+        /// </summary>
+        /// <param name="inputs">Dictionary specifying the inputs to the function.</param>
+        /// <param name="gradients">Dictionary specifying the variables to calculate the
+        /// gradients with respect to.</param>
+        /// <param name="outputsToEvaluate">Dictionary specifying the output variables to
+        /// evaluate on the forward pass.</param>
+        /// <param name="computeDevice"></param>
+        public void Gradients(
+                IDictionary<Variable, Value> inputs,
+                IDictionary<Variable, Value> gradients,
+                IDictionary<Variable, Value> outputsToEvaluate,
+                DeviceDescriptor computeDevice
+                )
+        {
+            var inputMap = new UnorderedMapVariableValuePtr();
+            var gradientMap = new UnorderedMapVariableValuePtr();
+            var outputMap = new UnorderedMapVariableValuePtr();
+            foreach (var p in inputs)
+            {
+                inputMap.Add(p.Key, p.Value);
+            }
+            foreach (var p in gradients)
+            {
+                gradientMap.Add(p.Key, p.Value);
+            }
+            foreach (var p in outputsToEvaluate)
+            {
+                outputMap.Add(p.Key, p.Value);
+            }
+
+            _Gradients(inputMap, gradientMap, outputMap, computeDevice);
+
+            foreach (var p in gradientMap)
+            {
+                // for shared_ptr<Value>, the p.Value returns a copy, so it is safe to use it directly in outputs.
+                gradients[p.Key] = p.Value;
+            }
+            foreach (var p in outputMap)
+            {
+                outputsToEvaluate[p.Key] = p.Value;
+            }
+        }
+
+        /// <summary>
         /// Find the function with the specified name.
         /// </summary>
         /// <param name="name"></param>


### PR DESCRIPTION
Accessing the gradients from the C# bindings has been requested by users for some time, see #2661 and #3332.
This pull request adddresses both of those issues by exposing Function::Gradients() in C#.