### PR TITLE
Remove #include "device_functions.h"

### DIFF
--- a/Source/Math/GPUMatrixCUDAKernels.cuh
+++ b/Source/Math/GPUMatrixCUDAKernels.cuh
@@ -15,7 +15,6 @@
 #include "CommonMatrix.h"
 #include "GPUMatrix.h"
 #include "TensorOps.h" // for exp_() etc.
-#include "device_functions.h"
 #include <cuda_runtime.h>
 #include <assert.h>
 #include <float.h>


### PR DESCRIPTION
From CUDA 10.0, warning messages are added to "device_functions.h"
that the header file is "an internal header and must not be used
directly", and that the header file "will be removed in a future
CUDA release". It is also advised to use "cuda_runtime_api.h" or
"cuda_runtime.h" instead, the latter of which is already included
in the modified file "Source/Math/GPUMatrixCUDAKernels.cuh".

I've also checked that at least from CUDA 9.0, "cuda_runtime.h"
includes "device_functions.h" internally. So I think it is safe
to remove #include "device_functions.h" from now on.