### PR TITLE
Fix several DeprecationWarning: invalid escape sequence

### DIFF
--- a/Tests/EndToEndTests/CNTKv2Python/Examples/Basic_GAN_Distributed_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Examples/Basic_GAN_Distributed_test.py
@@ -29,5 +29,5 @@ def test_cifar_resnet_distributed(device_id):
     str_out = mpiexec_execute(script_under_test, mpiexec_params, params)
 
     #Training loss of the generator at worker: {0} is: {2.201804}, time taken is: {40} seconds
-    results = re.findall("Training loss of the generator at worker: \{.+?\} is: \{.+?\}", str_out)
+    results = re.findall(r"Training loss of the generator at worker: \{.+?\} is: \{.+?\}", str_out)
     assert(len(results) == 4)

--- a/Tests/EndToEndTests/CNTKv2Python/Examples/ConvNet_CIFAR10_DataAug_Distributed_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Examples/ConvNet_CIFAR10_DataAug_Distributed_test.py
@@ -84,7 +84,7 @@ def test_cifar_convnet_distributed_block_momentum(device_id):
     # 13000 samples / 2 worker / 64 mb_size = 101 minibatchs. 
     # We expect to see only Minibatch[ 1 -100] 
     output = mpiexec_execute(script_under_test, mpiexec_params, params, device_id=device_id)
-    results = re.findall("Minibatch\[(.+?)\]: loss = .+?%", output)
+    results = re.findall(r"Minibatch\[(.+?)\]: loss = .+?%", output)
     assert len(results) == 2
     assert results[0] == '   1- 100'
     assert results[1] == '   1- 100'

--- a/Tests/EndToEndTests/CNTKv2Python/Examples/ConvNet_CIFAR10_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Examples/ConvNet_CIFAR10_test.py
@@ -79,7 +79,7 @@ def test_check_percentages_after_restarting_training(device_id):
 
     # Restarting training
     out = subprocess.check_output(cmdStr.split(" "), stderr=subprocess.STDOUT)
-    all_percentages = re.findall('.* Epoch\[ *\d+ of \d+]-Minibatch\[ *\d+- *\d+, *(\d+\.\d+)\%\].*', out.decode('utf-8'))
+    all_percentages = re.findall(r'.* Epoch\[ *\d+ of \d+]-Minibatch\[ *\d+- *\d+, *(\d+\.\d+)\%\].*', out.decode('utf-8'))
 
     expected_percentages = set(["14.29", "28.57", "57.14", "42.86", "71.43", "85.71", "100.00"])
     assert set(all_percentages) == expected_percentages

--- a/Tests/EndToEndTests/CNTKv2Python/Examples/HTK_LSTM_Truncated_Distributed_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Examples/HTK_LSTM_Truncated_Distributed_test.py
@@ -57,6 +57,6 @@ def test_htk_lstm_truncated_distributed_gpu_with_cv(device_id):
                "-device", str(device_id) ]
 
     output = mpiexec_execute(device_id=device_id, script=script_under_test, mpiexec_params=mpiexec_params, params=params)
-    results = re.findall("Finished Evaluation \[.+?\]: Minibatch\[.+?\]: metric = (.+?)%", output)
+    results = re.findall(r"Finished Evaluation \[.+?\]: Minibatch\[.+?\]: metric = (.+?)%", output)
     assert len(results) == 6, output
 

--- a/Tests/EndToEndTests/CNTKv2Python/Examples/binary_convnet_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Examples/binary_convnet_test.py
@@ -29,7 +29,7 @@ def test_binary_convnet_error(device_id):
         "Please check if HALIDE_PATH is configured properly "
         "and try building {1} again"
         .format('Cntk.BinaryConvolution-' + C.__version__.rstrip('+'),
-        'Extnsibiliy\BinaryConvolution'))
+        'Extnsibiliy\\BinaryConvolution'))
      
     if cntk_device(device_id).type() != DeviceKind_GPU:
         pytest.skip('test only runs on GPU')

--- a/Tests/EndToEndTests/CNTKv2Python/Examples/binary_convolution_native_eval_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Examples/binary_convolution_native_eval_test.py
@@ -26,7 +26,7 @@ def test_native_binary_function():
         "Please check if HALIDE_PATH is configured properly "
         "and try building {1} again"
         .format('Cntk.BinaryConvolution-' + C.__version__.rstrip('+'),
-        'Extnsibiliy\BinaryConvolution'))          
+        'Extnsibiliy\\BinaryConvolution'))
 
     # be sure to only run on CPU, binary convolution does not have GPU support for now
     dev = C.cpu()

--- a/Tests/EndToEndTests/CNTKv2Python/Examples/distributed_common.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Examples/distributed_common.py
@@ -43,7 +43,7 @@ def mpiexec_execute(script, mpiexec_params, params, timeout_seconds=TIMEOUT_SECO
 
 def mpiexec_test(device_id, script, mpiexec_params, params, expected_test_error, match_exactly=True, per_minibatch_tolerance=TOLERANCE_ABSOLUTE, error_tolerance=TOLERANCE_ABSOLUTE, timeout_seconds=TIMEOUT_SECONDS, use_only_cpu=False):
     str_out = mpiexec_execute(script, mpiexec_params, params, timeout_seconds, device_id, use_only_cpu)
-    results = re.findall("Finished Evaluation \[.+?\]: Minibatch\[.+?\]: metric = (.+?)%", str_out)
+    results = re.findall(r"Finished Evaluation \[.+?\]: Minibatch\[.+?\]: metric = (.+?)%", str_out)
 
     assert len(results) == 2, str_out
 

--- a/Tests/EndToEndTests/CNTKv2Python/Manual/Manual_How_to_train_using_declarative_and_imperative_API_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Manual/Manual_How_to_train_using_declarative_and_imperative_API_test.py
@@ -20,7 +20,7 @@ def test_cntk_how_to_train_no_errors(nb):
               for output in cell['outputs'] if output.output_type == "error"]
     assert errors == []
 
-expectedOutput = 'Minibatch\[ 191- 200\]: loss = '
+expectedOutput = r'Minibatch\[ 191- 200\]: loss = '
 def test_cntk_how_to_train_eval_correct(nb):
     testCells = [cell for cell in nb.cells
                 if cell.cell_type == 'code']

--- a/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_101_LogisticRegression_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_101_LogisticRegression_test.py
@@ -19,6 +19,6 @@ expectedEvalError = '0.12'
 
 def test_cntk_101_logisticregression_evalCorrect(nb):
     testCell = [cell for cell in nb.cells
-                if cell.cell_type == 'code' and re.search('trainer\.test_minibatch', cell.source)]
+                if cell.cell_type == 'code' and re.search(r'trainer\.test_minibatch', cell.source)]
     assert len(testCell) == 1
     assert testCell[0].outputs[0]['data']['text/plain'] == expectedEvalError

--- a/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_102_FeedForward_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_102_FeedForward_test.py
@@ -19,6 +19,6 @@ expectedEvalError = '0.12'
 
 def test_cntk_102_feedforward_evalCorrect(nb):
     testCell = [cell for cell in nb.cells
-                if cell.cell_type == 'code' and re.search('trainer\.test_minibatch', cell.source)]
+                if cell.cell_type == 'code' and re.search(r'trainer\.test_minibatch', cell.source)]
     assert len(testCell) == 1
     assert testCell[0].outputs[0]['data']['text/plain'] == expectedEvalError

--- a/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_103B_MNIST_LogisticRegression_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_103B_MNIST_LogisticRegression_test.py
@@ -20,7 +20,7 @@ expectedEvalErrorByDeviceId = { -1: 7.4, 0: 7.4 }
 
 def test_cntk_103b_mnist_logisticregression_evalCorrect(nb, device_id):
     testCell = [cell for cell in nb.cells
-                if cell.cell_type == 'code' and re.search('trainer\.test_minibatch', cell.source)]
+                if cell.cell_type == 'code' and re.search(r'trainer\.test_minibatch', cell.source)]
     assert len(testCell) == 1
     m = re.match(r"Average test error: (?P<actualEvalError>\d+\.\d+)%\r?$", testCell[0].outputs[0]['text'])
     # TODO tighten tolerances

--- a/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_103C_MNIST_MultiLayerPerceptron_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_103C_MNIST_MultiLayerPerceptron_test.py
@@ -20,7 +20,7 @@ expectedEvalErrorByDeviceId = { -1: 1.72, 0: 1.81 }
 
 def test_cntk_103c_mnist_multilayerperceptron_evalCorrect(nb, device_id):
     testCell = [cell for cell in nb.cells
-                if cell.cell_type == 'code' and re.search('trainer\.test_minibatch', cell.source)]
+                if cell.cell_type == 'code' and re.search(r'trainer\.test_minibatch', cell.source)]
     assert len(testCell) == 1
     m = re.match(r"Average test error: (?P<actualEvalError>\d+\.\d+)%\r?$", testCell[0].outputs[0]['text'])
     # TODO tighten tolerances

--- a/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_103D_MNIST_ConvolutionalNeuralNetwork_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_103D_MNIST_ConvolutionalNeuralNetwork_test.py
@@ -24,7 +24,7 @@ def test_cntk_103d_mnist_convolutionalneuralnetwork_trainerror(nb, device_id):
     for cell in nb.cells:
         try:
            if cell.cell_type == 'code':
-               m = re.search('Average test error: (?P<metric>\d+\.\d+)%', cell.outputs[0]['text'])
+               m = re.search(r'Average test error: (?P<metric>\d+\.\d+)%', cell.outputs[0]['text'])
                if m:
                    metrics.append(float(m.group('metric')))
         except IndexError:

--- a/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_201B_CIFAR-10_ImageHandsOn_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_201B_CIFAR-10_ImageHandsOn_test.py
@@ -22,7 +22,7 @@ def test_cntk_201B_cifar_10_imagehandson_noErrors(nb):
     for cell in nb.cells:
         try:
            if cell.cell_type == 'code':
-               m = re.search('Final Results: .* errs = (?P<metric>\d+\.\d+)%', cell.outputs[0]['text'])
+               m = re.search(r'Final Results: .* errs = (?P<metric>\d+\.\d+)%', cell.outputs[0]['text'])
                if m:
                    metrics.append(float(m.group('metric')))
                    break

--- a/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_202_Language_Understanding_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_202_Language_Understanding_test.py
@@ -25,7 +25,7 @@ def test_cntk_202_language_understanding_trainerror(nb):
     for cell in nb.cells:
         try:
            if cell.cell_type == 'code':
-               m = re.search('Finished Evaluation.* metric = (?P<metric>\d+\.\d+)%', cell.outputs[0]['text'])
+               m = re.search(r'Finished Evaluation.* metric = (?P<metric>\d+\.\d+)%', cell.outputs[0]['text'])
                if m:
                    metrics.append(float(m.group('metric')))
         except IndexError:

--- a/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_208_Speech_Connectionist_Temporal_Classification_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_208_Speech_Connectionist_Temporal_Classification_test.py
@@ -24,6 +24,6 @@ expectedEvalError3 = '1.0'
 
 def test_cntk_208_speech_connectionist_temporal_classification_evalCorrect(nb):
     testCell = [cell for cell in nb.cells
-                if cell.cell_type == 'code' and re.search('trainer\.test_minibatch', cell.source)]
+                if cell.cell_type == 'code' and re.search(r'trainer\.test_minibatch', cell.source)]
     assert len(testCell) == 1
     assert testCell[0].outputs[0]['data']['text/plain'] == expectedEvalError1 or testCell[0].outputs[0]['data']['text/plain'] == expectedEvalError2 or testCell[0].outputs[0]['data']['text/plain'] == expectedEvalError3

--- a/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_303_Deep_Structured_Semantic_Modeling_with_LSTM_Networks.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_303_Deep_Structured_Semantic_Modeling_with_LSTM_Networks.py
@@ -25,7 +25,7 @@ def test_cntk_303_deep_structured_semantic_modeling_with_lstm_networks_trainerro
     for cell in nb.cells:
         try:
            if cell.cell_type == 'code':
-               m = re.search('Finished Evaluation.* metric = (?P<metric>\d+\.\d+)%', cell.outputs[0]['text'])
+               m = re.search(r'Finished Evaluation.* metric = (?P<metric>\d+\.\d+)%', cell.outputs[0]['text'])
                if m:
                    metrics.append(float(m.group('metric')))
         except IndexError:

--- a/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_FastRCNNEval_test.py
+++ b/Tests/EndToEndTests/CNTKv2Python/Tutorials/CNTK_FastRCNNEval_test.py
@@ -36,10 +36,10 @@ def test_cntk_fastrcnn_eval_evalCorrect(nb):
                  if cell.cell_type == 'code' and
                      len(cell.outputs) > 0 and
                      'text' in cell.outputs[0] and
-                     re.search('Number of detections: (\d+)',  get_output_stream_from_cell(cell))]
+                     re.search(r'Number of detections: (\d+)',  get_output_stream_from_cell(cell))]
     assert len(detectionCells) == 1
     
-    number_of_detections = int(re.search('Number of detections: (\d+)', get_output_stream_from_cell(detectionCells[0])).group(1))
+    number_of_detections = int(re.search(r'Number of detections: (\d+)', get_output_stream_from_cell(detectionCells[0])).group(1))
     assert(number_of_detections > 0)
 
 

--- a/Tests/EndToEndTests/MetricsDriver.py
+++ b/Tests/EndToEndTests/MetricsDriver.py
@@ -30,10 +30,10 @@ class Baseline:
   # Finished Epoch[ 5 of 5]: [Training] ce = 2.32253198 * 1000 err = 0.90000000 * 1000 totalSamplesSeen = 5000 learningRatePerSample = 2e-06 epochTime=0.175781
   # Final Results: Minibatch[1-1]: err = 0.90000000 * 100 ce = 2.32170486 * 100 perplexity = 10.1930372
   def extractResultsInfo(self, baselineContent):
-    trainResults = re.findall('.*(Finished Epoch\[ *\d+ of \d+\]\: \[Training\]) (.*)', baselineContent)
+    trainResults = re.findall(r'.*(Finished Epoch\[ *\d+ of \d+\]\: \[Training\]) (.*)', baselineContent)
     if trainResults:                                       
       self.trainResult = Baseline.formatLastTrainResult(trainResults[-1])[0:-2]
-    testResults = re.findall('.*(Final Results: Minibatch\[1-\d+\]:)(\s+\* \d+)?\s+(.*)', baselineContent)
+    testResults = re.findall(r'.*(Final Results: Minibatch\[1-\d+\]:)(\s+\* \d+)?\s+(.*)', baselineContent)
     if testResults:
       self.testResult = Baseline.formatLastTestResult(testResults[-1])[0:-2]
 
@@ -49,10 +49,10 @@ class Baseline:
   def extractHardwareInfo(self, baselineContent):
     startCpuInfoIndex = baselineContent.find("CPU info:")
     endCpuInfoIndex = baselineContent.find("----------", startCpuInfoIndex)
-    cpuInfo = re.search("^CPU info:\s+"
-                       "CPU Model (Name:\s*.*)\s+"                        
-                       "(Hardware threads: \d+)\s+"
-                       "Total (Memory:\s*.*)\s+", baselineContent[startCpuInfoIndex:endCpuInfoIndex], re.MULTILINE)
+    cpuInfo = re.search(r"^CPU info:\s+"
+                        r"CPU Model (Name:\s*.*)\s+"
+                        r"(Hardware threads: \d+)\s+"
+                        r"Total (Memory:\s*.*)\s+", baselineContent[startCpuInfoIndex:endCpuInfoIndex], re.MULTILINE)
     if cpuInfo is None:
       return
     self.cpuInfo = "\n".join(cpuInfo.groups())
@@ -61,7 +61,7 @@ class Baseline:
     endGpuInfoIndex = baselineContent.find("----------", startGpuInfoIndex)
     gpuInfoSnippet = baselineContent[startGpuInfoIndex:endGpuInfoIndex]
 
-    gpuDevices = re.findall("\t\t(Device\[\d+\]: cores = \d+; computeCapability = \d\.\d; type = .*; memory = \d+ MB)[\r\n]?", gpuInfoSnippet)
+    gpuDevices = re.findall(r"\t\t(Device\[\d+\]: cores = \d+; computeCapability = \d\.\d; type = .*; memory = \d+ MB)[\r\n]?", gpuInfoSnippet)
     if not gpuDevices:
       return
     gpuInfo = [ device for device in gpuDevices ]
@@ -135,7 +135,7 @@ def getExamplesMetrics():
     for baseline in baselineListForExample:        
       with open(baseline.fullPath, "r") as f:
         baselineContent = f.read()
-        gitHash = re.search('.*Build SHA1:\s([a-z0-9]{40})[\r\n]+', baselineContent, re.MULTILINE)
+        gitHash = re.search(r'.*Build SHA1:\s([a-z0-9]{40})[\r\n]+', baselineContent, re.MULTILINE)
         if gitHash is None:
           continue
         example.gitHash = gitHash.group(1) 

--- a/bindings/python/cntk/contrib/netopt/quantization.py
+++ b/bindings/python/cntk/contrib/netopt/quantization.py
@@ -45,7 +45,7 @@ def convert_to_native_binary_convolution(model):
             "Please check if HALIDE_PATH is configured properly "
             "and try building {1} again"
             .format('Cntk.BinaryConvolution-' + C.__version__.rstrip('+'),
-            'Extnsibiliy\BinaryConvolution'))
+            'Extnsibiliy\\BinaryConvolution'))
 
     bin_conv_filter = (lambda m: type(m) == C.Function 
                 and m.is_block 

--- a/bindings/python/cntk/core.py
+++ b/bindings/python/cntk/core.py
@@ -252,7 +252,7 @@ class Value(cntk_py.Value):
           * a pure Python structure (list of lists, ...),
           * a list of NumPy arrays or SciPy sparse CSR matrices
           * a :class:`~cntk.core.Value` object (e.g. returned by :func:`one_hot`)
-        seq_starts (list of `bool`\ s or None): if None, every sequence is
+        seq_starts (list of `bool`\\ s or None): if None, every sequence is
          treated as a new sequence. Otherwise, it is interpreted as a list of
          Booleans that tell whether a sequence is a new sequence (`True`) or a
          continuation of the sequence in the same slot of the previous
@@ -378,7 +378,7 @@ class Value(cntk_py.Value):
               * a single NumPy array denoting the full minibatch
               * a list of NumPy arrays or SciPy sparse CSR matrices
               * a single NumPy array denoting one parameter or constant
-            seq_starts (list of `bool`\ s or None): if None, every sequence is
+            seq_starts (list of `bool`\\ s or None): if None, every sequence is
              treated as a new sequence. Otherwise, it is interpreted as a list of
              Booleans that tell whether a sequence is a new sequence (`True`) or a
              continuation of the sequence in the same slot of the previous

--- a/bindings/python/cntk/layers/layers.py
+++ b/bindings/python/cntk/layers/layers.py
@@ -922,19 +922,19 @@ def ConvolutionTranspose(filter_shape,        # shape of receptive field, e.g. (
          (3, 128, 3, 4)
 
     Args:
-     filter_shape (`int` or tuple of `int`\ s): shape (spatial extent) of the receptive field, *not* including the input feature-map depth. E.g. (3,3) for a 2D convolution.
+     filter_shape (`int` or tuple of `int`\\ s): shape (spatial extent) of the receptive field, *not* including the input feature-map depth. E.g. (3,3) for a 2D convolution.
      num_filters (int): number of filters (output feature-map depth), or ``()`` to denote scalar output items (output shape will have no depth axis).
      activation (:class:`~cntk.ops.functions.Function`, optional): optional function to apply at the end, e.g. `relu`
      init (scalar or :mod:`cntk.initializer`, default :func:`~cntk.initializer.glorot_uniform`): initial value of weights `W`
-     pad (`bool` or tuple of `bool`\ s, default `False`): if `False`, then the filter will be shifted over the "valid"
+     pad (`bool` or tuple of `bool`\\ s, default `False`): if `False`, then the filter will be shifted over the "valid"
       area of input, that is, no value outside the area is used. If ``pad=True`` on the other hand,
       the filter will be applied to all input positions, and positions outside the valid region will be considered containing zero.
       Use a `tuple` to specify a per-axis value.
-     strides (`int` or tuple of `int`\ s, default 1): stride of the convolution (increment when sliding the filter over the input). Use a `tuple` to specify a per-axis value.
+     strides (`int` or tuple of `int`\\ s, default 1): stride of the convolution (increment when sliding the filter over the input). Use a `tuple` to specify a per-axis value.
      sharing (`bool`, default `True`): weight sharing, must be True for now.
      bias (`bool`, optional, default `True`): the layer will have no bias if `False` is passed here
      init_bias (scalar or NumPy array or :mod:`cntk.initializer`): initial value of weights `b`
-     output_shape (`int` or tuple of `int`\ s): output shape. When strides > 2, the output shape is non-deterministic. User can specify the wanted output shape. Note the
+     output_shape (`int` or tuple of `int`\\ s): output shape. When strides > 2, the output shape is non-deterministic. User can specify the wanted output shape. Note the
       specified shape must satisify the condition that if a convolution is perform from the output with the same setting, the result must have same shape as the input.
       that is stored with tensor shape (H,W) instead of (1,H,W)
      reduction_rank (`int`, defaults to 1): set to 0 if input items are scalars (input has no depth axis), e.g. an audio signal or a black-and-white image.

--- a/bindings/python/cntk/ops/__init__.py
+++ b/bindings/python/cntk/ops/__init__.py
@@ -663,7 +663,7 @@ def local_response_normalization(operand, depth_radius, bias, alpha, beta, name=
 
     The mathematical equation is:
 
-    ``b_{x,y}^i=a_{x,y}^i/(bias+\alpha\sum_{j=max(0,i-depth_radius)}^{min(N-1, i+depth_radius)}(a_{x,y}^j)^2)^\beta``
+    ``b_{x,y}^i=a_{x,y}^i/(bias+\\alpha\\sum_{j=max(0,i-depth_radius)}^{min(N-1, i+depth_radius)}(a_{x,y}^j)^2)^\\beta``
 
     where a_{x,y}^i is the activity of a neuron computed by applying kernel i at position (x,y)
     N is the total number of kernels, depth_radius is half normalization width.
@@ -1557,7 +1557,7 @@ def softplus(x, steepness=1, name=''):
     '''
     Softplus operation. Computes the element-wise softplus of ``x``:
 
-    :math:`\mathrm{softplus}(x) = {\log(1+\exp(x))}`
+    :math:`\\mathrm{softplus}(x) = {\\log(1+\\exp(x))}`
 
     The optional ``steepness`` allows to make the knee sharper (``steepness>1``) or softer, by computing
     ``softplus(x * steepness) / steepness``.
@@ -1593,7 +1593,7 @@ def softsign(x, steepness=1, name=''):
     '''
     Computes the element-wise softsign of ``x``:
 
-    :math:`sigmoid(x) = {x \over {1+\abs(x)}}`
+    :math:`sigmoid(x) = {x \\over {1+\\abs(x)}}`
 
     The output tensor has the same shape as ``x``.
 
@@ -1616,7 +1616,7 @@ def sigmoid(x, name=''):
     '''
     Computes the element-wise sigmoid of ``x``:
 
-    :math:`sigmoid(x) = {1 \over {1+\exp(-x)}}`
+    :math:`sigmoid(x) = {1 \\over {1+\\exp(-x)}}`
 
     The output tensor has the same shape as ``x``.
 
@@ -2031,7 +2031,7 @@ def exp(x, name=''):
     '''
     Computes the element-wise exponential of ``x``:
 
-    :math:`\exp(x) = {e^x}`
+    :math:`\\exp(x) = {e^x}`
 
     Example:
         >>> C.exp([0., 1.]).eval()
@@ -2079,7 +2079,7 @@ def sqrt(x, name=''):
     '''
     Computes the element-wise square-root of ``x``:
 
-    :math:`sqrt(x) = {\sqrt[2]{x}}`
+    :math:`sqrt(x) = {\\sqrt[2]{x}}`
 
     Example:
         >>> C.sqrt([0., 4.]).eval()

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -102,14 +102,14 @@ CNTK_EXTRA_LIBRARIES = []
 EXCLUDE_LIBS = []
 EXCLUDE_LIBS_SUFFIX = ""
 if IS_WINDOWS:
-    EXCLUDE_LIBS_SUFFIX = "[a-z0-9_\-\.]*\.dll$" # Match specific DLLs listed below
+    EXCLUDE_LIBS_SUFFIX = r"[a-z0-9_\-\.]*\.dll$" # Match specific DLLs listed below
     EXCLUDE_LIBS += ["cublas", "cudart", "curand", "cusparse"] # Cuda
     EXCLUDE_LIBS += ["cudnn"] # CUDNN
     EXCLUDE_LIBS += ["opencv_world"] # OpenCV
     EXCLUDE_LIBS += ["mkldnn", "mklml", "libiomp5md"] # MKL + MKL-DNN
     EXCLUDE_LIBS += ["nvml"] # NVML (Nvidia driver)
 else:
-    EXCLUDE_LIBS_SUFFIX = "[a-z0-9_\-\.]*.so[0-9\.]*"
+    EXCLUDE_LIBS_SUFFIX = r"[a-z0-9_\-\.]*.so[0-9\.]*"
     EXCLUDE_LIBS += ["libcudart", "libcublas", "libcurand", "libcusparse", "libcuda", "libnvidia-ml"] # CUDA
     EXCLUDE_LIBS += ["libcudnn"] # CUDNN
     EXCLUDE_LIBS += ["libopencv_core", "libopencv_imgproc", "libopencv_imgcodecs"] # OpenCV


### PR DESCRIPTION
Hello,

This is a patch to fix all `DeprecationWarning: invalid escape sequence` in the Python bindings.

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>