### PR TITLE
hide protobuf library symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,9 +274,13 @@ ifdef CNTK_CUDA_DEVICE_DEBUGINFO
   CUFLAGS += -G
 endif
 
+# Make sure we statically link with protobuf and avoid leaking symbols
+# (as users of this library may use their own version of protobuf library)
+PROTOBUF_STATIC_LIB:= $(PROTOBUF_PATH)/lib/libprotobuf.a -Wl,--exclude-libs,libprotobuf.a
+
 # Create the library link options for the linker.
 # LIBS_LIST must not be changed beyond this point.
-LIBS:= $(addprefix -l,$(LIBS_LIST))
+LIBS:= $(addprefix -l,$(LIBS_LIST)) $(PROTOBUF_STATIC_LIB)
 
 OBJDIR:= $(BUILD_TOP)/.build
 BINDIR:= $(BUILD_TOP)/bin


### PR DESCRIPTION
Altough CNTK libraries are statically linked with libprotobuf.a, if a user the a CNTK library will use a higher version (not compatible) of protobuf (like 3.5), we will get an assertion: 

[libprotobuf FATAL google/protobuf/stubs/common.cc:79] This program was compiled against version 3.1.0 of the Protocol Buffer runtime library, which is not compatible with the installed version (3.5.1).  Contact the program author for an update.  If you compiled the program yourself, make sure that your headers are from the same version of Protocol Buffers as your link-time library.  (Version verification failed in "Source/CNTKv2LibraryDll/proto/CNTK.pb.cc".)
terminate called after throwing an instance of 'google::protobuf::FatalException'

The reason is that the method google::protobuf::internal::VerifyVersion(int, int, char const*)  used in CNTK library will be relocated to the user's newer version – hence validation will fail (part of Linux dynamic linker magic for globally declared methods). 

This can be either resolved by compiling CNTK with a matching version of protobuf (but will create a dependency between the user version and CNTK version) or make sure all protobuf symbols are hidden. 
Note that the user of the CNTK library should make sure to ALSO *statically* link with the higher version of protobuf !
