### PR TITLE
Rpengms/fp16 bmuf

### DIFF
--- a/Source/1BitSGD/BlockMomentumDistributedLearner.h
+++ b/Source/1BitSGD/BlockMomentumDistributedLearner.h
@@ -524,38 +524,40 @@ namespace CNTK
                     ResetBuffer<double>(i, p);
                 else if (p->GetDataType() == DataType::Float)
                     ResetBuffer<float>(i, p);
+                else if (p->GetDataType() == DataType::Float16)
+                    ResetBuffer<half, float16>(i, p);
                 else
                     RuntimeError("Unsupported type.");
             }
         }
 
-        template<class ElemType>
+        template<class ElemTypeV1, class ElemTypeV2=ElemTypeV1>
         void ResetBuffer(size_t index, const NDArrayViewPtr& p)
         {
-            auto data = p->GetMatrix<ElemType>();
+            auto data = p->GetMatrix<ElemTypeV1>();
             if (!m_blockLevelSmoothedGradient[index])
             {
                 // has not been initialized yet
-                auto pSmoothedGrad = std::make_shared<NDArrayView>(AsDataType<ElemType>(), p->Shape(), AsDeviceDescriptor(data->GetDeviceId()));
-                pSmoothedGrad->SetValue(static_cast<ElemType>(0));
+                auto pSmoothedGrad = std::make_shared<NDArrayView>(AsDataType<ElemTypeV2>(), p->Shape(), AsDeviceDescriptor(data->GetDeviceId()));
+                pSmoothedGrad->SetValue(static_cast<ElemTypeV2>(0));
                 m_blockLevelSmoothedGradient[index] = pSmoothedGrad;
             }
 
             if (!m_prevParameters[index])
             {
-                NDArrayViewPtr newValue = std::make_shared<NDArrayView>(AsDataType<ElemType>(), p->Shape(), AsDeviceDescriptor(data->GetDeviceId()));
-                std::shared_ptr<Matrix<ElemType>> newData = newValue->GetWritableMatrix<ElemType>();
+                NDArrayViewPtr newValue = std::make_shared<NDArrayView>(AsDataType<ElemTypeV2>(), p->Shape(), AsDeviceDescriptor(data->GetDeviceId()));
+                std::shared_ptr<Matrix<ElemTypeV1>> newData = newValue->GetWritableMatrix<ElemTypeV1>();
                 newData->SetValue(*data);
                 m_prevParameters[index] = newValue;
             }
             else
             {
-                m_prevParameters[index]->GetWritableMatrix<ElemType>()->SetValue(*data);
+                m_prevParameters[index]->GetWritableMatrix<ElemTypeV1>()->SetValue(*data);
             }
 
             if (!m_tempBlockGradient[index])
             {
-                m_tempBlockGradient[index] = std::make_shared<NDArrayView>(AsDataType<ElemType>(), p->Shape(), AsDeviceDescriptor(data->GetDeviceId()));
+                m_tempBlockGradient[index] = std::make_shared<NDArrayView>(AsDataType<ElemTypeV2>(), p->Shape(), AsDeviceDescriptor(data->GetDeviceId()));
             }
         }
 

--- a/Source/1BitSGD/BlockMomentumDistributedLearner.h
+++ b/Source/1BitSGD/BlockMomentumDistributedLearner.h
@@ -470,6 +470,9 @@ namespace CNTK
 
             m_numSamplesSeenInCurrentBlock = 0;
 
+            // For half, SynchronizeModel will update the parameters (half) in network.
+            // However, the local learner also have a copy of full precision parameters (float), which needs to be updated too.
+            // Set the flag so that the float copy will be updated / copied from half parameters.
             m_learner->SetNeedToUpdateMasterParameter();
 
             if (m_resetSGDMomentumAfterAggregation)

--- a/Source/1BitSGD/BlockMomentumDistributedLearner.h
+++ b/Source/1BitSGD/BlockMomentumDistributedLearner.h
@@ -464,16 +464,18 @@ namespace CNTK
             else if (parameters.front()->GetDataType() == DataType::Float)
                 SynchronizeModel<float>(parameters);
             else if (parameters.front()->GetDataType() == DataType::Float16)
+            {
                 SynchronizeModel<half>(parameters);
+
+                // For half, SynchronizeModel will update the parameters (half) in network.
+                // However, the local learner also have a copy of full precision parameters (float), which needs to be updated too.
+                // Set the flag so that the float copy will be updated / copied from half parameters.
+                m_learner->SetNeedToUpdateMasterParameter();
+            }
             else
                 RuntimeError("Unsupported type.");
 
             m_numSamplesSeenInCurrentBlock = 0;
-
-            // For half, SynchronizeModel will update the parameters (half) in network.
-            // However, the local learner also have a copy of full precision parameters (float), which needs to be updated too.
-            // Set the flag so that the float copy will be updated / copied from half parameters.
-            m_learner->SetNeedToUpdateMasterParameter();
 
             if (m_resetSGDMomentumAfterAggregation)
                 m_learner->ResetSmoothedGradients();

--- a/Source/1BitSGD/BlockMomentumDistributedLearner.h
+++ b/Source/1BitSGD/BlockMomentumDistributedLearner.h
@@ -470,6 +470,8 @@ namespace CNTK
 
             m_numSamplesSeenInCurrentBlock = 0;
 
+            m_learner->SetNeedToUpdateMasterParameter();
+
             if (m_resetSGDMomentumAfterAggregation)
                 m_learner->ResetSmoothedGradients();
         }

--- a/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
+++ b/Source/CNTKv2LibraryDll/API/CNTKLibrary.h
@@ -5147,6 +5147,8 @@ namespace CNTK
         ///
         virtual void ResetSmoothedGradients() = 0;
 
+        virtual void SetNeedToUpdateMasterParameter() { NOT_IMPLEMENTED }
+
         ///
         /// Returns current learning rate.
         ///

--- a/Source/CNTKv2LibraryDll/Learner.cpp
+++ b/Source/CNTKv2LibraryDll/Learner.cpp
@@ -110,10 +110,18 @@ namespace CNTK
     {
         for(auto v : m_smoothedGradientValues)
         {
-            if (v.second->GetDataType() == DataType::Float)
+            if (v.first.GetDataType() == DataType::Float)
                 v.second->SetValue(0.0f);
-            else if (v.second->GetDataType() == DataType::Double)
+            else if (v.first.GetDataType() == DataType::Double)
                 v.second->SetValue(0.0);
+            else if (v.first.GetDataType() == DataType::Float16)
+            {
+                // reset gradients only, don't reset other things
+                const auto& parameterMatrix = GetWritableMatrix<half>(v.first.Value());
+                const auto& compoundMatrix = GetWritableMatrix<float>(v.second);
+                auto smoothedGradientMatrix = compoundMatrix->ColumnSlice(0, parameterMatrix->GetNumCols());
+                smoothedGradientMatrix.SetValue(0.0f);
+            }
             else
                 LogicError("Unsupported DataType %s", DataTypeName(v.second->GetDataType()));
         }

--- a/Source/CNTKv2LibraryDll/Learner.cpp
+++ b/Source/CNTKv2LibraryDll/Learner.cpp
@@ -110,11 +110,12 @@ namespace CNTK
     {
         for(auto v : m_smoothedGradientValues)
         {
-            if (v.first.GetDataType() == DataType::Float)
+            auto dt = v.first.GetDataType();
+            if (dt == DataType::Float)
                 v.second->SetValue(0.0f);
-            else if (v.first.GetDataType() == DataType::Double)
+            else if (dt == DataType::Double)
                 v.second->SetValue(0.0);
-            else if (v.first.GetDataType() == DataType::Float16)
+            else if (dt == DataType::Float16)
             {
                 // reset gradients only, don't reset other things
                 const auto& parameterMatrix = GetWritableMatrix<half>(v.first.Value());
@@ -123,7 +124,7 @@ namespace CNTK
                 smoothedGradientMatrix.SetValue(0.0f);
             }
             else
-                LogicError("Unsupported DataType %s", DataTypeName(v.second->GetDataType()));
+                LogicError("Unsupported DataType %s", DataTypeName(dt));
         }
     }
 

--- a/Source/CNTKv2LibraryDll/Learner.h
+++ b/Source/CNTKv2LibraryDll/Learner.h
@@ -29,6 +29,8 @@ namespace CNTK
 
         virtual void ResetSmoothedGradients() override;
 
+        virtual void SetNeedToUpdateMasterParameter() override { m_masterParameterUpdated = false; }
+
     protected:
         LearnerBase(const std::vector<Parameter>& parameters,
             const LearningRateSchedule& learningRateSchedule,


### PR DESCRIPTION
Fix FP16 BMUF bug for V2/python.
Local learner's smoothed gradients now is a compound metrix of fp32 SG+TempGradients+Parameters. For BMUF:
1. ResetSmoothedGradients should NOT reset Parameters.
2. fp32 Parameters needs to be updated after BMUF distributed learner updated the fp16 ones.