### PR TITLE
Fix perf issue in text format reader

### DIFF
--- a/Source/Readers/CNTKTextFormatReader/TextParser.cpp
+++ b/Source/Readers/CNTKTextFormatReader/TextParser.cpp
@@ -307,6 +307,12 @@ typename TextParser<ElemType>::SequenceBuffer TextParser<ElemType>::LoadSequence
 {
     size_t fileOffset = sequenceDsc.OffsetInChunk() + chunkOffsetInFile;
 
+	auto cachedSequencePos = m_fileOffsetToSequenceBuffer.find(fileOffset);
+	if (cachedSequencePos != m_fileOffsetToSequenceBuffer.end())
+	{
+        return cachedSequencePos->second;
+	}
+
     m_fileReader->SetFileOffset(fileOffset);
 
     size_t bytesToRead = sequenceDsc.SizeInBytes();
@@ -430,6 +436,8 @@ typename TextParser<ElemType>::SequenceBuffer TextParser<ElemType>::LoadSequence
     }
 
     FillSequenceMetadata(sequence, { sequenceDsc.m_key, 0 });
+
+    m_fileOffsetToSequenceBuffer[fileOffset] = sequence;
     return sequence;
 }
 

--- a/Source/Readers/CNTKTextFormatReader/TextParser.h
+++ b/Source/Readers/CNTKTextFormatReader/TextParser.h
@@ -10,6 +10,7 @@
 #include "TextConfigHelper.h"
 #include "Index.h"
 #include "CorpusDescriptor.h"
+#include <unordered_map>
 
 namespace CNTK {
 
@@ -135,6 +136,7 @@ private:
     bool m_cacheIndex;
     unsigned int m_numRetries; // specifies the number of times an unsuccessful
                                // file operation should be repeated (default value is 5).
+    std::unordered_map<size_t, SequenceBuffer> m_fileOffsetToSequenceBuffer;
 
     // Corpus descriptor.
     CorpusDescriptorPtr m_corpus;


### PR DESCRIPTION
When reading from a sparse text format file that is larger than 3 GB, the performance of the text format reader bottlenecked training so that the GPU utilization hovered around 10%. These changes fix that, enabling full GPU utilization for these large text format files.


