### PR TITLE
fix the error "pip has not attribute 'main'" for pip version 10 and later

### DIFF
--- a/bindings/python/cntk/sample_installer.py
+++ b/bindings/python/cntk/sample_installer.py
@@ -15,9 +15,15 @@ import textwrap
 import zipfile
 import string
 import pip
+
+if int(pip.__version__.split('.')[0])>9:
+    from pip._internal import main
+else:
+    from pip import main
+
 try:
-    from urllib.request import urlretrieve 
-except ImportError: 
+    from urllib.request import urlretrieve
+except ImportError:
     from urllib import urlretrieve
 
 from cntk import __version__
@@ -76,7 +82,7 @@ def install_samples(url=None, directory=None, quiet=False):
         requirements_file = os.path.join(directory, 'requirements.txt')
         if os.path.isfile(requirements_file):
             show_message('INFO: installing requirements')
-            pip.main(['install', '-r', requirements_file])
+            main(['install', '-r', requirements_file])
         else:
             show_message('WARNING: file %s does not exist, modules to run the samples may be missing'
                 % (requirements_file))
@@ -95,7 +101,7 @@ if __name__ == '__main__':
             default=default_sample_dir())
     parser.add_argument('-q', '--quiet', action='store_true',
             help='suppress output (default: %(default)s)', default=False)
-    
+
     options = parser.parse_args(sys.argv[1:])
 
     install_samples(options.url, options.directory, options.quiet)


### PR DESCRIPTION
pip 10 and later doesn't has attribute main(). pip did a refactor and moved main() to internal. This fixes the error raised from sample_installer.py.